### PR TITLE
feat: implement Vertex AI backend with SSE streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,6 +2041,8 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
+ "serde",
+ "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.32"
 gcp_auth = "0.12.6"
 pin-project-lite = "0.2.17"
 ratatui = "0.30.0"
-reqwest = { version = "0.13.2", features = ["stream"] }
+reqwest = { version = "0.13.2", features = ["json", "stream"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.50.0", features = ["full"] }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -46,6 +46,7 @@ mod tests {
         let messages: Vec<Message> = vec![];
         let config = RequestConfig {
             model: "test-model".to_string(),
+            max_tokens: 1024,
         };
 
         let mut stream = backend

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -90,7 +90,10 @@ impl LlmBackend for VertexBackend {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| String::from("<failed to read response body>"));
             anyhow::bail!("Vertex AI returned {}: {}", status, body);
         }
 
@@ -156,6 +159,32 @@ fn extract_sse_data(event_text: &str) -> Option<&str> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_sse_data_returns_json_after_data_prefix() {
+        let event = "event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}";
+        assert_eq!(
+            extract_sse_data(event),
+            Some("{\"type\":\"content_block_delta\"}")
+        );
+    }
+
+    #[test]
+    fn extract_sse_data_returns_none_when_no_data_line() {
+        let event = "event: content_block_delta\n";
+        assert!(extract_sse_data(event).is_none());
+    }
+
+    #[test]
+    fn extract_sse_data_returns_first_data_line_when_multiple_present() {
+        let event = "data: first\ndata: second";
+        assert_eq!(extract_sse_data(event), Some("first"));
+    }
 }
 
 /// Parse an SSE data payload JSON into a StreamEvent.

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -1,1 +1,177 @@
-// Vertex AI implementation — filled in Task 4
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::Client;
+
+use super::LlmBackend;
+use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+
+/// Vertex AI backend for Claude models.
+pub struct VertexBackend {
+    client: Client,
+    project: String,
+    region: String,
+    auth_manager: Arc<dyn gcp_auth::TokenProvider>,
+}
+
+impl VertexBackend {
+    /// Create a new VertexBackend using Application Default Credentials.
+    pub async fn new(project: String, region: String) -> Result<Self> {
+        let auth_manager = gcp_auth::provider().await.context(
+            "Failed to initialize GCP authentication. Run: gcloud auth application-default login",
+        )?;
+        Ok(Self {
+            client: Client::new(),
+            project,
+            region,
+            auth_manager,
+        })
+    }
+
+    fn endpoint(&self, model: &str) -> String {
+        format!(
+            "https://{region}-aiplatform.googleapis.com/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:streamRawPredict",
+            region = self.region,
+            project = self.project,
+            model = model,
+        )
+    }
+
+    fn build_request_body(&self, messages: &[Message], model: &str) -> serde_json::Value {
+        let messages_json: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "role": m.role,
+                    "content": m.content,
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "anthropic_version": "vertex-2023-10-16",
+            "model": model,
+            "max_tokens": 8192,
+            "stream": true,
+            "messages": messages_json,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmBackend for VertexBackend {
+    async fn send_message(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>> {
+        let scopes = &["https://www.googleapis.com/auth/cloud-platform"];
+        let token = self
+            .auth_manager
+            .token(scopes)
+            .await
+            .context("Failed to get GCP auth token")?;
+        let token_str = token.as_str().to_owned();
+
+        let url = self.endpoint(&config.model);
+        let body = self.build_request_body(messages, &config.model);
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&token_str)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send request to Vertex AI")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Vertex AI returned {}: {}", status, body);
+        }
+
+        let byte_stream = response.bytes_stream();
+
+        let event_stream = futures::stream::unfold(
+            (byte_stream, String::new()),
+            |(mut byte_stream, mut buffer)| async move {
+                loop {
+                    if let Some(pos) = buffer.find("\n\n") {
+                        let event_text = buffer[..pos].to_string();
+                        buffer = buffer[pos + 2..].to_string();
+
+                        if let Some(data) = extract_sse_data(&event_text) {
+                            match parse_sse_data(data) {
+                                Ok(Some(event)) => return Some((Ok(event), (byte_stream, buffer))),
+                                Ok(None) => continue,
+                                Err(e) => return Some((Err(e), (byte_stream, buffer))),
+                            }
+                        }
+                        continue;
+                    }
+
+                    match byte_stream.next().await {
+                        Some(Ok(bytes)) => {
+                            buffer.push_str(&String::from_utf8_lossy(&bytes));
+                        }
+                        Some(Err(e)) => {
+                            return Some((
+                                Err(anyhow::anyhow!("Stream read error: {}", e)),
+                                (byte_stream, buffer),
+                            ));
+                        }
+                        None => {
+                            if !buffer.trim().is_empty()
+                                && let Some(data) = extract_sse_data(&buffer).map(str::to_owned)
+                            {
+                                buffer.clear();
+                                match parse_sse_data(&data) {
+                                    Ok(Some(event)) => {
+                                        return Some((Ok(event), (byte_stream, buffer)));
+                                    }
+                                    Ok(None) => return None,
+                                    Err(e) => return Some((Err(e), (byte_stream, buffer))),
+                                }
+                            }
+                            return None;
+                        }
+                    }
+                }
+            },
+        );
+
+        Ok(Box::pin(event_stream))
+    }
+}
+
+/// Extract the data payload from an SSE event block.
+fn extract_sse_data(event_text: &str) -> Option<&str> {
+    for line in event_text.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            return Some(data);
+        }
+    }
+    None
+}
+
+/// Parse an SSE data payload JSON into a StreamEvent.
+/// Returns None for event types we intentionally ignore.
+pub fn parse_sse_data(data: &str) -> Result<Option<StreamEvent>> {
+    let json: serde_json::Value = serde_json::from_str(data)
+        .with_context(|| format!("Failed to parse SSE data: {}", data))?;
+
+    let event_type = json["type"].as_str().unwrap_or("");
+
+    match event_type {
+        "content_block_delta" => {
+            let text = json["delta"]["text"].as_str().unwrap_or("").to_string();
+            Ok(Some(StreamEvent::TextDelta(text)))
+        }
+        "message_stop" => Ok(Some(StreamEvent::Done)),
+        _ => Ok(None),
+    }
+}

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -8,6 +8,9 @@ use reqwest::Client;
 use super::LlmBackend;
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 
+/// Required protocol version string for Vertex AI's Anthropic API.
+const ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
+
 /// Vertex AI backend for Claude models.
 pub struct VertexBackend {
     client: Client,
@@ -38,26 +41,6 @@ impl VertexBackend {
             model = model,
         )
     }
-
-    fn build_request_body(&self, messages: &[Message], model: &str) -> serde_json::Value {
-        let messages_json: Vec<serde_json::Value> = messages
-            .iter()
-            .map(|m| {
-                serde_json::json!({
-                    "role": m.role,
-                    "content": m.content,
-                })
-            })
-            .collect();
-
-        serde_json::json!({
-            "anthropic_version": "vertex-2023-10-16",
-            "model": model,
-            "max_tokens": 8192,
-            "stream": true,
-            "messages": messages_json,
-        })
-    }
 }
 
 #[async_trait]
@@ -76,7 +59,7 @@ impl LlmBackend for VertexBackend {
         let token_str = token.as_str().to_owned();
 
         let url = self.endpoint(&config.model);
-        let body = self.build_request_body(messages, &config.model);
+        let body = build_request_body(messages, config);
 
         let response = self
             .client
@@ -151,6 +134,26 @@ impl LlmBackend for VertexBackend {
     }
 }
 
+fn build_request_body(messages: &[Message], config: &RequestConfig) -> serde_json::Value {
+    let messages_json: Vec<serde_json::Value> = messages
+        .iter()
+        .map(|m| {
+            serde_json::json!({
+                "role": m.role,
+                "content": m.content,
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "anthropic_version": ANTHROPIC_VERSION,
+        "model": config.model,
+        "max_tokens": config.max_tokens,
+        "stream": true,
+        "messages": messages_json,
+    })
+}
+
 /// Extract the data payload from an SSE event block.
 fn extract_sse_data(event_text: &str) -> Option<&str> {
     for line in event_text.lines() {
@@ -164,6 +167,18 @@ fn extract_sse_data(event_text: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_request_body_uses_max_tokens_and_model_from_config() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 32768,
+        };
+        let body = build_request_body(&[], &config);
+        assert_eq!(body["max_tokens"], 32768);
+        assert_eq!(body["model"], "claude-test");
+        assert_eq!(body["anthropic_version"], ANTHROPIC_VERSION);
+    }
 
     #[test]
     fn extract_sse_data_returns_json_after_data_prefix() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-pub mod backend;
-pub mod config;
-pub mod types;
-
 fn main() {
     println!("Hello, world!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+pub mod backend;
+pub mod config;
+pub mod types;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,6 +23,7 @@ pub struct Message {
 #[derive(Debug, Clone)]
 pub struct RequestConfig {
     pub model: String,
+    pub max_tokens: u32,
 }
 
 /// Events emitted by the LLM backend during streaming

--- a/tests/vertex_test.rs
+++ b/tests/vertex_test.rs
@@ -1,0 +1,44 @@
+#[test]
+fn test_parse_sse_content_block_delta() {
+    let data =
+        r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+    let event = illustrious_manager::backend::vertex::parse_sse_data(data).unwrap();
+    match event {
+        Some(illustrious_manager::types::StreamEvent::TextDelta(text)) => {
+            assert_eq!(text, "Hello");
+        }
+        other => panic!("Expected TextDelta, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_sse_message_stop() {
+    let data = r#"{"type":"message_stop"}"#;
+    let event = illustrious_manager::backend::vertex::parse_sse_data(data).unwrap();
+    match event {
+        Some(illustrious_manager::types::StreamEvent::Done) => {}
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_sse_message_start_ignored() {
+    let data = r#"{"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":1}}}"#;
+    let event = illustrious_manager::backend::vertex::parse_sse_data(data).unwrap();
+    assert!(event.is_none(), "message_start should be ignored");
+}
+
+#[test]
+fn test_parse_sse_content_block_start_ignored() {
+    let data =
+        r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+    let event = illustrious_manager::backend::vertex::parse_sse_data(data).unwrap();
+    assert!(event.is_none(), "content_block_start should be ignored");
+}
+
+#[test]
+fn test_parse_sse_ping_ignored() {
+    let data = r#"{"type":"ping"}"#;
+    let event = illustrious_manager::backend::vertex::parse_sse_data(data).unwrap();
+    assert!(event.is_none(), "ping should be ignored");
+}

--- a/tests/vertex_test.rs
+++ b/tests/vertex_test.rs
@@ -42,3 +42,10 @@ fn test_parse_sse_ping_ignored() {
     let event = illustrious_manager::backend::vertex::parse_sse_data(data).unwrap();
     assert!(event.is_none(), "ping should be ignored");
 }
+
+#[test]
+fn test_parse_sse_malformed_json_returns_err() {
+    let data = "this is not json";
+    let result = illustrious_manager::backend::vertex::parse_sse_data(data);
+    assert!(result.is_err(), "malformed JSON should return Err");
+}


### PR DESCRIPTION
## Summary
- Implements `VertexBackend` with GCP ADC authentication via `gcp_auth`
- Constructs `streamRawPredict` endpoint URL and Anthropic messages API request body
- Parses SSE stream events: `content_block_delta` → `TextDelta`, `message_stop` → `Done`, others ignored
- Makes `types` module public for integration test access
- Adds 5 unit tests for `parse_sse_data` covering all event types

Closes #4

## Test plan
- [x] `cargo test --test vertex_test` — all 5 SSE parsing tests pass
- [x] `cargo test` — all 16 tests pass (no regressions)
- [x] `cargo build` — compiles successfully
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — code formatted