### PR TITLE
feat: implement BashTool (#30)

### DIFF
--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -4,7 +4,7 @@ use reqwest::Client;
 
 use super::LlmBackend;
 use super::sse::create_sse_event_stream;
-use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+use crate::types::{BoxStream, ContentBlock, Message, RequestConfig, StreamEvent};
 
 const ENDPOINT: &str = "https://api.z.ai/api/coding/paas/v4/chat/completions";
 
@@ -33,10 +33,17 @@ impl ZaiBackend {
         let messages_json: Vec<serde_json::Value> = messages
             .iter()
             .map(|m| {
-                serde_json::json!({
-                    "role": m.role,
-                    "content": m.content,
-                })
+                let content: Vec<serde_json::Value> = m
+                    .content
+                    .iter()
+                    .map(|block| match block {
+                        ContentBlock::Text(text) => {
+                            serde_json::json!({"type": "text", "text": text})
+                        }
+                        other => serde_json::to_value(other).unwrap_or(serde_json::Value::Null),
+                    })
+                    .collect();
+                serde_json::json!({"role": m.role, "content": content})
             })
             .collect();
 
@@ -170,12 +177,37 @@ mod tests {
 
         assert_eq!(body["messages"].as_array().unwrap().len(), 2);
         assert_eq!(body["messages"][0]["role"], "user");
-        assert_eq!(body["messages"][0]["content"], serde_json::json!(["Hello"]));
+        assert_eq!(
+            body["messages"][0]["content"],
+            serde_json::json!([{"type": "text", "text": "Hello"}])
+        );
         assert_eq!(body["messages"][1]["role"], "assistant");
         assert_eq!(
             body["messages"][1]["content"],
-            serde_json::json!(["Hi there!"])
+            serde_json::json!([{"type": "text", "text": "Hi there!"}])
         );
+    }
+
+    #[test]
+    fn build_request_body_formats_text_blocks_as_typed_objects() {
+        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
+        let config = RequestConfig {
+            model: "glm-5-turbo".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![crate::types::ContentBlock::Text(
+                "read the test.txt file".to_string(),
+            )],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        let content0 = &body["messages"][0]["content"][0];
+        assert_eq!(content0["type"], "text", "text block must have type='text'");
+        assert_eq!(content0["text"], "read the test.txt file");
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,5 +1,6 @@
 // Tool trait and registry for extensible tool system
 
+use crate::config::ConfirmationMode;
 use crate::types::ContentBlock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -584,5 +585,331 @@ mod sandbox_tests {
             result.is_ok(),
             "Current directory should be in default sandbox"
         );
+    }
+}
+
+pub struct BashTool {
+    allowlist: Vec<String>,
+    denylist: Vec<String>,
+    sandbox_root: PathBuf,
+    confirmation: ConfirmationMode,
+    confirm_fn: Box<dyn Fn(&str) -> bool + Send + Sync>,
+    schema: Value,
+}
+
+impl BashTool {
+    pub fn new(
+        allowlist: Vec<String>,
+        denylist: Vec<String>,
+        sandbox_root: PathBuf,
+        confirmation: ConfirmationMode,
+        confirm_fn: Box<dyn Fn(&str) -> bool + Send + Sync>,
+    ) -> Self {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute"
+                }
+            },
+            "required": ["command"]
+        });
+        Self {
+            allowlist,
+            denylist,
+            sandbox_root,
+            confirmation,
+            confirm_fn,
+            schema,
+        }
+    }
+
+    fn first_tokens_of_pipe_segments(command: &str) -> Vec<&str> {
+        command
+            .split('|')
+            .filter_map(|segment| segment.trim().split_whitespace().next())
+            .collect()
+    }
+}
+
+impl Tool for BashTool {
+    fn name(&self) -> &str {
+        "bash"
+    }
+
+    fn description(&self) -> &str {
+        "Execute shell commands in the sandbox directory"
+    }
+
+    fn input_schema(&self) -> &Value {
+        &self.schema
+    }
+
+    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let command = input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidInput {
+                message: "missing required field 'command'".to_string(),
+            })?;
+
+        let tokens = Self::first_tokens_of_pipe_segments(command);
+
+        for token in &tokens {
+            if self.denylist.iter().any(|d| d == token) {
+                return Ok(ToolResult {
+                    content: vec![ContentBlock::Text(format!(
+                        "Command rejected: '{}' is not allowed",
+                        token
+                    ))],
+                    is_error: true,
+                });
+            }
+        }
+
+        let all_allowlisted = tokens
+            .iter()
+            .all(|token| self.allowlist.iter().any(|a| a == token));
+
+        if !all_allowlisted {
+            let needs_confirmation = matches!(
+                self.confirmation,
+                ConfirmationMode::Always | ConfirmationMode::WriteOnly
+            );
+
+            if needs_confirmation && !(self.confirm_fn)(command) {
+                return Ok(ToolResult {
+                    content: vec![ContentBlock::Text(
+                        "Command rejected: user denied confirmation".to_string(),
+                    )],
+                    is_error: true,
+                });
+            }
+        }
+
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .current_dir(&self.sandbox_root)
+            .output()
+            .map_err(|e| ToolError::Execution {
+                tool_name: "bash".to_string(),
+                message: format!("Failed to spawn command: {}", e),
+            })?;
+
+        let is_error = !output.status.success();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        let content = match (stdout.is_empty(), stderr.is_empty()) {
+            (false, false) => format!("{}\n{}", stdout, stderr),
+            (true, _) => stderr.into_owned(),
+            (_, true) => stdout.into_owned(),
+        };
+
+        Ok(ToolResult {
+            content: vec![ContentBlock::Text(content)],
+            is_error,
+        })
+    }
+}
+
+#[cfg(test)]
+mod bash_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_tool(
+        confirmation: ConfirmationMode,
+        sandbox_root: std::path::PathBuf,
+        confirm_fn: Box<dyn Fn(&str) -> bool + Send + Sync>,
+    ) -> BashTool {
+        BashTool::new(
+            vec!["echo", "ls", "cat"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            vec!["rm", "sudo"].into_iter().map(String::from).collect(),
+            sandbox_root,
+            confirmation,
+            confirm_fn,
+        )
+    }
+
+    #[test]
+    fn allowlisted_command_executes_without_confirmation() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Always,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| panic!("confirm_fn must not be called for allowlisted commands")),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo hello"}))
+            .expect("should succeed");
+        assert!(!result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => assert!(text.contains("hello")),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn denylisted_command_is_rejected() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "rm -rf /"}))
+            .expect("execute must not err");
+        assert!(result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => assert!(text.contains("rm")),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn unlisted_command_with_never_policy_executes() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| panic!("confirm_fn must not be called with Never policy")),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "pwd"}))
+            .expect("should succeed");
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn unlisted_command_with_always_policy_and_approved_executes() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Always,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "pwd"}))
+            .expect("should succeed");
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn unlisted_command_with_always_policy_and_denied_returns_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Always,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| false),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "pwd"}))
+            .expect("execute must not err");
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn unlisted_command_with_write_only_policy_and_denied_returns_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::WriteOnly,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| false),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "pwd"}))
+            .expect("execute must not err");
+        assert!(result.is_error);
+    }
+
+    #[test]
+    fn piped_command_with_denylisted_segment_is_rejected() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "cat file.txt | rm -rf /"}))
+            .expect("execute must not err");
+        assert!(result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => assert!(text.contains("rm")),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn piped_command_with_all_allowlisted_segments_executes_without_confirmation() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        // confirm_fn panics to prove it is not called
+        let tool = make_tool(
+            ConfirmationMode::Always,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| panic!("confirm_fn must not be called when all segments allowlisted")),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo hello | cat"}))
+            .expect("should succeed");
+        assert!(!result.is_error);
+    }
+
+    #[test]
+    fn command_runs_with_sandbox_root_as_cwd() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let sandbox = temp_dir.path().canonicalize().expect("canonicalize");
+        let tool = make_tool(ConfirmationMode::Never, sandbox.clone(), Box::new(|_| true));
+        let result = tool
+            .execute(serde_json::json!({"command": "pwd"}))
+            .expect("should succeed");
+        assert!(!result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => {
+                assert_eq!(
+                    text.trim(),
+                    sandbox.to_string_lossy(),
+                    "cwd should be sandbox root"
+                );
+            }
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn command_failure_returns_is_error_true_with_stderr() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo 'err msg' >&2; exit 1"}))
+            .expect("execute must not err");
+        assert!(result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => assert!(text.contains("err msg")),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn missing_command_field_returns_invalid_input_error() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool.execute(serde_json::json!({"not_command": "echo hello"}));
+        assert!(matches!(result, Err(ToolError::InvalidInput { .. })));
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -4,7 +4,7 @@ use crate::config::ConfirmationMode;
 use crate::types::ContentBlock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// Error type for tool operations
@@ -588,9 +588,22 @@ mod sandbox_tests {
     }
 }
 
+/// Executes shell commands in the sandbox directory.
+///
+/// # Confirmation behavior
+/// - Allowlisted commands execute without confirmation regardless of `ConfirmationMode`.
+/// - Denylisted commands are always rejected.
+/// - All other commands follow `ConfirmationMode`. Because bash commands cannot be reliably
+///   classified as read-only or write operations, `WriteOnly` is treated identically to `Always`.
+///
+/// # Denylist limitations
+/// Segment detection splits on common shell operators (`|`, `&`, `;`, newline, `(`, backtick)
+/// to catch obvious bypass patterns. It is best-effort: complex quoting, heredocs, variable
+/// indirection, and other shell features can still evade detection. Confirmation policy is
+/// the primary security gate; the denylist is a convenience filter.
 pub struct BashTool {
-    allowlist: Vec<String>,
-    denylist: Vec<String>,
+    allowlist: HashSet<String>,
+    denylist: HashSet<String>,
     sandbox_root: PathBuf,
     confirmation: ConfirmationMode,
     confirm_fn: Box<dyn Fn(&str) -> bool + Send + Sync>,
@@ -616,8 +629,8 @@ impl BashTool {
             "required": ["command"]
         });
         Self {
-            allowlist,
-            denylist,
+            allowlist: allowlist.into_iter().collect(),
+            denylist: denylist.into_iter().collect(),
             sandbox_root,
             confirmation,
             confirm_fn,
@@ -625,9 +638,13 @@ impl BashTool {
         }
     }
 
-    fn first_tokens_of_pipe_segments(command: &str) -> Vec<&str> {
+    /// Extracts the first token (command name) from each shell segment.
+    ///
+    /// Splits on `|`, `&`, `;`, newline, `(`, and backtick to catch common shell operator
+    /// bypass patterns. Best-effort only — see struct-level docs.
+    fn shell_command_tokens(command: &str) -> Vec<&str> {
         command
-            .split('|')
+            .split(['|', '&', ';', '\n', '(', '`'])
             .filter_map(|segment| segment.split_whitespace().next())
             .collect()
     }
@@ -654,10 +671,10 @@ impl Tool for BashTool {
                 message: "missing required field 'command'".to_string(),
             })?;
 
-        let tokens = Self::first_tokens_of_pipe_segments(command);
+        let tokens = Self::shell_command_tokens(command);
 
         for token in &tokens {
-            if self.denylist.iter().any(|d| d == token) {
+            if self.denylist.contains(*token) {
                 return Ok(ToolResult {
                     content: vec![ContentBlock::Text(format!(
                         "Command rejected: '{}' is not allowed",
@@ -668,9 +685,7 @@ impl Tool for BashTool {
             }
         }
 
-        let all_allowlisted = tokens
-            .iter()
-            .all(|token| self.allowlist.iter().any(|a| a == token));
+        let all_allowlisted = tokens.iter().all(|token| self.allowlist.contains(*token));
 
         if !all_allowlisted {
             let needs_confirmation = matches!(
@@ -704,8 +719,9 @@ impl Tool for BashTool {
 
         let content = match (stdout.is_empty(), stderr.is_empty()) {
             (false, false) => format!("{}\n{}", stdout, stderr),
-            (true, _) => stderr.into_owned(),
-            (_, true) => stdout.into_owned(),
+            (true, false) => stderr.into_owned(),
+            (false, true) => stdout.into_owned(),
+            (true, true) => "(no output)".to_string(),
         };
 
         Ok(ToolResult {
@@ -911,5 +927,111 @@ mod bash_tests {
         );
         let result = tool.execute(serde_json::json!({"not_command": "echo hello"}));
         assert!(matches!(result, Err(ToolError::InvalidInput { .. })));
+    }
+
+    #[test]
+    fn and_operator_denylist_bypass_is_blocked() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo hello && rm -rf /"}))
+            .expect("execute must not err");
+        assert!(
+            result.is_error,
+            "&&-separated denylist command must be blocked"
+        );
+    }
+
+    #[test]
+    fn semicolon_denylist_bypass_is_blocked() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo hello; rm -rf /"}))
+            .expect("execute must not err");
+        assert!(
+            result.is_error,
+            "semicolon-separated denylist command must be blocked"
+        );
+    }
+
+    #[test]
+    fn newline_denylist_bypass_is_blocked() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo hello\nrm -rf /"}))
+            .expect("execute must not err");
+        assert!(
+            result.is_error,
+            "newline-separated denylist command must be blocked"
+        );
+    }
+
+    #[test]
+    fn subshell_denylist_bypass_is_blocked() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo $(rm -rf /)"}))
+            .expect("execute must not err");
+        assert!(
+            result.is_error,
+            "$() subshell denylist command must be blocked"
+        );
+    }
+
+    #[test]
+    fn backtick_denylist_bypass_is_blocked() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "echo `rm -rf /`"}))
+            .expect("execute must not err");
+        assert!(
+            result.is_error,
+            "backtick subshell denylist command must be blocked"
+        );
+    }
+
+    #[test]
+    fn silent_command_produces_no_output_sentinel() {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let tool = make_tool(
+            ConfirmationMode::Never,
+            temp_dir.path().to_path_buf(),
+            Box::new(|_| true),
+        );
+        let result = tool
+            .execute(serde_json::json!({"command": "true"}))
+            .expect("should succeed");
+        assert!(!result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => assert!(
+                !text.is_empty(),
+                "silent command should produce sentinel, not empty string"
+            ),
+            _ => panic!("expected Text"),
+        }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -628,7 +628,7 @@ impl BashTool {
     fn first_tokens_of_pipe_segments(command: &str) -> Vec<&str> {
         command
             .split('|')
-            .filter_map(|segment| segment.trim().split_whitespace().next())
+            .filter_map(|segment| segment.split_whitespace().next())
             .collect()
     }
 }


### PR DESCRIPTION
## Summary

- Adds `BashTool` struct implementing the `Tool` trait in `src/tools.rs`
- Commands are classified per pipe segment (first token of each `|`-separated segment): allowlisted → auto-execute, denylisted → reject, unlisted → follow `ConfirmationMode`
- Executes via `sh -c <command>` with `current_dir` set to `sandbox_root`
- Returns stdout/stderr combined as `ToolResult`; failed commands set `is_error = true`
- Confirmation callback injected via `Box<dyn Fn(&str) -> bool + Send + Sync>` for testability

## Test plan

- [x] Allowlisted command executes without calling confirm_fn (even under `Always` policy)
- [x] Denylisted command is rejected with `is_error = true`
- [x] Unlisted command with `Never` policy executes without confirmation
- [x] Unlisted command with `Always` policy and approved confirm_fn executes
- [x] Unlisted command with `Always` policy and denied confirm_fn returns error
- [x] Unlisted command with `WriteOnly` policy and denied confirm_fn returns error
- [x] Piped command with any denylisted segment is rejected
- [x] Piped command with all allowlisted segments skips confirmation
- [x] Command runs with sandbox root as cwd
- [x] Failing command returns `is_error = true` with stderr content
- [x] Missing `command` field returns `InvalidInput` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)