### PR TITLE
Task 3: LlmBackend trait definition

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,19 @@
+pub mod vertex;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+
+/// Trait for LLM provider backends.
+///
+/// Implementations handle authentication, request formatting, and
+/// response streaming for a specific LLM provider.
+#[async_trait]
+pub trait LlmBackend: Send + Sync {
+    async fn send_message(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>>;
+}

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -1,0 +1,1 @@
+// Vertex AI implementation — filled in Task 4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod backend;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+pub mod backend;
+pub mod types;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/tests/backend_test.rs
+++ b/tests/backend_test.rs
@@ -1,0 +1,66 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+
+use illustrious_manager::backend::LlmBackend;
+use illustrious_manager::types::{BoxStream, Message, RequestConfig, Role, StreamEvent};
+
+/// A mock backend implementation to verify the trait compiles correctly
+struct MockBackend;
+
+#[async_trait]
+impl LlmBackend for MockBackend {
+    async fn send_message(
+        &self,
+        _messages: &[Message],
+        _config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>> {
+        let events = vec![
+            Ok(StreamEvent::TextDelta("Hello".to_string())),
+            Ok(StreamEvent::Done),
+        ];
+        let stream = futures::stream::iter(events);
+        Ok(Box::pin(stream))
+    }
+}
+
+#[tokio::test]
+async fn test_trait_is_object_safe() {
+    // Verify we can create a boxed trait object
+    let backend: Box<dyn LlmBackend> = Box::new(MockBackend);
+
+    let messages = vec![Message {
+        role: Role::User,
+        content: "Test".to_string(),
+    }];
+
+    let config = RequestConfig {
+        model: "test-model".to_string(),
+    };
+
+    let mut stream = backend.send_message(&messages, &config).await.unwrap();
+
+    // Collect events
+    let mut events = Vec::new();
+    while let Some(result) = stream.next().await {
+        events.push(result.unwrap());
+    }
+
+    assert_eq!(events.len(), 2);
+    match &events[0] {
+        StreamEvent::TextDelta(text) => assert_eq!(text, "Hello"),
+        _ => panic!("Expected TextDelta"),
+    }
+    match &events[1] {
+        StreamEvent::Done => {}
+        _ => panic!("Expected Done"),
+    }
+}
+
+#[test]
+fn test_trait_is_send_sync() {
+    // This is a compile-time check. If the trait is not Send + Sync,
+    // this function will not compile.
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Box<dyn LlmBackend>>();
+}


### PR DESCRIPTION
## Overview

This PR implements the `LlmBackend` async trait that all LLM providers will implement. This is the abstraction boundary between the agent core and any LLM service.

## Changes

- ✅ Created `src/backend/mod.rs` with the `LlmBackend` trait definition
- ✅ Trait signature: `async fn send_message(&self, messages: &[Message], config: &RequestConfig) -> Result<BoxStream<Result<StreamEvent>>>`
- ✅ Trait is `Send + Sync` as required
- ✅ Created placeholder `src/backend/vertex.rs` for Task 4
- ✅ Updated `src/lib.rs` and `src/main.rs` to declare backend module
- ✅ Added comprehensive tests for trait object safety and Send/Sync bounds
- ✅ All tests pass (`cargo test`)
- ✅ Build succeeds (`cargo build`)
- ✅ Code formatted (`cargo fmt`)
- ✅ No clippy warnings (`cargo clippy`)

## Test Coverage

Added `tests/backend_test.rs` with:
- Test for trait object safety (can be boxed as `Box<dyn LlmBackend>`)
- Test for Send + Sync bounds (compile-time verification)
- Integration test with mock backend implementation

## TDD Approach

This implementation followed Test-Driven Development:
1. **RED**: Wrote tests first that failed with "unresolved import"
2. **GREEN**: Implemented minimal trait definition to pass tests
3. **REFACTOR**: Verified formatting and linting

Closes #3