### PR TITLE
feat: add z.ai backend support (#23)

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,3 +1,4 @@
+pub mod sse;
 pub mod vertex;
 pub mod zai;
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,11 +1,12 @@
-pub mod sse;
-pub mod vertex;
-pub mod zai;
-
 use anyhow::Result;
 use async_trait::async_trait;
 
+use crate::config::AppConfig;
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+
+pub mod sse;
+pub mod vertex;
+pub mod zai;
 
 #[async_trait]
 pub trait LlmBackend: Send + Sync {
@@ -14,6 +15,42 @@ pub trait LlmBackend: Send + Sync {
         messages: &[Message],
         config: &RequestConfig,
     ) -> Result<BoxStream<Result<StreamEvent>>>;
+}
+
+pub struct BackendSelection {
+    pub backend: Box<dyn LlmBackend>,
+    pub model: String,
+}
+
+pub async fn from_config(config: &AppConfig) -> Result<BackendSelection> {
+    match config.backend.as_str() {
+        "vertex" => {
+            let backend = vertex::VertexBackend::new(
+                config.vertex.project.clone(),
+                config.vertex.region.clone(),
+            )
+            .await?;
+            Ok(BackendSelection {
+                backend: Box::new(backend),
+                model: config.vertex.model.clone(),
+            })
+        }
+        "zai" => {
+            let zai_config = config.zai.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "zai backend configuration is missing. Add a [zai] section to your config file."
+                )
+            })?;
+            let backend = zai::ZaiBackend::new(zai_config.api_key.clone())?;
+            Ok(BackendSelection {
+                backend: Box::new(backend),
+                model: zai_config.model.clone(),
+            })
+        }
+        _ => {
+            anyhow::bail!("Invalid backend '{}'", config.backend);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,4 +1,5 @@
 pub mod vertex;
+pub mod zai;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/backend/sse.rs
+++ b/src/backend/sse.rs
@@ -1,0 +1,102 @@
+use anyhow::Result;
+use futures::stream::unfold;
+use futures::{Stream, StreamExt};
+
+use crate::types::{BoxStream, StreamEvent};
+
+pub fn extract_sse_data(event_text: &str) -> Option<&str> {
+    for line in event_text.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            return Some(data);
+        }
+    }
+    None
+}
+
+pub fn create_sse_event_stream<S, B, E>(
+    byte_stream: S,
+    parser: fn(&str) -> Result<Option<StreamEvent>>,
+) -> BoxStream<Result<StreamEvent>>
+where
+    S: Stream<Item = Result<B, E>> + Unpin + Send + 'static,
+    B: AsRef<[u8]>,
+    E: std::fmt::Display + 'static,
+{
+    let event_stream = unfold(
+        (byte_stream, String::new()),
+        move |(mut byte_stream, mut buffer)| async move {
+            loop {
+                if let Some(pos) = buffer.find("\n\n") {
+                    let event_text = buffer[..pos].to_string();
+                    buffer = buffer[pos + 2..].to_string();
+
+                    if let Some(data) = extract_sse_data(&event_text) {
+                        match parser(data) {
+                            Ok(Some(event)) => {
+                                return Some((Ok(event), (byte_stream, buffer)));
+                            }
+                            Ok(None) => continue,
+                            Err(e) => return Some((Err(e), (byte_stream, buffer))),
+                        }
+                    }
+                    continue;
+                }
+
+                match byte_stream.next().await {
+                    Some(Ok(bytes)) => {
+                        buffer.push_str(&String::from_utf8_lossy(bytes.as_ref()));
+                    }
+                    Some(Err(e)) => {
+                        return Some((
+                            Err(anyhow::anyhow!("Stream read error: {}", e)),
+                            (byte_stream, buffer),
+                        ));
+                    }
+                    None => {
+                        if !buffer.trim().is_empty()
+                            && let Some(data) = extract_sse_data(&buffer).map(str::to_owned)
+                        {
+                            buffer.clear();
+                            match parser(&data) {
+                                Ok(Some(event)) => {
+                                    return Some((Ok(event), (byte_stream, buffer)));
+                                }
+                                Ok(None) => return None,
+                                Err(e) => return Some((Err(e), (byte_stream, buffer))),
+                            }
+                        }
+                        return None;
+                    }
+                }
+            }
+        },
+    );
+
+    Box::pin(event_stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_sse_data_returns_json_after_data_prefix() {
+        let event = "event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}";
+        assert_eq!(
+            extract_sse_data(event),
+            Some("{\"type\":\"content_block_delta\"}")
+        );
+    }
+
+    #[test]
+    fn extract_sse_data_returns_none_when_no_data_line() {
+        let event = "event: content_block_delta\n";
+        assert!(extract_sse_data(event).is_none());
+    }
+
+    #[test]
+    fn extract_sse_data_returns_first_data_line_when_multiple_present() {
+        let event = "data: first\ndata: second";
+        assert_eq!(extract_sse_data(event), Some("first"));
+    }
+}

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::StreamExt;
 use reqwest::Client;
 
 use super::LlmBackend;
+use super::sse::create_sse_event_stream;
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 
 /// Required protocol version string for Vertex AI's Anthropic API.
@@ -81,56 +81,8 @@ impl LlmBackend for VertexBackend {
         }
 
         let byte_stream = response.bytes_stream();
-
-        let event_stream = futures::stream::unfold(
-            (byte_stream, String::new()),
-            |(mut byte_stream, mut buffer)| async move {
-                loop {
-                    if let Some(pos) = buffer.find("\n\n") {
-                        let event_text = buffer[..pos].to_string();
-                        buffer = buffer[pos + 2..].to_string();
-
-                        if let Some(data) = extract_sse_data(&event_text) {
-                            match parse_sse_data(data) {
-                                Ok(Some(event)) => return Some((Ok(event), (byte_stream, buffer))),
-                                Ok(None) => continue,
-                                Err(e) => return Some((Err(e), (byte_stream, buffer))),
-                            }
-                        }
-                        continue;
-                    }
-
-                    match byte_stream.next().await {
-                        Some(Ok(bytes)) => {
-                            buffer.push_str(&String::from_utf8_lossy(&bytes));
-                        }
-                        Some(Err(e)) => {
-                            return Some((
-                                Err(anyhow::anyhow!("Stream read error: {}", e)),
-                                (byte_stream, buffer),
-                            ));
-                        }
-                        None => {
-                            if !buffer.trim().is_empty()
-                                && let Some(data) = extract_sse_data(&buffer).map(str::to_owned)
-                            {
-                                buffer.clear();
-                                match parse_sse_data(&data) {
-                                    Ok(Some(event)) => {
-                                        return Some((Ok(event), (byte_stream, buffer)));
-                                    }
-                                    Ok(None) => return None,
-                                    Err(e) => return Some((Err(e), (byte_stream, buffer))),
-                                }
-                            }
-                            return None;
-                        }
-                    }
-                }
-            },
-        );
-
-        Ok(Box::pin(event_stream))
+        let event_stream = create_sse_event_stream(byte_stream, parse_sse_data);
+        Ok(event_stream)
     }
 }
 
@@ -151,16 +103,6 @@ fn build_request_body(messages: &[Message], config: &RequestConfig) -> serde_jso
         "stream": true,
         "messages": messages_json,
     })
-}
-
-/// Extract the data payload from an SSE event block.
-fn extract_sse_data(event_text: &str) -> Option<&str> {
-    for line in event_text.lines() {
-        if let Some(data) = line.strip_prefix("data: ") {
-            return Some(data);
-        }
-    }
-    None
 }
 
 #[cfg(test)]
@@ -189,27 +131,6 @@ mod tests {
             body.get("model").is_none() || body["model"].is_null(),
             "model must not be in the request body; Vertex AI embeds it in the URL"
         );
-    }
-
-    #[test]
-    fn extract_sse_data_returns_json_after_data_prefix() {
-        let event = "event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}";
-        assert_eq!(
-            extract_sse_data(event),
-            Some("{\"type\":\"content_block_delta\"}")
-        );
-    }
-
-    #[test]
-    fn extract_sse_data_returns_none_when_no_data_line() {
-        let event = "event: content_block_delta\n";
-        assert!(extract_sse_data(event).is_none());
-    }
-
-    #[test]
-    fn extract_sse_data_returns_first_data_line_when_multiple_present() {
-        let event = "data: first\ndata: second";
-        assert_eq!(extract_sse_data(event), Some("first"));
     }
 }
 

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -1,12 +1,13 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use futures::StreamExt;
 use reqwest::Client;
 
 use super::LlmBackend;
+use super::sse::create_sse_event_stream;
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 
-/// Z.ai backend for LLM models.
+const ENDPOINT: &str = "https://api.z.ai/v1/chat/completions";
+
 #[derive(Debug)]
 pub struct ZaiBackend {
     client: Client,
@@ -14,7 +15,6 @@ pub struct ZaiBackend {
 }
 
 impl ZaiBackend {
-    /// Create a new ZaiBackend using an API key.
     pub fn new(api_key: String) -> Result<Self> {
         if api_key.is_empty() {
             anyhow::bail!("API key cannot be empty");
@@ -23,10 +23,6 @@ impl ZaiBackend {
             client: Client::new(),
             api_key,
         })
-    }
-
-    fn endpoint(&self) -> String {
-        "https://api.z.ai/v1/chat/completions".to_string()
     }
 
     fn build_request_body(
@@ -60,12 +56,11 @@ impl LlmBackend for ZaiBackend {
         messages: &[Message],
         config: &RequestConfig,
     ) -> Result<BoxStream<Result<StreamEvent>>> {
-        let url = self.endpoint();
         let body = self.build_request_body(messages, config);
 
         let response = self
             .client
-            .post(&url)
+            .post(ENDPOINT)
             .bearer_auth(&self.api_key)
             .header("Content-Type", "application/json")
             .json(&body)
@@ -83,71 +78,11 @@ impl LlmBackend for ZaiBackend {
         }
 
         let byte_stream = response.bytes_stream();
-
-        let event_stream = futures::stream::unfold(
-            (byte_stream, String::new()),
-            |(mut byte_stream, mut buffer)| async move {
-                loop {
-                    if let Some(pos) = buffer.find("\n\n") {
-                        let event_text = buffer[..pos].to_string();
-                        buffer = buffer[pos + 2..].to_string();
-
-                        if let Some(data) = extract_sse_data(&event_text) {
-                            match parse_sse_data(data) {
-                                Ok(Some(event)) => return Some((Ok(event), (byte_stream, buffer))),
-                                Ok(None) => continue,
-                                Err(e) => return Some((Err(e), (byte_stream, buffer))),
-                            }
-                        }
-                        continue;
-                    }
-
-                    match byte_stream.next().await {
-                        Some(Ok(bytes)) => {
-                            buffer.push_str(&String::from_utf8_lossy(&bytes));
-                        }
-                        Some(Err(e)) => {
-                            return Some((
-                                Err(anyhow::anyhow!("Stream read error: {}", e)),
-                                (byte_stream, buffer),
-                            ));
-                        }
-                        None => {
-                            if !buffer.trim().is_empty()
-                                && let Some(data) = extract_sse_data(&buffer).map(str::to_owned)
-                            {
-                                buffer.clear();
-                                match parse_sse_data(&data) {
-                                    Ok(Some(event)) => {
-                                        return Some((Ok(event), (byte_stream, buffer)));
-                                    }
-                                    Ok(None) => return None,
-                                    Err(e) => return Some((Err(e), (byte_stream, buffer))),
-                                }
-                            }
-                            return None;
-                        }
-                    }
-                }
-            },
-        );
-
-        Ok(Box::pin(event_stream))
+        let event_stream = create_sse_event_stream(byte_stream, parse_sse_data);
+        Ok(event_stream)
     }
 }
 
-/// Extract the data payload from an SSE event block.
-fn extract_sse_data(event_text: &str) -> Option<&str> {
-    for line in event_text.lines() {
-        if let Some(data) = line.strip_prefix("data: ") {
-            return Some(data);
-        }
-    }
-    None
-}
-
-/// Parse an SSE data payload JSON into a StreamEvent.
-/// Returns None for event types we intentionally ignore.
 pub fn parse_sse_data(data: &str) -> Result<Option<StreamEvent>> {
     if data == "[DONE]" {
         return Ok(Some(StreamEvent::Done));
@@ -186,12 +121,6 @@ mod tests {
         assert!(result.is_ok(), "Should accept valid API key");
         let backend = result.unwrap();
         assert_eq!(backend.api_key, "test-key");
-    }
-
-    #[test]
-    fn endpoint_returns_correct_url() {
-        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
-        assert_eq!(backend.endpoint(), "https://api.z.ai/v1/chat/completions");
     }
 
     #[test]
@@ -271,5 +200,13 @@ mod tests {
         let data = "not valid json";
         let result = parse_sse_data(data);
         assert!(result.is_err(), "Should return error for invalid JSON");
+    }
+
+    #[test]
+    fn parse_sse_data_returns_none_for_empty_delta() {
+        let data = r#"{"choices":[{"delta":{}}]}"#;
+        let result = parse_sse_data(data);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 }

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -1,0 +1,275 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures::StreamExt;
+use reqwest::Client;
+
+use super::LlmBackend;
+use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+
+/// Z.ai backend for LLM models.
+#[derive(Debug)]
+pub struct ZaiBackend {
+    client: Client,
+    api_key: String,
+}
+
+impl ZaiBackend {
+    /// Create a new ZaiBackend using an API key.
+    pub fn new(api_key: String) -> Result<Self> {
+        if api_key.is_empty() {
+            anyhow::bail!("API key cannot be empty");
+        }
+        Ok(Self {
+            client: Client::new(),
+            api_key,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        "https://api.z.ai/v1/chat/completions".to_string()
+    }
+
+    fn build_request_body(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> serde_json::Value {
+        let messages_json: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|m| {
+                serde_json::json!({
+                    "role": m.role,
+                    "content": m.content,
+                })
+            })
+            .collect();
+
+        serde_json::json!({
+            "model": config.model,
+            "messages": messages_json,
+            "stream": true,
+            "max_tokens": config.max_tokens,
+        })
+    }
+}
+
+#[async_trait]
+impl LlmBackend for ZaiBackend {
+    async fn send_message(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>> {
+        let url = self.endpoint();
+        let body = self.build_request_body(messages, config);
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send request to z.ai")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| String::from("<failed to read response body>"));
+            anyhow::bail!("z.ai returned {}: {}", status, body);
+        }
+
+        let byte_stream = response.bytes_stream();
+
+        let event_stream = futures::stream::unfold(
+            (byte_stream, String::new()),
+            |(mut byte_stream, mut buffer)| async move {
+                loop {
+                    if let Some(pos) = buffer.find("\n\n") {
+                        let event_text = buffer[..pos].to_string();
+                        buffer = buffer[pos + 2..].to_string();
+
+                        if let Some(data) = extract_sse_data(&event_text) {
+                            match parse_sse_data(data) {
+                                Ok(Some(event)) => return Some((Ok(event), (byte_stream, buffer))),
+                                Ok(None) => continue,
+                                Err(e) => return Some((Err(e), (byte_stream, buffer))),
+                            }
+                        }
+                        continue;
+                    }
+
+                    match byte_stream.next().await {
+                        Some(Ok(bytes)) => {
+                            buffer.push_str(&String::from_utf8_lossy(&bytes));
+                        }
+                        Some(Err(e)) => {
+                            return Some((
+                                Err(anyhow::anyhow!("Stream read error: {}", e)),
+                                (byte_stream, buffer),
+                            ));
+                        }
+                        None => {
+                            if !buffer.trim().is_empty()
+                                && let Some(data) = extract_sse_data(&buffer).map(str::to_owned)
+                            {
+                                buffer.clear();
+                                match parse_sse_data(&data) {
+                                    Ok(Some(event)) => {
+                                        return Some((Ok(event), (byte_stream, buffer)));
+                                    }
+                                    Ok(None) => return None,
+                                    Err(e) => return Some((Err(e), (byte_stream, buffer))),
+                                }
+                            }
+                            return None;
+                        }
+                    }
+                }
+            },
+        );
+
+        Ok(Box::pin(event_stream))
+    }
+}
+
+/// Extract the data payload from an SSE event block.
+fn extract_sse_data(event_text: &str) -> Option<&str> {
+    for line in event_text.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            return Some(data);
+        }
+    }
+    None
+}
+
+/// Parse an SSE data payload JSON into a StreamEvent.
+/// Returns None for event types we intentionally ignore.
+pub fn parse_sse_data(data: &str) -> Result<Option<StreamEvent>> {
+    if data == "[DONE]" {
+        return Ok(Some(StreamEvent::Done));
+    }
+
+    let json: serde_json::Value = serde_json::from_str(data)
+        .with_context(|| format!("Failed to parse SSE data: {}", data))?;
+
+    let content = json["choices"][0]["delta"]["content"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    if content.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(StreamEvent::TextDelta(content)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Role;
+
+    #[test]
+    fn new_rejects_empty_api_key() {
+        let result = ZaiBackend::new("".to_string());
+        assert!(result.is_err(), "Should reject empty API key");
+        assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn new_accepts_valid_api_key() {
+        let result = ZaiBackend::new("test-key".to_string());
+        assert!(result.is_ok(), "Should accept valid API key");
+        let backend = result.unwrap();
+        assert_eq!(backend.api_key, "test-key");
+    }
+
+    #[test]
+    fn endpoint_returns_correct_url() {
+        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
+        assert_eq!(backend.endpoint(), "https://api.z.ai/v1/chat/completions");
+    }
+
+    #[test]
+    fn build_request_body_includes_model_and_stream() {
+        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
+        let config = RequestConfig {
+            model: "glm-5-turbo".to_string(),
+            max_tokens: 4096,
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: "Hello".to_string(),
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        assert_eq!(body["model"], "glm-5-turbo");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn build_request_body_includes_messages_with_correct_roles() {
+        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
+        let config = RequestConfig {
+            model: "glm-5-turbo".to_string(),
+            max_tokens: 4096,
+        };
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: "Hello".to_string(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: "Hi there!".to_string(),
+            },
+        ];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        assert_eq!(body["messages"].as_array().unwrap().len(), 2);
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "Hello");
+        assert_eq!(body["messages"][1]["role"], "assistant");
+        assert_eq!(body["messages"][1]["content"], "Hi there!");
+    }
+
+    #[test]
+    fn parse_sse_data_extracts_text_delta() {
+        let data = r#"{"choices":[{"delta":{"content":"Hello"}}]}"#;
+        let result = parse_sse_data(data);
+        assert!(result.is_ok(), "Should successfully parse valid SSE data");
+        let event = result.unwrap();
+        assert!(event.is_some(), "Should return Some(event)");
+        assert!(
+            matches!(event, Some(StreamEvent::TextDelta(_))),
+            "Should be TextDelta"
+        );
+        if let Some(StreamEvent::TextDelta(text)) = event {
+            assert_eq!(text, "Hello");
+        }
+    }
+
+    #[test]
+    fn parse_sse_data_returns_done_for_done_event() {
+        let data = "[DONE]";
+        let result = parse_sse_data(data);
+        assert!(result.is_ok(), "Should successfully parse [DONE]");
+        let event = result.unwrap();
+        assert!(event.is_some(), "Should return Some(event) for [DONE]");
+        assert!(matches!(event, Some(StreamEvent::Done)), "Should be Done");
+    }
+
+    #[test]
+    fn parse_sse_data_returns_error_for_invalid_json() {
+        let data = "not valid json";
+        let result = parse_sse_data(data);
+        assert!(result.is_err(), "Should return error for invalid JSON");
+    }
+}

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -6,7 +6,7 @@ use super::LlmBackend;
 use super::sse::create_sse_event_stream;
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 
-const ENDPOINT: &str = "https://api.z.ai/v1/chat/completions";
+const ENDPOINT: &str = "https://api.z.ai/api/coding/paas/v4/chat/completions";
 
 #[derive(Debug)]
 pub struct ZaiBackend {

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ model = "claude-sonnet-4-20250514"
 # Required: your z.ai API key
 api_key = ""
 # Model to use
-model = "glm-5-turbo"
+model = "glm-5.1"
 "#;
 
 #[derive(Debug, serde::Deserialize)]
@@ -54,7 +54,7 @@ fn default_backend() -> String {
 }
 
 fn default_zai_model() -> String {
-    "glm-5-turbo".to_string()
+    "glm-5.1".to_string()
 }
 
 fn default_region() -> String {
@@ -108,14 +108,26 @@ pub fn apply_overrides(
     region: Option<&str>,
     model: Option<&str>,
 ) {
-    if let Some(p) = project {
-        config.vertex.project = p.to_string();
-    }
-    if let Some(r) = region {
-        config.vertex.region = r.to_string();
-    }
-    if let Some(m) = model {
-        config.vertex.model = m.to_string();
+    match config.backend.as_str() {
+        "vertex" => {
+            if let Some(p) = project {
+                config.vertex.project = p.to_string();
+            }
+            if let Some(r) = region {
+                config.vertex.region = r.to_string();
+            }
+            if let Some(m) = model {
+                config.vertex.model = m.to_string();
+            }
+        }
+        "zai" => {
+            if let Some(m) = model
+                && let Some(ref mut zai) = config.zai
+            {
+                zai.model = m.to_string();
+            }
+        }
+        _ => {}
     }
 }
 
@@ -235,7 +247,7 @@ mod tests {
             },
             zai: Some(ZaiConfig {
                 api_key: "".to_string(),
-                model: "glm-5-turbo".to_string(),
+                model: "glm-5.1".to_string(),
             }),
         };
         let result = validate(&config, None);
@@ -254,7 +266,7 @@ mod tests {
             },
             zai: Some(ZaiConfig {
                 api_key: "test-key".to_string(),
-                model: "glm-5-turbo".to_string(),
+                model: "glm-5.1".to_string(),
             }),
         };
         let result = validate(&config, None);

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,19 +4,33 @@ use anyhow::{Context, Result, bail};
 
 const DEFAULT_REGION: &str = "us-east5";
 const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+const DEFAULT_BACKEND: &str = "vertex";
 
-const CONFIG_TEMPLATE: &str = r#"[vertex]
+const CONFIG_TEMPLATE: &str = r#"# Which backend to use: "vertex" or "zai"
+backend = "vertex"
+
+[vertex]
 # Required: your GCP project ID
 project = ""
 # Vertex AI region
 region = "us-east5"
 # Model to use
 model = "claude-sonnet-4-20250514"
+
+[zai]
+# Required: your z.ai API key
+api_key = ""
+# Model to use
+model = "glm-5-turbo"
 "#;
 
 #[derive(Debug, serde::Deserialize)]
 pub struct AppConfig {
+    #[serde(default = "default_backend")]
+    pub backend: String,
     pub vertex: VertexConfig,
+    #[serde(default)]
+    pub zai: Option<ZaiConfig>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -26,6 +40,21 @@ pub struct VertexConfig {
     pub region: String,
     #[serde(default = "default_model")]
     pub model: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct ZaiConfig {
+    pub api_key: String,
+    #[serde(default = "default_zai_model")]
+    pub model: String,
+}
+
+fn default_backend() -> String {
+    DEFAULT_BACKEND.to_string()
+}
+
+fn default_zai_model() -> String {
+    "glm-5-turbo".to_string()
 }
 
 fn default_region() -> String {
@@ -90,22 +119,161 @@ pub fn apply_overrides(
     }
 }
 
-/// Validate that the config has all required fields.
+/// Validate that the config has all required fields for the selected backend.
 ///
 /// `config_path`: The path that was actually used to load the config, for accurate error messages.
 /// Pass `None` if the default path was used.
 pub fn validate(config: &AppConfig, config_path: Option<&Path>) -> Result<()> {
-    if config.vertex.project.is_empty() {
-        let path = match config_path {
-            Some(p) => p.display().to_string(),
-            None => default_config_path()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|_| "~/.config/illustrious-manager/config.toml".to_string()),
-        };
-        bail!(
-            "GCP project ID is required. Set it in your config file at:\n  {}\n\nOr pass --project <PROJECT> on the command line.",
-            path
-        );
+    match config.backend.as_str() {
+        "vertex" => {
+            if config.vertex.project.is_empty() {
+                let path = match config_path {
+                    Some(p) => p.display().to_string(),
+                    None => default_config_path()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|_| {
+                            "~/.config/illustrious-manager/config.toml".to_string()
+                        }),
+                };
+                bail!(
+                    "GCP project ID is required for vertex backend. Set it in your config file at:\n  {}\n\nOr pass --project <PROJECT> on the command line.",
+                    path
+                );
+            }
+        }
+        "zai" => {
+            if let Some(ref zai_config) = config.zai {
+                if zai_config.api_key.is_empty() {
+                    let path = match config_path {
+                        Some(p) => p.display().to_string(),
+                        None => default_config_path()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|_| {
+                                "~/.config/illustrious-manager/config.toml".to_string()
+                            }),
+                    };
+                    bail!(
+                        "API key is required for zai backend. Set it in your config file at:\n  {}",
+                        path
+                    );
+                }
+            } else {
+                bail!(
+                    "zai backend configuration is missing. Add a [zai] section to your config file."
+                );
+            }
+        }
+        _ => {
+            bail!(
+                "Invalid backend '{}'. Supported backends are: vertex, zai",
+                config.backend
+            );
+        }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_vertex_backend_with_empty_project_errors() {
+        let config = AppConfig {
+            backend: "vertex".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+        };
+        let result = validate(&config, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("GCP project ID"));
+    }
+
+    #[test]
+    fn validate_vertex_backend_with_valid_project_succeeds() {
+        let config = AppConfig {
+            backend: "vertex".to_string(),
+            vertex: VertexConfig {
+                project: "my-project".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+        };
+        let result = validate(&config, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_zai_backend_with_missing_config_errors() {
+        let config = AppConfig {
+            backend: "zai".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+        };
+        let result = validate(&config, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("[zai]"));
+    }
+
+    #[test]
+    fn validate_zai_backend_with_empty_api_key_errors() {
+        let config = AppConfig {
+            backend: "zai".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: Some(ZaiConfig {
+                api_key: "".to_string(),
+                model: "glm-5-turbo".to_string(),
+            }),
+        };
+        let result = validate(&config, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn validate_zai_backend_with_valid_config_succeeds() {
+        let config = AppConfig {
+            backend: "zai".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: Some(ZaiConfig {
+                api_key: "test-key".to_string(),
+                model: "glm-5-turbo".to_string(),
+            }),
+        };
+        let result = validate(&config, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_invalid_backend_errors() {
+        let config = AppConfig {
+            backend: "invalid".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+        };
+        let result = validate(&config, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid backend"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use clap::Parser;
 use std::path::PathBuf;
 
 use agent::Agent;
+use backend::LlmBackend;
 use backend::vertex::VertexBackend;
+use backend::zai::ZaiBackend;
 use types::RequestConfig;
 
 const DEFAULT_MAX_TOKENS: u32 = 8192;
@@ -73,18 +75,45 @@ async fn main() -> Result<()> {
     );
     config::validate(&app_config, cli.config.as_deref())?;
 
-    let vertex_backend = VertexBackend::new(
-        app_config.vertex.project.clone(),
-        app_config.vertex.region.clone(),
-    )
-    .await?;
+    let backend: Box<dyn LlmBackend> = match app_config.backend.as_str() {
+        "vertex" => {
+            let vertex_backend = VertexBackend::new(
+                app_config.vertex.project.clone(),
+                app_config.vertex.region.clone(),
+            )
+            .await?;
+            Box::new(vertex_backend)
+        }
+        "zai" => {
+            let zai_config = app_config
+                .zai
+                .as_ref()
+                .expect("zai config should be validated");
+            let zai_backend = ZaiBackend::new(zai_config.api_key.clone())?;
+            Box::new(zai_backend)
+        }
+        _ => {
+            anyhow::bail!("Invalid backend '{}'", app_config.backend);
+        }
+    };
+
+    let model = match app_config.backend.as_str() {
+        "vertex" => app_config.vertex.model.clone(),
+        "zai" => app_config
+            .zai
+            .as_ref()
+            .expect("zai config should be validated")
+            .model
+            .clone(),
+        _ => anyhow::bail!("Invalid backend '{}'", app_config.backend),
+    };
 
     let request_config = RequestConfig {
-        model: app_config.vertex.model.clone(),
+        model,
         max_tokens: DEFAULT_MAX_TOKENS,
     };
 
-    let mut agent = Agent::new(Box::new(vertex_backend), request_config);
+    let mut agent = Agent::new(backend, request_config);
 
     match mode {
         Mode::SingleShot { prompt } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,6 @@ use clap::Parser;
 use std::path::PathBuf;
 
 use agent::Agent;
-use backend::LlmBackend;
-use backend::vertex::VertexBackend;
-use backend::zai::ZaiBackend;
 use types::RequestConfig;
 
 const DEFAULT_MAX_TOKENS: u32 = 8192;
@@ -75,39 +72,7 @@ async fn main() -> Result<()> {
     );
     config::validate(&app_config, cli.config.as_deref())?;
 
-    struct BackendSelection {
-        backend: Box<dyn LlmBackend>,
-        model: String,
-    }
-
-    let selection = match app_config.backend.as_str() {
-        "vertex" => {
-            let vertex_backend = VertexBackend::new(
-                app_config.vertex.project.clone(),
-                app_config.vertex.region.clone(),
-            )
-            .await?;
-            BackendSelection {
-                backend: Box::new(vertex_backend),
-                model: app_config.vertex.model.clone(),
-            }
-        }
-        "zai" => {
-            let zai_config = app_config.zai.as_ref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "zai backend configuration is missing. Add a [zai] section to your config file."
-                )
-            })?;
-            let zai_backend = ZaiBackend::new(zai_config.api_key.clone())?;
-            BackendSelection {
-                backend: Box::new(zai_backend),
-                model: zai_config.model.clone(),
-            }
-        }
-        _ => {
-            anyhow::bail!("Invalid backend '{}'", app_config.backend);
-        }
-    };
+    let selection = backend::from_config(&app_config).await?;
 
     let request_config = RequestConfig {
         model: selection.model,

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,45 +75,46 @@ async fn main() -> Result<()> {
     );
     config::validate(&app_config, cli.config.as_deref())?;
 
-    let backend: Box<dyn LlmBackend> = match app_config.backend.as_str() {
+    struct BackendSelection {
+        backend: Box<dyn LlmBackend>,
+        model: String,
+    }
+
+    let selection = match app_config.backend.as_str() {
         "vertex" => {
             let vertex_backend = VertexBackend::new(
                 app_config.vertex.project.clone(),
                 app_config.vertex.region.clone(),
             )
             .await?;
-            Box::new(vertex_backend)
+            BackendSelection {
+                backend: Box::new(vertex_backend),
+                model: app_config.vertex.model.clone(),
+            }
         }
         "zai" => {
-            let zai_config = app_config
-                .zai
-                .as_ref()
-                .expect("zai config should be validated");
+            let zai_config = app_config.zai.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "zai backend configuration is missing. Add a [zai] section to your config file."
+                )
+            })?;
             let zai_backend = ZaiBackend::new(zai_config.api_key.clone())?;
-            Box::new(zai_backend)
+            BackendSelection {
+                backend: Box::new(zai_backend),
+                model: zai_config.model.clone(),
+            }
         }
         _ => {
             anyhow::bail!("Invalid backend '{}'", app_config.backend);
         }
     };
 
-    let model = match app_config.backend.as_str() {
-        "vertex" => app_config.vertex.model.clone(),
-        "zai" => app_config
-            .zai
-            .as_ref()
-            .expect("zai config should be validated")
-            .model
-            .clone(),
-        _ => anyhow::bail!("Invalid backend '{}'", app_config.backend),
-    };
-
     let request_config = RequestConfig {
-        model,
+        model: selection.model,
         max_tokens: DEFAULT_MAX_TOKENS,
     };
 
-    let mut agent = Agent::new(backend, request_config);
+    let mut agent = Agent::new(selection.backend, request_config);
 
     match mode {
         Mode::SingleShot { prompt } => {

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -50,7 +50,6 @@ model = "claude-sonnet-4-20250514"
     let mut config = illustrious_manager::config::load_config_from_path(tmp.path())
         .expect("Failed to load config from temp file");
 
-    // Simulate CLI overrides for all fields
     illustrious_manager::config::apply_overrides(
         &mut config,
         Some("cli-project"),
@@ -77,12 +76,11 @@ model = "claude-haiku-4-20250514"
     let mut config = illustrious_manager::config::load_config_from_path(tmp.path())
         .expect("Failed to load config from temp file");
 
-    // Override only the project, leaving region and model from config file
     illustrious_manager::config::apply_overrides(&mut config, Some("cli-project"), None, None);
 
     assert_eq!(config.vertex.project, "cli-project");
-    assert_eq!(config.vertex.region, "us-central1"); // unchanged
-    assert_eq!(config.vertex.model, "claude-haiku-4-20250514"); // unchanged
+    assert_eq!(config.vertex.region, "us-central1");
+    assert_eq!(config.vertex.model, "claude-haiku-4-20250514");
 }
 
 #[test]
@@ -122,7 +120,6 @@ project = ""
 
     assert!(result.is_err());
     let err_msg = result.expect_err("Expected validation to fail").to_string();
-    // The error message should include the actual temp file path, not the default path
     assert!(
         err_msg.contains(&tmp.path().display().to_string()),
         "Error should mention the actual config path that was used"
@@ -134,22 +131,17 @@ fn test_load_config_auto_creates_file() {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let config_path = temp_dir.path().join("new_config.toml");
 
-    // Verify the file doesn't exist yet
     assert!(!config_path.exists());
 
-    // Load config, which should auto-create the file
     let config = illustrious_manager::config::load_config(Some(&config_path))
         .expect("Failed to auto-create and load config");
 
-    // Verify the file was created
     assert!(config_path.exists());
 
-    // Verify the config has default values and empty project
     assert_eq!(config.vertex.project, "");
     assert_eq!(config.vertex.region, "us-east5");
     assert_eq!(config.vertex.model, "claude-sonnet-4-20250514");
 
-    // Verify the file content matches the template
     let file_content =
         std::fs::read_to_string(&config_path).expect("Failed to read created config file");
     assert!(file_content.contains("[vertex]"));
@@ -157,4 +149,119 @@ fn test_load_config_auto_creates_file() {
     assert!(file_content.contains("region = \"us-east5\""));
     assert!(file_content.contains("model = \"claude-sonnet-4-20250514\""));
     assert!(file_content.contains("# Required: your GCP project ID"));
+}
+
+#[test]
+fn test_parse_zai_config() {
+    let toml_content = r#"
+backend = "zai"
+
+[vertex]
+project = "my-project"
+region = "us-east5"
+model = "claude-sonnet-4-20250514"
+
+[zai]
+api_key = "test-api-key"
+model = "glm-5.1"
+"#;
+    let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+    write!(tmp, "{}", toml_content).expect("Failed to write to temp file");
+
+    let config = illustrious_manager::config::load_config_from_path(tmp.path())
+        .expect("Failed to load config from temp file");
+    assert_eq!(config.backend, "zai");
+    let zai = config.zai.as_ref().expect("zai config should be present");
+    assert_eq!(zai.api_key, "test-api-key");
+    assert_eq!(zai.model, "glm-5.1");
+}
+
+#[test]
+fn test_backend_defaults_to_vertex() {
+    let toml_content = r#"
+[vertex]
+project = "my-project"
+"#;
+    let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+    write!(tmp, "{}", toml_content).expect("Failed to write to temp file");
+
+    let config = illustrious_manager::config::load_config_from_path(tmp.path())
+        .expect("Failed to load config from temp file");
+    assert_eq!(config.backend, "vertex");
+}
+
+#[test]
+fn test_zai_config_uses_default_model() {
+    let toml_content = r#"
+backend = "zai"
+
+[vertex]
+project = "my-project"
+
+[zai]
+api_key = "test-api-key"
+"#;
+    let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+    write!(tmp, "{}", toml_content).expect("Failed to write to temp file");
+
+    let config = illustrious_manager::config::load_config_from_path(tmp.path())
+        .expect("Failed to load config from temp file");
+    let zai = config.zai.as_ref().expect("zai config should be present");
+    assert_eq!(zai.model, "glm-5.1");
+}
+
+#[test]
+fn test_cli_model_overrides_zai_model() {
+    let toml_content = r#"
+backend = "zai"
+
+[vertex]
+project = "my-project"
+
+[zai]
+api_key = "test-api-key"
+model = "glm-5.1"
+"#;
+    let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+    write!(tmp, "{}", toml_content).expect("Failed to write to temp file");
+
+    let mut config = illustrious_manager::config::load_config_from_path(tmp.path())
+        .expect("Failed to load config from temp file");
+
+    illustrious_manager::config::apply_overrides(&mut config, None, None, Some("glm-4"));
+
+    let zai = config.zai.as_ref().expect("zai config should be present");
+    assert_eq!(zai.model, "glm-4");
+}
+
+#[test]
+fn test_cli_vertex_flags_ignored_for_zai_backend() {
+    let toml_content = r#"
+backend = "zai"
+
+[vertex]
+project = "original-project"
+region = "us-east5"
+
+[zai]
+api_key = "test-api-key"
+model = "glm-5.1"
+"#;
+    let mut tmp = NamedTempFile::new().expect("Failed to create temp file");
+    write!(tmp, "{}", toml_content).expect("Failed to write to temp file");
+
+    let mut config = illustrious_manager::config::load_config_from_path(tmp.path())
+        .expect("Failed to load config from temp file");
+
+    illustrious_manager::config::apply_overrides(
+        &mut config,
+        Some("cli-project"),
+        Some("europe-west1"),
+        None,
+    );
+
+    assert_eq!(
+        config.vertex.project, "original-project",
+        "project flag should not affect vertex config when backend is zai"
+    );
 }

--- a/tests/zai_test.rs
+++ b/tests/zai_test.rs
@@ -1,0 +1,45 @@
+#[test]
+fn test_parse_sse_text_delta() {
+    let data = r#"{"choices":[{"delta":{"content":"Hello"}}]}"#;
+    let event = illustrious_manager::backend::zai::parse_sse_data(data).unwrap();
+    match event {
+        Some(illustrious_manager::types::StreamEvent::TextDelta(text)) => {
+            assert_eq!(text, "Hello");
+        }
+        other => panic!("Expected TextDelta, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_sse_done_event() {
+    let data = "[DONE]";
+    let event = illustrious_manager::backend::zai::parse_sse_data(data).unwrap();
+    match event {
+        Some(illustrious_manager::types::StreamEvent::Done) => {}
+        other => panic!("Expected Done, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_parse_sse_empty_delta_returns_none() {
+    let data = r#"{"choices":[{"delta":{}}]}"#;
+    let event = illustrious_manager::backend::zai::parse_sse_data(data).unwrap();
+    assert!(
+        event.is_none(),
+        "choices with no delta content should be ignored"
+    );
+}
+
+#[test]
+fn test_parse_sse_empty_content_returns_none() {
+    let data = r#"{"choices":[{"delta":{"content":""}}]}"#;
+    let event = illustrious_manager::backend::zai::parse_sse_data(data).unwrap();
+    assert!(event.is_none(), "empty content string should be ignored");
+}
+
+#[test]
+fn test_parse_sse_malformed_json_returns_err() {
+    let data = "this is not json";
+    let result = illustrious_manager::backend::zai::parse_sse_data(data);
+    assert!(result.is_err(), "malformed JSON should return Err");
+}


### PR DESCRIPTION
## Summary
- Implement z.ai (Zhipu AI) backend as an alternative to Vertex AI
- Support both backends simultaneously with runtime selection via config
- Follow TDD principles throughout implementation

## Changes
- **New `ZaiBackend` implementation** (`src/backend/zai.rs`)
  - Bearer token authentication using API key
  - OpenAI-style SSE streaming support
  - Request body builder for z.ai API format
  - SSE parser for z.ai response format

- **Updated config schema** (`src/config.rs`)
  - Add `backend` field to select backend (vertex/zai)
  - Add `[zai]` section with `api_key` and `model` fields
  - Updated validation to support both backends
  - New config template with both backends documented

- **Backend selection logic** (`src/main.rs`)
  - Dynamic backend creation based on config
  - Model selection based on active backend

## Configuration Example
```toml
# Select backend: "vertex" or "zai"
backend = "zai"

[vertex]
project = "my-gcp-project"
region = "us-east5"
model = "claude-sonnet-4-20250514"

[zai]
api_key = "your-zai-api-key"
model = "glm-5-turbo"
```

## Test Plan
- [x] All existing tests pass
- [x] New tests for z.ai backend construction
- [x] New tests for request body building
- [x] New tests for SSE parsing
- [x] Config validation tests for both backends
- [x] cargo fmt passes
- [x] cargo clippy passes

## Testing
```bash
cargo test                    # All tests pass
cargo fmt                     # Code formatted
cargo clippy                  # No warnings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)