### PR TITLE
fix: display user message immediately with "thinking" indicator (issue #21)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -30,7 +30,7 @@ impl Agent {
         lock(&self.history).clone()
     }
 
-    pub async fn send(&mut self, input: String) -> Result<BoxStream<AgentEvent>> {
+    pub async fn send(&self, input: String) -> Result<BoxStream<AgentEvent>> {
         lock(&self.history).push(Message {
             role: Role::User,
             content: input,

--- a/src/frontend/tui.rs
+++ b/src/frontend/tui.rs
@@ -17,12 +17,15 @@ use tokio::task::JoinHandle;
 
 use crate::agent::Agent;
 use crate::types::AgentEvent;
+use std::sync::Arc;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppState {
     Input,
     Streaming,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConversationRole {
     User,
     Assistant,
@@ -135,7 +138,7 @@ pub fn render_app(app: &App, frame: &mut ratatui::Frame) {
 }
 
 /// Run the TUI REPL. If `initial_prompt` is provided, it's sent immediately.
-pub async fn run(agent: &mut Agent, initial_prompt: Option<String>) -> Result<()> {
+pub async fn run(agent: Arc<Agent>, initial_prompt: Option<String>) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -153,7 +156,7 @@ pub async fn run(agent: &mut Agent, initial_prompt: Option<String>) -> Result<()
 
 async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    agent: &mut Agent,
+    agent: Arc<Agent>,
     initial_prompt: Option<String>,
 ) -> Result<()> {
     let mut app = App::new();
@@ -162,7 +165,7 @@ async fn run_app(
 
     if let Some(prompt) = initial_prompt {
         app.input = prompt;
-        stream_task = Some(submit_message(&mut app, agent, &event_tx).await?);
+        stream_task = Some(submit_message(&mut app, agent.clone(), &event_tx).await?);
     }
 
     loop {
@@ -188,7 +191,7 @@ async fn run_app(
                         } => {
                             if !app.input.trim().is_empty() {
                                 stream_task =
-                                    Some(submit_message(&mut app, agent, &event_tx).await?);
+                                    Some(submit_message(&mut app, agent.clone(), &event_tx).await?);
                             }
                         }
                         KeyEvent {
@@ -255,9 +258,9 @@ async fn run_app(
     Ok(())
 }
 
-async fn submit_message(
+pub async fn submit_message(
     app: &mut App,
-    agent: &mut Agent,
+    agent: Arc<Agent>,
     event_tx: &mpsc::Sender<AgentEvent>,
 ) -> Result<JoinHandle<()>> {
     let input = app.input.drain(..).collect::<String>();
@@ -269,13 +272,22 @@ async fn submit_message(
 
     app.state = AppState::Streaming;
 
-    let mut stream = agent.send(input).await?;
     let tx = event_tx.clone();
 
+    // Spawn the entire message sending operation in a background task
+    // so it doesn't block the UI event loop
     let handle = tokio::spawn(async move {
-        while let Some(event) = stream.next().await {
-            if tx.send(event).await.is_err() {
-                break;
+        // Call agent.send() in the background task
+        match agent.send(input).await {
+            Ok(mut stream) => {
+                while let Some(event) = stream.next().await {
+                    if tx.send(event).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            Err(e) => {
+                let _ = tx.send(AgentEvent::Error(e.to_string())).await;
             }
         }
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ pub mod types;
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use agent::Agent;
 use types::RequestConfig;
@@ -79,7 +80,7 @@ async fn main() -> Result<()> {
         max_tokens: DEFAULT_MAX_TOKENS,
     };
 
-    let mut agent = Agent::new(selection.backend, request_config);
+    let agent = Arc::new(Agent::new(selection.backend, request_config));
 
     match mode {
         Mode::SingleShot { prompt } => {
@@ -87,7 +88,7 @@ async fn main() -> Result<()> {
             frontend::stdout::run(stream).await?;
         }
         Mode::Repl { initial_prompt } => {
-            frontend::tui::run(&mut agent, initial_prompt).await?;
+            frontend::tui::run(agent.clone(), initial_prompt).await?;
         }
     }
 

--- a/tests/tui_test.rs
+++ b/tests/tui_test.rs
@@ -68,7 +68,6 @@ async fn regression_test_issue_21_user_message_appears_immediately() {
 
     use anyhow::Result;
     use async_trait::async_trait;
-    use futures::stream;
     use illustrious_manager::agent::Agent;
     use illustrious_manager::backend::LlmBackend;
     use illustrious_manager::types::*;

--- a/tests/tui_test.rs
+++ b/tests/tui_test.rs
@@ -56,3 +56,99 @@ fn test_tui_streaming_state() {
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
+
+#[tokio::test]
+async fn regression_test_issue_21_user_message_appears_immediately() {
+    // This test verifies that submit_message completes quickly without
+    // waiting for the backend response.
+    //
+    // The bug in issue #21 was that submit_message would await the backend
+    // response, blocking the UI event loop. The fix is to spawn the backend
+    // request in a background task and return immediately.
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use futures::stream;
+    use illustrious_manager::agent::Agent;
+    use illustrious_manager::backend::LlmBackend;
+    use illustrious_manager::types::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::mpsc;
+    use tokio::time::Duration;
+
+    // A mock backend that blocks for a long time before responding
+    struct SlowBackend {
+        delay_ms: u64,
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl LlmBackend for SlowBackend {
+        async fn send_message(
+            &self,
+            _messages: &[Message],
+            _config: &RequestConfig,
+        ) -> Result<BoxStream<Result<StreamEvent>>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            // Simulate a slow backend that takes time to start responding
+            tokio::time::sleep(Duration::from_millis(self.delay_ms)).await;
+            let stream = futures::stream::empty::<Result<StreamEvent>>();
+            Ok(Box::pin(stream))
+        }
+    }
+
+    let config = RequestConfig {
+        model: "test-model".to_string(),
+        max_tokens: 1024,
+    };
+
+    // Create a backend that will delay for 5 seconds
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let backend = Box::new(SlowBackend {
+        delay_ms: 5000,
+        call_count: call_count.clone(),
+    });
+    let agent = Arc::new(Agent::new(backend, config));
+
+    // Create app with user input
+    let mut app = App::new();
+    app.input = "Hello, world!".to_string();
+
+    // Submit the message - this should return QUICKLY (< 100ms) without
+    // waiting for the backend, because the backend request is spawned
+    // in a background task
+    let (event_tx, _) = mpsc::channel(100);
+
+    let start = std::time::Instant::now();
+    let _task =
+        illustrious_manager::frontend::tui::submit_message(&mut app, agent.clone(), &event_tx)
+            .await
+            .expect("submit_message must succeed");
+    let elapsed = start.elapsed();
+
+    // Verify submit_message completed quickly (should be < 100ms)
+    // If it takes longer, the code is awaiting the backend response (BUG)
+    assert!(
+        elapsed < Duration::from_millis(100),
+        "submit_message took {:?}, should complete in < 100ms (backend call is slow)",
+        elapsed
+    );
+
+    // Verify the user message is in the conversation
+    assert_eq!(app.conversation.len(), 1);
+    assert_eq!(app.conversation[0].role, ConversationRole::User);
+    assert_eq!(app.conversation[0].content, "Hello, world!");
+
+    // Verify the state is Streaming
+    assert_eq!(app.state, AppState::Streaming);
+
+    // Verify input was cleared
+    assert_eq!(app.input, "");
+
+    // Give the background task a moment to start and call the backend
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Verify the backend call was actually made (background task started)
+    assert_eq!(call_count.load(Ordering::SeqCst), 1);
+}

--- a/tests/tui_test.rs
+++ b/tests/tui_test.rs
@@ -58,7 +58,7 @@ fn test_tui_streaming_state() {
 }
 
 #[tokio::test]
-async fn regression_test_issue_21_user_message_appears_immediately() {
+async fn user_message_appears_immediately() {
     // This test verifies that submit_message completes quickly without
     // waiting for the backend response.
     //


### PR DESCRIPTION
## Summary
Fixed the sluggish input submission bug where the user's message didn't appear in the conversation until after the backend responded.

## Changes
- Changed `Agent::send` to take `&self` instead of `&mut self` since it only accesses thread-safe state (Arc<Mutex<Vec<Message>>>)
- Modified TUI event loop to spawn message submission in background task
- Wrapped Agent in Arc to allow sharing across async tasks
- Added regression test that verifies user message appears immediately with "Streaming..." indicator

## Test plan
- [x] Regression test added that verifies submit_message completes in < 100ms even with a slow backend
- [x] All existing tests pass
- [x] Code formatted with `cargo fmt`
- [x] Code linted with `cargo clippy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)