### PR TITLE
feat: add LlmBackend trait definition

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,0 +1,19 @@
+pub mod vertex;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+
+/// Trait for LLM provider backends.
+///
+/// Implementations handle authentication, request formatting, and
+/// response streaming for a specific LLM provider.
+#[async_trait]
+pub trait LlmBackend: Send + Sync {
+    async fn send_message(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>>;
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,10 +5,6 @@ use async_trait::async_trait;
 
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 
-/// Trait for LLM provider backends.
-///
-/// Implementations handle authentication, request formatting, and
-/// response streaming for a specific LLM provider.
 #[async_trait]
 pub trait LlmBackend: Send + Sync {
     async fn send_message(
@@ -75,6 +71,11 @@ mod tests {
         assert!(
             matches!(second, StreamEvent::Done),
             "expected Done, got {second:?}"
+        );
+
+        assert!(
+            stream.next().await.is_none(),
+            "stream should be exhausted after Done"
         );
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -17,3 +17,64 @@ pub trait LlmBackend: Send + Sync {
         config: &RequestConfig,
     ) -> Result<BoxStream<Result<StreamEvent>>>;
 }
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use futures::{StreamExt, stream};
+
+    use super::LlmBackend;
+    use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+
+    struct MockBackend;
+
+    #[async_trait]
+    impl LlmBackend for MockBackend {
+        async fn send_message(
+            &self,
+            _messages: &[Message],
+            _config: &RequestConfig,
+        ) -> Result<BoxStream<Result<StreamEvent>>> {
+            let events = vec![
+                Ok(StreamEvent::TextDelta("hello".to_string())),
+                Ok(StreamEvent::Done),
+            ];
+            Ok(Box::pin(stream::iter(events)))
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_backend_streams_text_delta_then_done() {
+        let backend = MockBackend;
+        let messages: Vec<Message> = vec![];
+        let config = RequestConfig {
+            model: "test-model".to_string(),
+        };
+
+        let mut stream = backend
+            .send_message(&messages, &config)
+            .await
+            .expect("send_message should succeed");
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should have first event")
+            .expect("first event should be Ok");
+        assert!(
+            matches!(first, StreamEvent::TextDelta(_)),
+            "expected TextDelta, got {first:?}"
+        );
+
+        let second = stream
+            .next()
+            .await
+            .expect("stream should have second event")
+            .expect("second event should be Ok");
+        assert!(
+            matches!(second, StreamEvent::Done),
+            "expected Done, got {second:?}"
+        );
+    }
+}

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -1,0 +1,1 @@
+// Vertex AI implementation — filled in Task 4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod backend;
 pub mod config;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+pub mod backend;
+mod types;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-pub mod backend;
-mod types;
-
 fn main() {
     println!("Hello, world!");
 }


### PR DESCRIPTION
## Summary
- Creates `src/backend/mod.rs` with the `LlmBackend` async trait (`Send + Sync`)
- Creates `src/backend/vertex.rs` as a placeholder for Task 4
- Exposes `pub mod backend` in `src/lib.rs`

Closes #3

## Test plan
- [ ] `cargo build` succeeds (verified)
- [ ] `cargo clippy` passes with no warnings (verified)