### PR TITLE
feat: stdout frontend for single-shot mode (closes #6)

### DIFF
--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -1,0 +1,2 @@
+pub mod stdout;
+pub mod tui;

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use futures::StreamExt;
+use std::io::{self, Write};
+
+use crate::types::{AgentEvent, BoxStream};
+
+pub async fn run(stream: BoxStream<AgentEvent>) -> Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    run_with_writer(stream, &mut handle).await
+}
+
+async fn run_with_writer<W: Write>(
+    mut stream: BoxStream<AgentEvent>,
+    writer: &mut W,
+) -> Result<()> {
+    while let Some(event) = stream.next().await {
+        match event {
+            AgentEvent::TokenReceived(text) => {
+                write!(writer, "{}", text)?;
+                writer.flush()?;
+            }
+            AgentEvent::ResponseComplete(_) => {
+                writeln!(writer)?;
+                break;
+            }
+            AgentEvent::Error(msg) => {
+                eprintln!("\nError: {}", msg);
+                anyhow::bail!("LLM error: {}", msg);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+
+    #[tokio::test]
+    async fn token_received_writes_text_to_writer() {
+        let events = vec![
+            AgentEvent::TokenReceived("hello".to_string()),
+            AgentEvent::TokenReceived(" world".to_string()),
+            AgentEvent::ResponseComplete("hello world".to_string()),
+        ];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+
+        run_with_writer(s, &mut buf).await.unwrap();
+
+        assert_eq!(String::from_utf8(buf).unwrap(), "hello world\n");
+    }
+
+    #[tokio::test]
+    async fn response_complete_writes_trailing_newline_and_stops() {
+        let events = vec![
+            AgentEvent::ResponseComplete("done".to_string()),
+            AgentEvent::TokenReceived("should not appear".to_string()),
+        ];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+
+        run_with_writer(s, &mut buf).await.unwrap();
+
+        assert_eq!(String::from_utf8(buf).unwrap(), "\n");
+    }
+
+    #[tokio::test]
+    async fn error_returns_err() {
+        let events = vec![AgentEvent::Error("something went wrong".to_string())];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+
+        let result = run_with_writer(s, &mut buf).await;
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("something went wrong")
+        );
+    }
+}

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -49,9 +49,14 @@ mod tests {
         let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
         let mut buf = Vec::new();
 
-        run_with_writer(s, &mut buf).await.unwrap();
+        run_with_writer(s, &mut buf)
+            .await
+            .expect("stdout run should succeed");
 
-        assert_eq!(String::from_utf8(buf).unwrap(), "hello world\n");
+        assert_eq!(
+            String::from_utf8(buf).expect("buffer should contain valid UTF-8"),
+            "hello world\n"
+        );
     }
 
     #[tokio::test]
@@ -63,9 +68,14 @@ mod tests {
         let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
         let mut buf = Vec::new();
 
-        run_with_writer(s, &mut buf).await.unwrap();
+        run_with_writer(s, &mut buf)
+            .await
+            .expect("stdout run should succeed");
 
-        assert_eq!(String::from_utf8(buf).unwrap(), "\n");
+        assert_eq!(
+            String::from_utf8(buf).expect("buffer should contain valid UTF-8"),
+            "\n"
+        );
     }
 
     #[tokio::test]
@@ -79,7 +89,7 @@ mod tests {
         assert!(result.is_err());
         assert!(
             result
-                .unwrap_err()
+                .expect_err("run should return an error on AgentEvent::Error")
                 .to_string()
                 .contains("something went wrong")
         );

--- a/src/frontend/tui.rs
+++ b/src/frontend/tui.rs
@@ -1,0 +1,1 @@
+// Ratatui TUI frontend — filled in Task 7

--- a/src/frontend/tui.rs
+++ b/src/frontend/tui.rs
@@ -1,1 +1,1 @@
-// Ratatui TUI frontend — filled in Task 7
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
 pub mod backend;
 pub mod config;
+pub mod frontend;
 pub mod types;

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -47,6 +47,7 @@ async fn test_agent_single_message() {
 
     let config = RequestConfig {
         model: "test-model".to_string(),
+        max_tokens: 1024,
     };
     let mut agent = Agent::new(Box::new(backend), config);
 
@@ -88,6 +89,7 @@ async fn test_agent_history_accumulates() {
 
     let config = RequestConfig {
         model: "test-model".to_string(),
+        max_tokens: 1024,
     };
     let mut agent = Agent::new(Box::new(backend), config);
 
@@ -125,6 +127,7 @@ async fn test_agent_backend_error_emits_error_event() {
 
     let config = RequestConfig {
         model: "test-model".to_string(),
+        max_tokens: 1024,
     };
     let mut agent = Agent::new(Box::new(ErrorBackend), config);
 


### PR DESCRIPTION
## Summary
- Creates `src/frontend/mod.rs`, `src/frontend/stdout.rs`, and a placeholder `src/frontend/tui.rs`
- `stdout::run(stream)` consumes a `BoxStream<AgentEvent>`, writes tokens immediately with flush, prints a trailing newline on `ResponseComplete`, and returns an error on `Error`
- Fixes a pre-existing compile error in `tests/agent_test.rs` where `RequestConfig` initializers were missing the `max_tokens` field

## Test plan
- [x] Three unit tests written first (TDD): `token_received_writes_text_to_writer`, `response_complete_writes_trailing_newline_and_stops`, `error_returns_err`
- [x] All 11 unit tests pass (`cargo test`)
- [x] All integration tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` applied