### PR TITLE
fix: remove underline from input area text

### DIFF
--- a/src/frontend/tui/input_area.rs
+++ b/src/frontend/tui/input_area.rs
@@ -1,4 +1,5 @@
 use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders};
 use ratatui_textarea::{TextArea, WrapMode};
 
@@ -30,6 +31,9 @@ impl<'a> InputArea<'a> {
             mode: InputMode::Input,
         };
         input.textarea.set_wrap_mode(WrapMode::WordOrGlyph);
+        input
+            .textarea
+            .set_cursor_line_style(Style::default().add_modifier(Modifier::empty()));
         input.apply_block();
         input
     }
@@ -58,6 +62,8 @@ impl<'a> InputArea<'a> {
         };
         self.textarea = TextArea::new(lines);
         self.textarea.set_wrap_mode(WrapMode::WordOrGlyph);
+        self.textarea
+            .set_cursor_line_style(Style::default().add_modifier(Modifier::empty()));
         self.apply_block();
     }
 


### PR DESCRIPTION
## Summary

Removes the default underline styling from the cursor line in the input area `TextArea` widget.

## Problem

The `ratatui-textarea` crate applies `Modifier::UNDERLINED` to the cursor line by default. This makes characters like `_` difficult to distinguish from the underline itself.

## Fix

Explicitly set the cursor line style to `Style::default().add_modifier(Modifier::empty())` in both places where `TextArea` instances are constructed:
- `InputArea::new()`
- `InputArea::set_text()`

Closes #66