### PR TITLE
fix: accurate scroll line counting prevents conversation desync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ dirs = "6.0.0"
 futures = "0.3.32"
 gcp_auth = "0.12.6"
 pin-project-lite = "0.2.17"
-ratatui = "0.30.0"
+ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 ratatui-textarea = "0.9.0"
 reqwest = { version = "0.13.2", features = ["json", "stream"] }
 rustls = "0.23.37"

--- a/src/frontend/tui/conversation_area.rs
+++ b/src/frontend/tui/conversation_area.rs
@@ -45,99 +45,177 @@ pub struct ConversationEntry {
     pub content: String,
 }
 
+/// Caches the rendered lines and accurate wrapped line count for finalized
+/// conversation entries.
+///
+/// `Paragraph::line_count()` uses ratatui's internal `WordWrapper` to get the
+/// exact number of visual lines after wrapping, but it is expensive to call.
+/// Markdown parsing via `entry_lines()` is also expensive for large
+/// conversations. This cache is only invalidated when entries are added or the
+/// text width changes — never on every render or every streaming token.
+pub struct LineCountCache {
+    entry_count: usize,
+    text_width: u16,
+    cached_total: u16,
+    cached_lines: Vec<Line<'static>>,
+}
+
+impl Default for LineCountCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LineCountCache {
+    pub fn new() -> Self {
+        Self {
+            entry_count: 0,
+            text_width: 0,
+            cached_total: 0,
+            cached_lines: Vec::new(),
+        }
+    }
+
+    pub fn get(&mut self, entries: &[ConversationEntry], text_width: u16) -> u16 {
+        if entries.len() != self.entry_count {
+            self.rebuild_lines(entries);
+        }
+        if text_width != self.text_width {
+            self.recount(text_width);
+        }
+        self.cached_total
+    }
+
+    pub fn lines(&self) -> &[Line<'static>] {
+        &self.cached_lines
+    }
+
+    fn rebuild_lines(&mut self, entries: &[ConversationEntry]) {
+        self.cached_lines = entry_lines_owned(entries);
+        self.entry_count = entries.len();
+        self.text_width = u16::MAX;
+        self.cached_total = 0;
+    }
+
+    fn recount(&mut self, text_width: u16) {
+        self.cached_total = paragraph_line_count(&self.cached_lines, text_width);
+        self.text_width = text_width;
+    }
+}
+
+fn paragraph_line_count(lines: &[Line<'_>], text_width: u16) -> u16 {
+    if text_width == 0 {
+        return lines.len() as u16;
+    }
+    let paragraph = Paragraph::new(lines.to_vec()).wrap(Wrap { trim: false });
+    paragraph.line_count(text_width) as u16
+}
+
+fn estimate_line_count(lines: &[Line<'_>], text_width: u16) -> u16 {
+    if text_width == 0 {
+        return lines.len() as u16;
+    }
+    lines
+        .iter()
+        .map(|line| {
+            let w = line.width() as u16;
+            if w == 0 { 1u16 } else { w.div_ceil(text_width) }
+        })
+        .sum()
+}
+
+fn entry_lines_owned(entries: &[ConversationEntry]) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    for entry in entries {
+        lines.push(Line::from(Span::styled(
+            format!("{}:", entry.role.display_label()),
+            Style::default().fg(entry.role.color()),
+        )));
+        let display_content = maybe_truncate(&entry.content, &entry.role);
+        let rendered = markdown_to_text(&display_content);
+        for line in rendered.lines {
+            let mut prefixed = Line::from(Span::raw("  "));
+            prefixed.spans.extend(
+                line.spans
+                    .into_iter()
+                    .map(|span| Span::styled(span.content.into_owned(), span.style)),
+            );
+            lines.push(prefixed);
+        }
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
+fn current_response_lines<'a>(current_response: &'a str) -> Vec<Line<'a>> {
+    let mut lines = Vec::new();
+    if !current_response.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "Assistant:",
+            Style::default().fg(Color::Blue),
+        )));
+        let rendered = markdown_to_text(current_response);
+        for line in rendered.lines {
+            let mut prefixed = Line::from(Span::raw("  "));
+            prefixed.spans.extend(line.spans);
+            lines.push(prefixed);
+        }
+    }
+    lines
+}
+
 pub struct ConversationArea<'a> {
-    entries: &'a [ConversationEntry],
+    cached_entry_lines: &'a [Line<'static>],
     current_response: &'a str,
     scroll_offset: u16,
     viewport_height: u16,
+    cached_entry_line_count: u16,
 }
 
 impl<'a> ConversationArea<'a> {
     pub fn new(
-        entries: &'a [ConversationEntry],
+        cached_entry_lines: &'a [Line<'static>],
         current_response: &'a str,
         scroll_offset: u16,
         viewport_height: u16,
+        cached_entry_line_count: u16,
     ) -> Self {
         Self {
-            entries,
+            cached_entry_lines,
             current_response,
             scroll_offset,
             viewport_height,
+            cached_entry_line_count,
         }
     }
 
     pub fn lines(&self) -> Vec<Line<'_>> {
-        let mut lines = Vec::new();
-        for entry in self.entries {
-            lines.push(Line::from(Span::styled(
-                format!("{}:", entry.role.display_label()),
-                Style::default().fg(entry.role.color()),
-            )));
-            let display_content = maybe_truncate(&entry.content, &entry.role);
-            let rendered = markdown_to_text(&display_content);
-            for line in rendered.lines {
-                let mut prefixed = Line::from(Span::raw("  "));
-                prefixed.spans.extend(
-                    line.spans
-                        .into_iter()
-                        .map(|span| Span::styled(span.content.into_owned(), span.style)),
-                );
-                lines.push(prefixed);
-            }
-            lines.push(Line::from(""));
-        }
-
-        if !self.current_response.is_empty() {
-            lines.push(Line::from(Span::styled(
-                "Assistant:",
-                Style::default().fg(Color::Blue),
-            )));
-            let rendered = markdown_to_text(self.current_response);
-            for line in rendered.lines {
-                let mut prefixed = Line::from(Span::raw("  "));
-                prefixed.spans.extend(line.spans);
-                lines.push(prefixed);
-            }
-        }
-
+        let mut lines: Vec<Line<'_>> = self.cached_entry_lines.to_vec();
+        lines.extend(current_response_lines(self.current_response));
         lines
     }
 
+    fn total_visual_lines(&self, text_width: u16) -> u16 {
+        let response_lines = current_response_lines(self.current_response);
+        let response_count = estimate_line_count(&response_lines, text_width);
+        self.cached_entry_line_count.saturating_add(response_count)
+    }
+
     pub fn max_scroll(&self, text_width: u16) -> u16 {
-        let conv_lines = self.lines();
-        let total_visual: u16 = conv_lines
-            .iter()
-            .map(|line| {
-                if text_width == 0 {
-                    1u16
-                } else {
-                    let w = line.width() as u16;
-                    if w == 0 { 1u16 } else { w.div_ceil(text_width) }
-                }
-            })
-            .sum();
+        let total_visual = self.total_visual_lines(text_width);
         total_visual.saturating_sub(self.viewport_height)
     }
 
     pub fn render(&self, frame: &mut ratatui::Frame, area: Rect, text_width: u16) {
-        let conv_lines = self.lines();
         let visible_height = area.height.saturating_sub(2);
-        let total_visual: u16 = conv_lines
-            .iter()
-            .map(|line| {
-                if text_width == 0 {
-                    1u16
-                } else {
-                    let w = line.width() as u16;
-                    if w == 0 { 1u16 } else { w.div_ceil(text_width) }
-                }
-            })
-            .sum();
+        let total_visual = self.total_visual_lines(text_width);
         let auto_scroll = total_visual.saturating_sub(visible_height);
         let scroll_row = auto_scroll.saturating_sub(self.scroll_offset.min(auto_scroll));
 
-        let conversation = Paragraph::new(conv_lines)
+        let mut all_lines: Vec<Line<'_>> = self.cached_entry_lines.to_vec();
+        all_lines.extend(current_response_lines(self.current_response));
+
+        let conversation = Paragraph::new(all_lines)
             .block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -174,6 +252,12 @@ pub fn tool_use_display_content(name: &str, input: &serde_json::Value) -> String
 mod tests {
     use super::*;
 
+    fn cached_lines(entries: &[ConversationEntry], text_width: u16) -> (u16, Vec<Line<'static>>) {
+        let mut cache = LineCountCache::new();
+        let count = cache.get(entries, text_width);
+        (count, cache.lines().to_vec())
+    }
+
     #[test]
     fn conversation_role_labels() {
         assert_eq!(ConversationRole::User.display_label(), "You");
@@ -194,7 +278,7 @@ mod tests {
 
     #[test]
     fn lines_empty_conversation() {
-        let area = ConversationArea::new(&[], "", 0, 10);
+        let area = ConversationArea::new(&[], "", 0, 10, 0);
         let lines = area.lines();
         assert!(lines.is_empty());
     }
@@ -211,14 +295,15 @@ mod tests {
                 content: "world".to_string(),
             },
         ];
-        let area = ConversationArea::new(&entries, "", 0, 10);
-        let lines = area.lines();
-        assert_eq!(lines.len(), 6);
+        let (_, lines) = cached_lines(&entries, 58);
+        let area = ConversationArea::new(&lines, "", 0, 10, 0);
+        let result = area.lines();
+        assert_eq!(result.len(), 6);
     }
 
     #[test]
     fn lines_with_current_response() {
-        let area = ConversationArea::new(&[], "streaming text", 0, 10);
+        let area = ConversationArea::new(&[], "streaming text", 0, 10, 0);
         let lines = area.lines();
         assert!(!lines.is_empty());
     }
@@ -272,7 +357,7 @@ mod tests {
     fn render_empty_conversation() {
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&[], "", 0, 20);
+        let area_widget = ConversationArea::new(&[], "", 0, 20, 0);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -295,9 +380,10 @@ mod tests {
                 content: "Hi there!".to_string(),
             },
         ];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -312,7 +398,7 @@ mod tests {
     fn render_with_current_response() {
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&[], "Streaming response...", 0, 20);
+        let area_widget = ConversationArea::new(&[], "Streaming response...", 0, 20, 0);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -331,7 +417,8 @@ mod tests {
                 content: format!("line {i}"),
             })
             .collect();
-        let area = ConversationArea::new(&entries, "", 0, 10);
+        let (count, lines) = cached_lines(&entries, 58);
+        let area = ConversationArea::new(&lines, "", 0, 10, count);
         let max = area.max_scroll(58);
         assert!(max > 0, "should have scrollable content");
     }
@@ -342,7 +429,8 @@ mod tests {
             role: ConversationRole::User,
             content: "short".to_string(),
         }];
-        let area = ConversationArea::new(&entries, "", 0, 100);
+        let (count, lines) = cached_lines(&entries, 58);
+        let area = ConversationArea::new(&lines, "", 0, 100, count);
         let max = area.max_scroll(58);
         assert_eq!(max, 0);
     }
@@ -360,9 +448,10 @@ mod tests {
             role: ConversationRole::Assistant,
             content: "This is **bold** text".to_string(),
         }];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -379,9 +468,10 @@ mod tests {
             role: ConversationRole::Assistant,
             content: "```rust\nfn main() {}\n```".to_string(),
         }];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -398,9 +488,10 @@ mod tests {
             role: ConversationRole::Assistant,
             content: "# Hello World\nSome content".to_string(),
         }];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -417,9 +508,10 @@ mod tests {
             role: ConversationRole::Assistant,
             content: "- item one\n- item two\n- item three".to_string(),
         }];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -436,9 +528,10 @@ mod tests {
             role: ConversationRole::User,
             content: "This is *italic* text".to_string(),
         }];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -455,9 +548,10 @@ mod tests {
             role: ConversationRole::ToolUse,
             content: "bash\n  {\"command\": \"ls\"}".to_string(),
         }];
+        let (count, lines) = cached_lines(&entries, 58);
         let backend = ratatui::backend::TestBackend::new(60, 20);
         let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
-        let area_widget = ConversationArea::new(&entries, "", 0, 20);
+        let area_widget = ConversationArea::new(&lines, "", 0, 20, count);
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
@@ -468,6 +562,115 @@ mod tests {
         insta::assert_snapshot!(
             "render_tool_entry_not_rendered_as_markdown",
             terminal.backend()
+        );
+    }
+
+    #[test]
+    fn line_count_cache_returns_same_value_on_repeated_calls() {
+        let entries = vec![
+            ConversationEntry {
+                role: ConversationRole::User,
+                content: "hello world".to_string(),
+            },
+            ConversationEntry {
+                role: ConversationRole::Assistant,
+                content: "hi there".to_string(),
+            },
+        ];
+        let mut cache = LineCountCache::new();
+        let first = cache.get(&entries, 58);
+        let second = cache.get(&entries, 58);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn line_count_cache_invalidates_on_new_entry() {
+        let mut entries = vec![ConversationEntry {
+            role: ConversationRole::User,
+            content: "hello".to_string(),
+        }];
+        let mut cache = LineCountCache::new();
+        let before = cache.get(&entries, 58);
+        entries.push(ConversationEntry {
+            role: ConversationRole::Assistant,
+            content: "world".to_string(),
+        });
+        let after = cache.get(&entries, 58);
+        assert!(after > before, "adding entry should increase line count");
+    }
+
+    #[test]
+    fn line_count_cache_invalidates_on_width_change() {
+        let entries = vec![ConversationEntry {
+            role: ConversationRole::User,
+            content: "a long message that should wrap at narrow widths but not at wide ones"
+                .to_string(),
+        }];
+        let mut cache = LineCountCache::new();
+        let wide = cache.get(&entries, 80);
+        let narrow = cache.get(&entries, 20);
+        assert!(
+            narrow > wide,
+            "narrow width should produce more lines: narrow={narrow}, wide={wide}"
+        );
+    }
+
+    #[test]
+    fn max_scroll_accounts_for_wrapping() {
+        let entries = vec![ConversationEntry {
+            role: ConversationRole::User,
+            content: "a ".repeat(100),
+        }];
+        let (count_wide, lines_wide) = cached_lines(&entries, 80);
+        let (count_narrow, lines_narrow) = cached_lines(&entries, 20);
+        let wide = ConversationArea::new(&lines_wide, "", 0, 5, count_wide);
+        let narrow = ConversationArea::new(&lines_narrow, "", 0, 5, count_narrow);
+        assert!(
+            narrow.max_scroll(20) > wide.max_scroll(80),
+            "narrow viewport should need more scroll"
+        );
+    }
+
+    #[test]
+    fn render_long_content_scrolls_to_bottom_showing_last_entry() {
+        let mut entries: Vec<ConversationEntry> = (0..20)
+            .map(|i| ConversationEntry {
+                role: ConversationRole::User,
+                content: format!("message {i}"),
+            })
+            .collect();
+        entries.push(ConversationEntry {
+            role: ConversationRole::Assistant,
+            content: "final answer".to_string(),
+        });
+
+        let backend = ratatui::backend::TestBackend::new(60, 10);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
+        let (count, lines) = cached_lines(&entries, 58);
+        let area_widget = ConversationArea::new(&lines, "", 0, 8, count);
+        terminal
+            .draw(|frame| {
+                let rect = ratatui::layout::Rect::new(0, 0, 60, 10);
+                area_widget.render(frame, rect, 58);
+            })
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut found_final = false;
+        for y in 0..buffer.area.height {
+            let mut row_text = String::new();
+            for x in 0..buffer.area.width {
+                let cell = &buffer[(x, y)];
+                row_text.push_str(cell.symbol());
+            }
+            if row_text.contains("final answer") {
+                found_final = true;
+                break;
+            }
+        }
+        assert!(
+            found_final,
+            "the last entry should be visible when auto-scrolled to bottom"
         );
     }
 }

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use super::conversation_area::{ConversationArea, ConversationEntry, ConversationRole};
+use super::conversation_area::{
+    ConversationArea, ConversationEntry, ConversationRole, LineCountCache,
+};
 use super::input_area::{InputArea, InputMode};
 use crate::agent::Agent;
 use crate::logging::Logger;
@@ -42,7 +44,9 @@ pub struct App {
     pub confirmation_tx: Option<fmpsc::UnboundedSender<ConfirmationResponse>>,
     pub scroll_offset: u16,
     pub viewport_height: u16,
+    pub text_width: u16,
     tools: std::sync::Arc<ToolRegistry>,
+    line_cache: LineCountCache,
 }
 
 impl App {
@@ -69,7 +73,9 @@ impl App {
             confirmation_tx: None,
             scroll_offset: 0,
             viewport_height: 0,
+            text_width: 0,
             tools,
+            line_cache: LineCountCache::new(),
         }
     }
 
@@ -168,15 +174,16 @@ impl App {
         }
     }
 
-    fn max_scroll(&self) -> u16 {
-        let text_width = 0;
+    fn max_scroll(&mut self) -> u16 {
+        let cached_count = self.line_cache.get(&self.conversation, self.text_width);
         let conv_area = ConversationArea::new(
-            &self.conversation,
+            self.line_cache.lines(),
             &self.current_response,
             0,
             self.viewport_height,
+            cached_count,
         );
-        conv_area.max_scroll(text_width)
+        conv_area.max_scroll(self.text_width)
     }
 }
 
@@ -187,7 +194,7 @@ impl Default for App {
 }
 
 /// Render the app to a frame. Includes scroll and cursor positioning.
-pub fn render_app(app: &App, frame: &mut ratatui::Frame) {
+pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
     let input_height = app
         .input
         .height_for_width(frame.area().width, frame.area().height);
@@ -198,11 +205,14 @@ pub fn render_app(app: &App, frame: &mut ratatui::Frame) {
         .split(frame.area());
 
     let text_width = chunks[0].width.saturating_sub(2);
+    app.text_width = text_width;
+    let cached_count = app.line_cache.get(&app.conversation, text_width);
     let conv_area = ConversationArea::new(
-        &app.conversation,
+        app.line_cache.lines(),
         &app.current_response,
         app.scroll_offset,
         chunks[0].height.saturating_sub(2),
+        cached_count,
     );
     conv_area.render(frame, chunks[0], text_width);
 
@@ -346,7 +356,7 @@ async fn run_app(
 
     loop {
         app.viewport_height = terminal.size()?.height.saturating_sub(5);
-        terminal.draw(|frame| render_app(&app, frame))?;
+        terminal.draw(|frame| render_app(&mut app, frame))?;
         tokio::select! {
             Some(agent_event) = event_rx.recv() => {
                 handle_agent_event(&mut app, agent_event, logger.as_mut())?;

--- a/tests/tui_test.rs
+++ b/tests/tui_test.rs
@@ -22,7 +22,7 @@ fn test_tui_tool_call_renders_inline() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
@@ -44,7 +44,7 @@ fn test_tui_tool_result_renders_below_invocation() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
@@ -63,7 +63,7 @@ fn test_tui_long_tool_result_is_truncated() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
@@ -85,21 +85,21 @@ fn test_tui_confirmation_prompt_state_renders() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
 
 #[test]
 fn test_tui_initial_state() {
-    let app = App::new(std::sync::Arc::new(
+    let mut app = App::new(std::sync::Arc::new(
         illustrious_manager::tools::ToolRegistry::new(),
     ));
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
 
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
@@ -122,7 +122,7 @@ fn test_tui_with_conversation() {
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
 
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
@@ -143,7 +143,7 @@ fn test_tui_streaming_state() {
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
 
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }
@@ -272,7 +272,7 @@ fn test_tui_auto_scroll_shows_bottom_with_wrapping_content() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
 
     let rendered = format!("{:?}", terminal.backend());
@@ -298,7 +298,7 @@ fn test_tui_scrolled_up_shows_earlier_content() {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal creation must succeed");
     terminal
-        .draw(|frame| render_app(&app, frame))
+        .draw(|frame| render_app(&mut app, frame))
         .expect("draw must succeed");
     assert_snapshot!(terminal.backend());
 }


### PR DESCRIPTION
## Problem

After many rounds of inference and tool calling, the conversation view fell out of sync — the user's prompt wouldn't appear in the chat until assistant messages started streaming. The conversation appeared to be behind by multiple messages.

### Root causes

1. **Inaccurate line count estimation**: `ConversationArea::render()` and `max_scroll()` used `line.width().div_ceil(text_width)` to estimate visual lines after wrapping. This doesn't match how ratatui's `WordWrapper` actually wraps text (word boundaries, grapheme clusters, etc.), causing progressive drift in the scroll position.

2. **Broken `App::max_scroll()`**: The method hardcoded `text_width = 0`, which hit the fallback branch counting every line as exactly 1 visual line — completely ignoring wrapping.

## Solution

- **Enable `unstable-rendered-line-info`** on ratatui to access `Paragraph::line_count()`, which uses the same internal `WordWrapper` that the actual render path uses
- **Add `LineCountCache`** that stores accurate line counts for finalized conversation entries, invalidated only when entry count or text width changes — never on every render or every streaming token (per issue requirements)
- **Use cheap estimate for streaming content** — the `current_response` changes every token and is always at the bottom, so the simple heuristic is acceptable there
- **Store `text_width` on `App`** so `max_scroll()` uses the real viewport width instead of `0`

## Tests

- `line_count_cache_returns_same_value_on_repeated_calls` — cache stability
- `line_count_cache_invalidates_on_new_entry` — cache invalidation on entry change
- `line_count_cache_invalidates_on_width_change` — cache invalidation on resize
- `max_scroll_accounts_for_wrapping` — narrow viewport produces more scroll than wide
- `render_long_content_scrolls_to_bottom_showing_last_entry` — regression test verifying auto-scroll shows the final entry

Fixes #86