### PR TITLE
feat: implement agent core with streaming and history management

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,12 +1,15 @@
+use std::sync::{Arc, Mutex};
+
 use anyhow::Result;
 use futures::StreamExt;
+use futures::channel::mpsc;
 
 use crate::backend::LlmBackend;
-use crate::types::*;
+use crate::types::{AgentEvent, BoxStream, Message, RequestConfig, Role, StreamEvent};
 
 pub struct Agent {
     backend: Box<dyn LlmBackend>,
-    history: Vec<Message>,
+    history: Arc<Mutex<Vec<Message>>>,
     config: RequestConfig,
 }
 
@@ -14,50 +17,71 @@ impl Agent {
     pub fn new(backend: Box<dyn LlmBackend>, config: RequestConfig) -> Self {
         Self {
             backend,
-            history: Vec::new(),
+            history: Arc::new(Mutex::new(Vec::new())),
             config,
         }
     }
 
-    pub fn history(&self) -> &[Message] {
-        &self.history
+    pub fn history(&self) -> Vec<Message> {
+        self.history.lock().expect("history mutex poisoned").clone()
     }
 
     pub async fn send(&mut self, input: String) -> Result<BoxStream<AgentEvent>> {
-        self.history.push(Message {
-            role: Role::User,
-            content: input,
-        });
+        self.history
+            .lock()
+            .expect("history mutex poisoned")
+            .push(Message {
+                role: Role::User,
+                content: input,
+            });
 
-        let mut backend_stream = self
+        let history_snapshot = self.history.lock().expect("history mutex poisoned").clone();
+
+        let backend_stream = match self
             .backend
-            .send_message(&self.history, &self.config)
-            .await?;
+            .send_message(&history_snapshot, &self.config)
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                self.history.lock().expect("history mutex poisoned").pop();
+                return Err(e);
+            }
+        };
 
-        let mut events = Vec::new();
-        let mut accumulated = String::new();
+        let (event_tx, event_rx) = mpsc::unbounded::<AgentEvent>();
+        let history_arc = Arc::clone(&self.history);
 
-        while let Some(result) = backend_stream.next().await {
-            match result {
-                Ok(StreamEvent::TextDelta(text)) => {
-                    accumulated.push_str(&text);
-                    events.push(AgentEvent::TokenReceived(text));
-                }
-                Ok(StreamEvent::Done) => {
-                    self.history.push(Message {
-                        role: Role::Assistant,
-                        content: accumulated.clone(),
-                    });
-                    events.push(AgentEvent::ResponseComplete(accumulated));
-                    break;
-                }
-                Err(e) => {
-                    events.push(AgentEvent::Error(e.to_string()));
-                    break;
+        tokio::spawn(async move {
+            let mut accumulated = String::new();
+            let mut backend_stream = backend_stream;
+
+            while let Some(result) = backend_stream.next().await {
+                match result {
+                    Ok(StreamEvent::TextDelta(text)) => {
+                        accumulated.push_str(&text);
+                        let _ = event_tx.unbounded_send(AgentEvent::TokenReceived(text));
+                    }
+                    Ok(StreamEvent::Done) => {
+                        history_arc
+                            .lock()
+                            .expect("history mutex poisoned")
+                            .push(Message {
+                                role: Role::Assistant,
+                                content: accumulated.clone(),
+                            });
+                        let _ = event_tx.unbounded_send(AgentEvent::ResponseComplete(accumulated));
+                        break;
+                    }
+                    Err(e) => {
+                        history_arc.lock().expect("history mutex poisoned").pop();
+                        let _ = event_tx.unbounded_send(AgentEvent::Error(e.to_string()));
+                        break;
+                    }
                 }
             }
-        }
+        });
 
-        Ok(Box::pin(futures::stream::iter(events)))
+        Ok(Box::pin(event_rx))
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -13,6 +13,10 @@ pub struct Agent {
     config: RequestConfig,
 }
 
+fn lock(m: &Mutex<Vec<Message>>) -> std::sync::MutexGuard<'_, Vec<Message>> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 impl Agent {
     pub fn new(backend: Box<dyn LlmBackend>, config: RequestConfig) -> Self {
         Self {
@@ -23,19 +27,16 @@ impl Agent {
     }
 
     pub fn history(&self) -> Vec<Message> {
-        self.history.lock().expect("history mutex poisoned").clone()
+        lock(&self.history).clone()
     }
 
     pub async fn send(&mut self, input: String) -> Result<BoxStream<AgentEvent>> {
-        self.history
-            .lock()
-            .expect("history mutex poisoned")
-            .push(Message {
-                role: Role::User,
-                content: input,
-            });
+        lock(&self.history).push(Message {
+            role: Role::User,
+            content: input,
+        });
 
-        let history_snapshot = self.history.lock().expect("history mutex poisoned").clone();
+        let history_snapshot = lock(&self.history).clone();
 
         let backend_stream = match self
             .backend
@@ -44,7 +45,7 @@ impl Agent {
         {
             Ok(s) => s,
             Err(e) => {
-                self.history.lock().expect("history mutex poisoned").pop();
+                lock(&self.history).pop();
                 return Err(e);
             }
         };
@@ -63,18 +64,15 @@ impl Agent {
                         let _ = event_tx.unbounded_send(AgentEvent::TokenReceived(text));
                     }
                     Ok(StreamEvent::Done) => {
-                        history_arc
-                            .lock()
-                            .expect("history mutex poisoned")
-                            .push(Message {
-                                role: Role::Assistant,
-                                content: accumulated.clone(),
-                            });
+                        lock(&history_arc).push(Message {
+                            role: Role::Assistant,
+                            content: accumulated.clone(),
+                        });
                         let _ = event_tx.unbounded_send(AgentEvent::ResponseComplete(accumulated));
                         break;
                     }
                     Err(e) => {
-                        history_arc.lock().expect("history mutex poisoned").pop();
+                        lock(&history_arc).pop();
                         let _ = event_tx.unbounded_send(AgentEvent::Error(e.to_string()));
                         break;
                     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use futures::StreamExt;
+
+use crate::backend::LlmBackend;
+use crate::types::*;
+
+pub struct Agent {
+    backend: Box<dyn LlmBackend>,
+    history: Vec<Message>,
+    config: RequestConfig,
+}
+
+impl Agent {
+    pub fn new(backend: Box<dyn LlmBackend>, config: RequestConfig) -> Self {
+        Self {
+            backend,
+            history: Vec::new(),
+            config,
+        }
+    }
+
+    pub fn history(&self) -> &[Message] {
+        &self.history
+    }
+
+    pub async fn send(&mut self, input: String) -> Result<BoxStream<AgentEvent>> {
+        self.history.push(Message {
+            role: Role::User,
+            content: input,
+        });
+
+        let mut backend_stream = self
+            .backend
+            .send_message(&self.history, &self.config)
+            .await?;
+
+        let mut events = Vec::new();
+        let mut accumulated = String::new();
+
+        while let Some(result) = backend_stream.next().await {
+            match result {
+                Ok(StreamEvent::TextDelta(text)) => {
+                    accumulated.push_str(&text);
+                    events.push(AgentEvent::TokenReceived(text));
+                }
+                Ok(StreamEvent::Done) => {
+                    self.history.push(Message {
+                        role: Role::Assistant,
+                        content: accumulated.clone(),
+                    });
+                    events.push(AgentEvent::ResponseComplete(accumulated));
+                    break;
+                }
+                Err(e) => {
+                    events.push(AgentEvent::Error(e.to_string()));
+                    break;
+                }
+            }
+        }
+
+        Ok(Box::pin(futures::stream::iter(events)))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod backend;
 pub mod config;
 pub mod types;

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -1,0 +1,149 @@
+use std::pin::Pin;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+
+use illustrious_manager::agent::Agent;
+use illustrious_manager::backend::LlmBackend;
+use illustrious_manager::types::*;
+
+/// A mock backend that returns a fixed sequence of StreamEvents.
+struct MockBackend {
+    responses: Vec<Vec<StreamEvent>>,
+    call_count: std::sync::atomic::AtomicUsize,
+}
+
+impl MockBackend {
+    fn new(responses: Vec<Vec<StreamEvent>>) -> Self {
+        Self {
+            responses,
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmBackend for MockBackend {
+    async fn send_message(
+        &self,
+        _messages: &[Message],
+        _config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>> {
+        let idx = self
+            .call_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let events = self.responses.get(idx).cloned().unwrap_or_default();
+        let stream = futures::stream::iter(events.into_iter().map(Ok));
+        Ok(Box::pin(stream))
+    }
+}
+
+#[tokio::test]
+async fn test_agent_single_message() {
+    let backend = MockBackend::new(vec![vec![
+        StreamEvent::TextDelta("Hello ".to_string()),
+        StreamEvent::TextDelta("world!".to_string()),
+        StreamEvent::Done,
+    ]]);
+
+    let config = RequestConfig {
+        model: "test-model".to_string(),
+    };
+    let mut agent = Agent::new(Box::new(backend), config);
+
+    let mut stream = agent.send("Hi".to_string()).await.unwrap();
+
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    // Should get: TokenReceived("Hello "), TokenReceived("world!"), ResponseComplete("Hello world!")
+    assert_eq!(events.len(), 3);
+    match &events[0] {
+        AgentEvent::TokenReceived(t) => assert_eq!(t, "Hello "),
+        other => panic!("Expected TokenReceived, got {:?}", other),
+    }
+    match &events[1] {
+        AgentEvent::TokenReceived(t) => assert_eq!(t, "world!"),
+        other => panic!("Expected TokenReceived, got {:?}", other),
+    }
+    match &events[2] {
+        AgentEvent::ResponseComplete(full) => assert_eq!(full, "Hello world!"),
+        other => panic!("Expected ResponseComplete, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_agent_history_accumulates() {
+    let backend = MockBackend::new(vec![
+        vec![
+            StreamEvent::TextDelta("First response".to_string()),
+            StreamEvent::Done,
+        ],
+        vec![
+            StreamEvent::TextDelta("Second response".to_string()),
+            StreamEvent::Done,
+        ],
+    ]);
+
+    let config = RequestConfig {
+        model: "test-model".to_string(),
+    };
+    let mut agent = Agent::new(Box::new(backend), config);
+
+    // First message
+    let stream = agent.send("Hello".to_string()).await.unwrap();
+    let _: Vec<_> = stream.collect().await;
+
+    // Second message
+    let stream = agent.send("Again".to_string()).await.unwrap();
+    let _: Vec<_> = stream.collect().await;
+
+    // History should have 4 messages: user, assistant, user, assistant
+    assert_eq!(agent.history().len(), 4);
+}
+
+#[tokio::test]
+async fn test_agent_backend_error_emits_error_event() {
+    // Backend that returns an error in the stream
+    struct ErrorBackend;
+
+    #[async_trait]
+    impl LlmBackend for ErrorBackend {
+        async fn send_message(
+            &self,
+            _messages: &[Message],
+            _config: &RequestConfig,
+        ) -> Result<BoxStream<Result<StreamEvent>>> {
+            let stream = futures::stream::iter(vec![
+                Ok(StreamEvent::TextDelta("partial".to_string())),
+                Err(anyhow::anyhow!("connection lost")),
+            ]);
+            Ok(Box::pin(stream))
+        }
+    }
+
+    let config = RequestConfig {
+        model: "test-model".to_string(),
+    };
+    let mut agent = Agent::new(Box::new(ErrorBackend), config);
+
+    let mut stream = agent.send("Hi".to_string()).await.unwrap();
+
+    let mut events = Vec::new();
+    while let Some(event) = stream.next().await {
+        events.push(event);
+    }
+
+    assert_eq!(events.len(), 2);
+    match &events[0] {
+        AgentEvent::TokenReceived(t) => assert_eq!(t, "partial"),
+        other => panic!("Expected TokenReceived, got {:?}", other),
+    }
+    match &events[1] {
+        AgentEvent::Error(msg) => assert!(msg.contains("connection lost")),
+        other => panic!("Expected Error, got {:?}", other),
+    }
+}

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -1,5 +1,3 @@
-use std::pin::Pin;
-
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;


### PR DESCRIPTION
## Summary
- Implements `Agent` struct in `src/agent.rs` with conversation history, `send()` streaming, and `history()` getter
- Adds `pub mod agent` to `src/lib.rs`
- Adds `tests/agent_test.rs` with 3 async tests covering single message, history accumulation, and backend error handling

## Test Plan
- [x] `test_agent_single_message` — TokenReceived + ResponseComplete events emitted correctly
- [x] `test_agent_history_accumulates` — 4 messages after 2 exchanges
- [x] `test_agent_backend_error_emits_error_event` — Error event emitted on backend stream error
- [x] All existing tests still pass

Closes #5