### PR TITLE
Add skill tool (#61)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -78,7 +78,7 @@ impl Agent {
             String::from("The following skills are available via the `skill` tool:\n\n");
         for name in names {
             let path = &skills[name];
-            let desc = crate::tools::skill::first_line(path)
+            let desc = crate::tools::skill::skill_description(path)
                 .unwrap_or_else(|| "(no description)".to_string());
             content.push_str(&format!("- {}: {}\n", name, desc));
         }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -64,6 +64,8 @@ impl Agent {
         Ok(self)
     }
 
+    // TODO: synthetic User messages are a design smell; use Role::System or a metadata
+    // mechanism if one is added in future.
     pub fn load_skills(&self, skills: &std::collections::HashMap<String, std::path::PathBuf>) {
         if skills.is_empty() {
             return;
@@ -75,7 +77,10 @@ impl Agent {
         let mut content =
             String::from("The following skills are available via the `skill` tool:\n\n");
         for name in names {
-            content.push_str(&format!("- {}\n", name));
+            let path = &skills[name];
+            let desc = crate::tools::skill::first_line(path)
+                .unwrap_or_else(|| "(no description)".to_string());
+            content.push_str(&format!("- {}: {}\n", name, desc));
         }
 
         lock(&self.history).push(Message::text(Role::User, content));

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -64,6 +64,23 @@ impl Agent {
         Ok(self)
     }
 
+    pub fn load_skills(&self, skills: &std::collections::HashMap<String, std::path::PathBuf>) {
+        if skills.is_empty() {
+            return;
+        }
+
+        let mut names: Vec<&str> = skills.keys().map(String::as_str).collect();
+        names.sort();
+
+        let mut content =
+            String::from("The following skills are available via the `skill` tool:\n\n");
+        for name in names {
+            content.push_str(&format!("- {}\n", name));
+        }
+
+        lock(&self.history).push(Message::text(Role::User, content));
+    }
+
     pub fn history(&self) -> Vec<Message> {
         lock(&self.history).clone()
     }
@@ -878,6 +895,60 @@ mod tests {
                 AgentEvent::ToolResult { is_error, .. } if !is_error
             )),
             "tool should execute after approval"
+        );
+    }
+
+    #[test]
+    fn load_skills_adds_skill_names_to_history() {
+        let backend = SequencedBackend::new(vec![]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(backend), config);
+
+        let mut skills = std::collections::HashMap::new();
+        skills.insert(
+            "my-skill".to_string(),
+            std::path::PathBuf::from("/fake/path"),
+        );
+        skills.insert(
+            "another-skill".to_string(),
+            std::path::PathBuf::from("/fake/path2"),
+        );
+        agent.load_skills(&skills);
+
+        let history = agent.history();
+        assert_eq!(history.len(), 1);
+        match &history[0].content[0] {
+            ContentBlock::Text(text) => {
+                assert!(
+                    text.contains("another-skill"),
+                    "should mention another-skill"
+                );
+                assert!(text.contains("my-skill"), "should mention my-skill");
+                assert!(text.contains("skill"), "should mention skill tool");
+            }
+            _ => panic!("expected Text content"),
+        }
+    }
+
+    #[test]
+    fn load_skills_with_empty_map_adds_nothing_to_history() {
+        let backend = SequencedBackend::new(vec![]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(backend), config);
+
+        agent.load_skills(&std::collections::HashMap::new());
+
+        assert!(
+            agent.history().is_empty(),
+            "empty skills map should not add history entry"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
     registry.register(Box::new(WriteFileTool::new(sandbox_policy)))?;
 
     let skills = discover_skills_from_env();
-    registry.register(Box::new(SkillTool::new(skills.clone())))?;
+    registry.register(Box::new(SkillTool::new(&skills)))?;
 
     let request_config = RequestConfig {
         model: selection.model,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use tools::ToolRegistry;
 use tools::bash::BashTool;
 use tools::edit_file::EditFile;
 use tools::sandbox::SandboxPolicy;
+use tools::skill::{SkillTool, discover_skills_from_env};
 use tools::write_file::WriteFileTool;
 use types::{ConfirmationResponse, RequestConfig};
 
@@ -102,6 +103,9 @@ async fn main() -> Result<()> {
     registry.register(Box::new(EditFile::new(sandbox_policy.clone())))?;
     registry.register(Box::new(WriteFileTool::new(sandbox_policy)))?;
 
+    let skills = discover_skills_from_env();
+    registry.register(Box::new(SkillTool::new(skills.clone())))?;
+
     let request_config = RequestConfig {
         model: selection.model,
         max_tokens: DEFAULT_MAX_TOKENS,
@@ -114,6 +118,7 @@ async fn main() -> Result<()> {
             .with_tool_config(&app_config.tools)
             .with_context_files()?,
     );
+    agent.load_skills(&skills);
 
     let mut logger = if cli.debug {
         let log_path = create_log_path()?;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@
 pub mod bash;
 pub mod edit_file;
 pub mod sandbox;
+pub mod skill;
 pub mod write_file;
 
 use crate::types::ContentBlock;

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -9,8 +9,10 @@ pub struct SkillTool {
 }
 
 impl SkillTool {
-    pub fn new(skills: HashMap<String, PathBuf>) -> Self {
-        Self { skills }
+    pub fn new(skills: &HashMap<String, PathBuf>) -> Self {
+        Self {
+            skills: skills.clone(),
+        }
     }
 }
 
@@ -66,36 +68,47 @@ impl Tool for SkillTool {
     }
 }
 
-pub fn discover_skills(pwd: &Path, home: &Path) -> HashMap<String, PathBuf> {
-    let mut skills = HashMap::new();
-
-    let skill_dirs = [home.join(".claude/skills"), pwd.join(".claude/skills")];
-
-    for dir in &skill_dirs {
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    let skill_file = path.join("SKILL.md");
-                    if skill_file.exists()
-                        && let Some(name) = path.file_name().and_then(|n| n.to_str())
-                    {
-                        skills.insert(name.to_string(), skill_file);
-                    }
+fn scan_skills_dir(dir: &Path, skills: &mut HashMap<String, PathBuf>) {
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let skill_file = path.join("SKILL.md");
+                if skill_file.exists()
+                    && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                {
+                    skills.insert(name.to_string(), skill_file);
                 }
             }
         }
     }
+}
 
+// home is scanned first so that pwd entries override home entries with the same name.
+pub fn discover_skills(pwd: &Path, home: &Path) -> HashMap<String, PathBuf> {
+    let mut skills = HashMap::new();
+    scan_skills_dir(&home.join(".claude/skills"), &mut skills);
+    scan_skills_dir(&pwd.join(".claude/skills"), &mut skills);
     skills
 }
 
 pub fn discover_skills_from_env() -> HashMap<String, PathBuf> {
-    let pwd = std::env::current_dir().unwrap_or_default();
-    match dirs::home_dir() {
-        Some(home) => discover_skills(&pwd, &home),
-        None => discover_skills(&pwd, Path::new("")),
+    let mut skills = HashMap::new();
+    if let Some(home) = dirs::home_dir() {
+        scan_skills_dir(&home.join(".claude/skills"), &mut skills);
     }
+    if let Ok(pwd) = std::env::current_dir() {
+        scan_skills_dir(&pwd.join(".claude/skills"), &mut skills);
+    }
+    skills
+}
+
+pub fn first_line(path: &Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .lines()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim_start_matches('#').trim().to_string())
 }
 
 #[cfg(test)]
@@ -190,6 +203,30 @@ mod tests {
     }
 
     #[test]
+    fn discover_skills_skips_dirs_with_non_utf8_names() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+
+        let skills_dir = home.path().join(".claude/skills");
+        fs::create_dir_all(&skills_dir).expect("create skills dir");
+
+        let bad_name = OsStr::from_bytes(b"bad-\xff-skill");
+        let bad_dir = skills_dir.join(bad_name);
+        fs::create_dir_all(&bad_dir).expect("create non-utf8 dir");
+        fs::write(bad_dir.join("SKILL.md"), "content").expect("write SKILL.md");
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert!(
+            skills.is_empty(),
+            "non-UTF8 skill dir names are silently skipped"
+        );
+    }
+
+    #[test]
     fn skill_tool_execute_returns_file_content() {
         let dir = TempDir::new().unwrap();
         let skill_file = dir.path().join("my-skill.md");
@@ -197,7 +234,7 @@ mod tests {
 
         let mut skills = HashMap::new();
         skills.insert("my-skill".to_string(), skill_file);
-        let tool = SkillTool::new(skills);
+        let tool = SkillTool::new(&skills);
 
         let result = tool
             .execute(serde_json::json!({"name": "my-skill"}))
@@ -214,7 +251,7 @@ mod tests {
 
     #[test]
     fn skill_tool_execute_unknown_name_returns_error() {
-        let tool = SkillTool::new(HashMap::new());
+        let tool = SkillTool::new(&HashMap::new());
 
         let result = tool.execute(serde_json::json!({"name": "nonexistent"}));
 
@@ -232,7 +269,7 @@ mod tests {
 
     #[test]
     fn skill_tool_execute_missing_name_field_returns_invalid_input() {
-        let tool = SkillTool::new(HashMap::new());
+        let tool = SkillTool::new(&HashMap::new());
 
         let result = tool.execute(serde_json::json!({}));
 
@@ -241,7 +278,34 @@ mod tests {
 
     #[test]
     fn skill_tool_is_not_a_write_tool() {
-        let tool = SkillTool::new(HashMap::new());
+        let tool = SkillTool::new(&HashMap::new());
         assert!(!tool.is_write_tool());
+    }
+
+    #[test]
+    fn first_line_strips_markdown_heading_marker() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("skill.md");
+        fs::write(&path, "# My Skill Title\nsome body text").unwrap();
+
+        assert_eq!(first_line(&path).unwrap(), "My Skill Title");
+    }
+
+    #[test]
+    fn first_line_skips_leading_blank_lines() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("skill.md");
+        fs::write(&path, "\n\n# Title").unwrap();
+
+        assert_eq!(first_line(&path).unwrap(), "Title");
+    }
+
+    #[test]
+    fn first_line_returns_none_for_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("skill.md");
+        fs::write(&path, "").unwrap();
+
+        assert!(first_line(&path).is_none());
     }
 }

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -103,12 +103,33 @@ pub fn discover_skills_from_env() -> HashMap<String, PathBuf> {
     skills
 }
 
-pub fn first_line(path: &Path) -> Option<String> {
-    std::fs::read_to_string(path)
-        .ok()?
-        .lines()
-        .find(|l| !l.trim().is_empty())
-        .map(|l| l.trim_start_matches('#').trim().to_string())
+/// Extracts the `description` field from YAML frontmatter at the top of a skill file.
+///
+/// Expects frontmatter delimited by `---` lines, e.g.:
+/// ```markdown
+/// ---
+/// name: my-skill
+/// description: what this skill does
+/// ---
+/// ```
+pub fn skill_description(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut lines = content.lines();
+
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+
+    for line in lines {
+        if line.trim() == "---" {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix("description:") {
+            return Some(rest.trim().to_string());
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -283,29 +304,38 @@ mod tests {
     }
 
     #[test]
-    fn first_line_strips_markdown_heading_marker() {
+    fn skill_description_extracts_description_from_frontmatter() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("skill.md");
-        fs::write(&path, "# My Skill Title\nsome body text").unwrap();
+        fs::write(
+            &path,
+            "---\nname: my-skill\ndescription: does the thing\n---\n\n# Body",
+        )
+        .unwrap();
 
-        assert_eq!(first_line(&path).unwrap(), "My Skill Title");
+        assert_eq!(skill_description(&path).unwrap(), "does the thing");
     }
 
     #[test]
-    fn first_line_skips_leading_blank_lines() {
+    fn skill_description_returns_none_when_no_frontmatter() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("skill.md");
-        fs::write(&path, "\n\n# Title").unwrap();
+        fs::write(&path, "# My Skill\nNo frontmatter here").unwrap();
 
-        assert_eq!(first_line(&path).unwrap(), "Title");
+        assert!(skill_description(&path).is_none());
     }
 
     #[test]
-    fn first_line_returns_none_for_empty_file() {
+    fn skill_description_returns_none_when_description_field_missing() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("skill.md");
-        fs::write(&path, "").unwrap();
+        fs::write(&path, "---\nname: my-skill\n---\n\n# Body").unwrap();
 
-        assert!(first_line(&path).is_none());
+        assert!(skill_description(&path).is_none());
+    }
+
+    #[test]
+    fn skill_description_returns_none_for_missing_file() {
+        assert!(skill_description(Path::new("/nonexistent/path.md")).is_none());
     }
 }

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -1,0 +1,247 @@
+use crate::tools::{Tool, ToolError, ToolResult};
+use crate::types::ContentBlock;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+pub struct SkillTool {
+    skills: HashMap<String, PathBuf>,
+}
+
+impl SkillTool {
+    pub fn new(skills: HashMap<String, PathBuf>) -> Self {
+        Self { skills }
+    }
+}
+
+impl Tool for SkillTool {
+    fn name(&self) -> &str {
+        "skill"
+    }
+
+    fn description(&self) -> &str {
+        "Load a skill by name and return its prompt content"
+    }
+
+    fn input_schema(&self) -> &Value {
+        use std::sync::LazyLock;
+        static SCHEMA: LazyLock<Value> = LazyLock::new(|| {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the skill to load"
+                    }
+                },
+                "required": ["name"]
+            })
+        });
+        &SCHEMA
+    }
+
+    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let name =
+            input
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolError::InvalidInput {
+                    message: "Missing 'name' field".to_string(),
+                })?;
+
+        let path = self.skills.get(name).ok_or_else(|| ToolError::Execution {
+            tool_name: "skill".to_string(),
+            message: format!("Skill '{}' not found", name),
+        })?;
+
+        let content = std::fs::read_to_string(path).map_err(|e| ToolError::Execution {
+            tool_name: "skill".to_string(),
+            message: format!("Failed to read skill file: {}", e),
+        })?;
+
+        Ok(ToolResult {
+            content: vec![ContentBlock::Text(content)],
+            is_error: false,
+        })
+    }
+}
+
+pub fn discover_skills(pwd: &Path, home: &Path) -> HashMap<String, PathBuf> {
+    let mut skills = HashMap::new();
+
+    let skill_dirs = [home.join(".claude/skills"), pwd.join(".claude/skills")];
+
+    for dir in &skill_dirs {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    let skill_file = path.join("SKILL.md");
+                    if skill_file.exists() {
+                        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                            skills.insert(name.to_string(), skill_file);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    skills
+}
+
+pub fn discover_skills_from_env() -> HashMap<String, PathBuf> {
+    let pwd = std::env::current_dir().unwrap_or_default();
+    match dirs::home_dir() {
+        Some(home) => discover_skills(&pwd, &home),
+        None => discover_skills(&pwd, Path::new("")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn make_skill(base: &Path, name: &str, content: &str) {
+        let skill_dir = base.join(".claude/skills").join(name);
+        fs::create_dir_all(&skill_dir).expect("create skill dir");
+        let mut f = File::create(skill_dir.join("SKILL.md")).expect("create SKILL.md");
+        f.write_all(content.as_bytes()).expect("write SKILL.md");
+    }
+
+    #[test]
+    fn discover_skills_finds_skills_in_home() {
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        make_skill(home.path(), "my-skill", "# My Skill\nContent here");
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert!(skills.contains_key("my-skill"), "should find home skill");
+    }
+
+    #[test]
+    fn discover_skills_finds_skills_in_pwd() {
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        make_skill(pwd.path(), "local-skill", "# Local Skill");
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert!(skills.contains_key("local-skill"), "should find pwd skill");
+    }
+
+    #[test]
+    fn discover_skills_finds_skills_from_both_locations() {
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        make_skill(home.path(), "home-skill", "# Home Skill");
+        make_skill(pwd.path(), "pwd-skill", "# Pwd Skill");
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert!(skills.contains_key("home-skill"));
+        assert!(skills.contains_key("pwd-skill"));
+    }
+
+    #[test]
+    fn discover_skills_ignores_dirs_without_skill_md() {
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        let empty_dir = home.path().join(".claude/skills/empty-skill");
+        fs::create_dir_all(&empty_dir).expect("create dir");
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert!(
+            !skills.contains_key("empty-skill"),
+            "should not include skill without SKILL.md"
+        );
+    }
+
+    #[test]
+    fn discover_skills_returns_empty_when_no_skill_dirs_exist() {
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn pwd_skill_overrides_home_skill_with_same_name() {
+        let pwd = TempDir::new().unwrap();
+        let home = TempDir::new().unwrap();
+        make_skill(home.path(), "shared-skill", "# Home version");
+        make_skill(pwd.path(), "shared-skill", "# Pwd version");
+
+        let skills = discover_skills(pwd.path(), home.path());
+
+        assert_eq!(skills.len(), 1, "should have one entry for the skill");
+        let content = fs::read_to_string(&skills["shared-skill"]).unwrap();
+        assert_eq!(
+            content, "# Pwd version",
+            "pwd skill should override home skill"
+        );
+    }
+
+    #[test]
+    fn skill_tool_execute_returns_file_content() {
+        let dir = TempDir::new().unwrap();
+        let skill_file = dir.path().join("my-skill.md");
+        fs::write(&skill_file, "# Skill Content\nThis is the skill prompt").unwrap();
+
+        let mut skills = HashMap::new();
+        skills.insert("my-skill".to_string(), skill_file);
+        let tool = SkillTool::new(skills);
+
+        let result = tool
+            .execute(serde_json::json!({"name": "my-skill"}))
+            .expect("should succeed");
+
+        assert!(!result.is_error);
+        match &result.content[0] {
+            ContentBlock::Text(text) => {
+                assert_eq!(text, "# Skill Content\nThis is the skill prompt")
+            }
+            _ => panic!("expected Text content"),
+        }
+    }
+
+    #[test]
+    fn skill_tool_execute_unknown_name_returns_error() {
+        let tool = SkillTool::new(HashMap::new());
+
+        let result = tool.execute(serde_json::json!({"name": "nonexistent"}));
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            ToolError::Execution { message, .. } => {
+                assert!(
+                    message.contains("nonexistent"),
+                    "error should name the skill"
+                );
+            }
+            other => panic!("expected Execution error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn skill_tool_execute_missing_name_field_returns_invalid_input() {
+        let tool = SkillTool::new(HashMap::new());
+
+        let result = tool.execute(serde_json::json!({}));
+
+        assert!(matches!(result, Err(ToolError::InvalidInput { .. })));
+    }
+
+    #[test]
+    fn skill_tool_is_not_a_write_tool() {
+        let tool = SkillTool::new(HashMap::new());
+        assert!(!tool.is_write_tool());
+    }
+}

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -77,10 +77,10 @@ pub fn discover_skills(pwd: &Path, home: &Path) -> HashMap<String, PathBuf> {
                 let path = entry.path();
                 if path.is_dir() {
                     let skill_file = path.join("SKILL.md");
-                    if skill_file.exists() {
-                        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                            skills.insert(name.to_string(), skill_file);
-                        }
+                    if skill_file.exists()
+                        && let Some(name) = path.file_name().and_then(|n| n.to_str())
+                    {
+                        skills.insert(name.to_string(), skill_file);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- New `src/tools/skill.rs` with `SkillTool` and `discover_skills` that scan `$PWD/.claude/skills` and `$HOME/.claude/skills` for subdirectories containing `SKILL.md`
- `SkillTool` reads the mapped file by name and returns its content to the agent context
- `Agent::load_skills` injects available skill names into initial context as a user message
- Skill tool registered in `main.rs`; PWD skills override HOME skills with the same name

## Test plan

- [ ] `cargo test` — unit tests in `skill.rs` cover discovery, override, missing name, execute success/failure
- [ ] Agent `load_skills` tests verify history is populated with skill names
- [ ] `cargo clippy` and `cargo fmt` pass

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)