### PR TITLE
fix: preserve conversation history on errors

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -138,7 +138,6 @@ impl Agent {
         input: String,
         confirmation_rx: Option<mpsc::UnboundedReceiver<ConfirmationResponse>>,
     ) -> Result<BoxStream<AgentEvent>> {
-        let pre_send_len = lock(&self.history).len();
         let user_msg = Message::text(Role::User, input);
         lock(&self.history).push(user_msg.clone());
 
@@ -159,10 +158,11 @@ impl Agent {
 
             'outer: loop {
                 if iterations >= max_iterations {
-                    lock(&history_arc).truncate(pre_send_len);
-                    let _ = event_tx.unbounded_send(AgentEvent::Error(format!(
-                        "Max tool iterations ({max_iterations}) exceeded"
-                    )));
+                    let error_msg = format!("Max tool iterations ({max_iterations}) exceeded");
+                    let error_user_msg = Message::text(Role::User, format!("[ERROR] {error_msg}"));
+                    lock(&history_arc).push(error_user_msg.clone());
+                    let _ = session.lock().await.insert_message(&error_user_msg).await;
+                    let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg));
                     break;
                 }
                 iterations += 1;
@@ -171,8 +171,12 @@ impl Agent {
                 let backend_stream = match backend.send_message(&history_snapshot, &config).await {
                     Ok(s) => s,
                     Err(e) => {
-                        lock(&history_arc).truncate(pre_send_len);
-                        let _ = event_tx.unbounded_send(AgentEvent::Error(e.to_string()));
+                        let error_msg = e.to_string();
+                        let error_user_msg =
+                            Message::text(Role::User, format!("[ERROR] {error_msg}"));
+                        lock(&history_arc).push(error_user_msg.clone());
+                        let _ = session.lock().await.insert_message(&error_user_msg).await;
+                        let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg));
                         break;
                     }
                 };
@@ -218,8 +222,20 @@ impl Agent {
                         }
                         Ok(StreamEvent::Done) => break,
                         Err(e) => {
-                            lock(&history_arc).truncate(pre_send_len);
-                            let _ = event_tx.unbounded_send(AgentEvent::Error(e.to_string()));
+                            if !text_accumulated.is_empty() {
+                                let partial_msg = Message {
+                                    role: Role::Assistant,
+                                    content: vec![ContentBlock::Text(text_accumulated)],
+                                };
+                                lock(&history_arc).push(partial_msg.clone());
+                                let _ = session.lock().await.insert_message(&partial_msg).await;
+                            }
+                            let error_msg = e.to_string();
+                            let error_user_msg =
+                                Message::text(Role::User, format!("[ERROR] {error_msg}"));
+                            lock(&history_arc).push(error_user_msg.clone());
+                            let _ = session.lock().await.insert_message(&error_user_msg).await;
+                            let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg));
                             break 'outer;
                         }
                     }
@@ -877,7 +893,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn backend_error_on_second_iteration_clears_history() {
+    async fn backend_error_on_second_iteration_preserves_history() {
         let backend = SequencedBackend::new(vec![
             tool_call_response("t1", "bash", r#"{}"#),
             vec![Err(anyhow::anyhow!("backend failure on iteration 2"))],
@@ -900,8 +916,150 @@ mod tests {
             "expected Error event"
         );
         assert!(
-            agent.history().is_empty(),
-            "history must be fully cleared after mid-loop backend error"
+            !agent.history().is_empty(),
+            "history must be preserved after error so agent retains context"
+        );
+        let history = agent.history();
+        assert!(
+            history.iter().any(|m| m.role == Role::User
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text(t) if t == "run"))),
+            "user message must be retained in history"
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_send_error_preserves_user_message_in_history() {
+        let backend = SequencedBackend::new(vec![vec![Err(anyhow::anyhow!("connection refused"))]]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("hello".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        assert!(
+            events.iter().any(|e| matches!(e, AgentEvent::Error(_))),
+            "expected Error event"
+        );
+        let history = agent.history();
+        assert!(
+            !history.is_empty(),
+            "history must not be cleared on backend error"
+        );
+        assert!(
+            history.iter().any(|m| m.role == Role::User
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text(t) if t == "hello"))),
+            "user message must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_error_preserves_partial_text_in_history() {
+        let backend = SequencedBackend::new(vec![vec![
+            Ok(StreamEvent::TextDelta("partial response".to_string())),
+            Err(anyhow::anyhow!("max_tokens reached")),
+        ]]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("tell me a story".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::TokenReceived(t) if t == "partial response")),
+            "expected partial text tokens before error"
+        );
+        assert!(
+            events.iter().any(|e| matches!(e, AgentEvent::Error(_))),
+            "expected Error event"
+        );
+
+        let history = agent.history();
+        assert!(
+            history.iter().any(|m| m.role == Role::Assistant
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text(t) if t.contains("partial response")))),
+            "partial assistant text must be saved in history"
+        );
+    }
+
+    #[tokio::test]
+    async fn error_message_is_added_to_history_as_user_message() {
+        let backend = SequencedBackend::new(vec![vec![Err(anyhow::anyhow!("max_tokens reached"))]]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("hi".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        let has_error_in_history = history.iter().any(|m| {
+            m.role == Role::User
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text(t) if t.contains("max_tokens reached")))
+        });
+        assert!(
+            has_error_in_history,
+            "error message must be added to history so the agent knows why a stoppage occurred"
+        );
+    }
+
+    #[tokio::test]
+    async fn max_iterations_error_preserves_history() {
+        let responses: Vec<Vec<Result<StreamEvent>>> = (0..30)
+            .map(|_| tool_call_response("tool-1", "bash", r#"{}"#))
+            .collect();
+        let backend = SequencedBackend::new(responses);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(EchoTool::new("bash", "output")))
+            .expect("register");
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Never,
+            max_tool_iterations: 3,
+            ..Default::default()
+        };
+
+        let agent = Agent::new(Box::new(backend), config, test_session().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        let stream = agent
+            .send("run".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        assert!(
+            !history.is_empty(),
+            "history must be preserved after max iterations error"
+        );
+        assert!(
+            history.iter().any(|m| m.role == Role::User
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text(t) if t == "run"))),
+            "original user message must be retained"
         );
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -159,10 +159,7 @@ impl Agent {
             'outer: loop {
                 if iterations >= max_iterations {
                     let error_msg = format!("Max tool iterations ({max_iterations}) exceeded");
-                    let error_user_msg = Message::text(Role::User, format!("[ERROR] {error_msg}"));
-                    lock(&history_arc).push(error_user_msg.clone());
-                    let _ = session.lock().await.insert_message(&error_user_msg).await;
-                    let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg));
+                    record_error(&error_msg, &history_arc, &session, &event_tx).await;
                     break;
                 }
                 iterations += 1;
@@ -171,12 +168,7 @@ impl Agent {
                 let backend_stream = match backend.send_message(&history_snapshot, &config).await {
                     Ok(s) => s,
                     Err(e) => {
-                        let error_msg = e.to_string();
-                        let error_user_msg =
-                            Message::text(Role::User, format!("[ERROR] {error_msg}"));
-                        lock(&history_arc).push(error_user_msg.clone());
-                        let _ = session.lock().await.insert_message(&error_user_msg).await;
-                        let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg));
+                        record_error(&e.to_string(), &history_arc, &session, &event_tx).await;
                         break;
                     }
                 };
@@ -225,17 +217,12 @@ impl Agent {
                             if !text_accumulated.is_empty() {
                                 let partial_msg = Message {
                                     role: Role::Assistant,
-                                    content: vec![ContentBlock::Text(text_accumulated)],
+                                    content: vec![ContentBlock::Text(text_accumulated.clone())],
                                 };
                                 lock(&history_arc).push(partial_msg.clone());
                                 let _ = session.lock().await.insert_message(&partial_msg).await;
                             }
-                            let error_msg = e.to_string();
-                            let error_user_msg =
-                                Message::text(Role::User, format!("[ERROR] {error_msg}"));
-                            lock(&history_arc).push(error_user_msg.clone());
-                            let _ = session.lock().await.insert_message(&error_user_msg).await;
-                            let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg));
+                            record_error(&e.to_string(), &history_arc, &session, &event_tx).await;
                             break 'outer;
                         }
                     }
@@ -284,6 +271,18 @@ impl Agent {
 
         Ok(Box::pin(event_rx))
     }
+}
+
+async fn record_error(
+    error_msg: &str,
+    history: &Arc<Mutex<Vec<Message>>>,
+    session: &Arc<TokioMutex<Session>>,
+    event_tx: &mpsc::UnboundedSender<AgentEvent>,
+) {
+    let error_user_msg = Message::text(Role::User, format!("[ERROR] {error_msg}"));
+    lock(history).push(error_user_msg.clone());
+    let _ = session.lock().await.insert_message(&error_user_msg).await;
+    let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg.to_string()));
 }
 
 async fn execute_tool_calls(
@@ -930,7 +929,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn backend_send_error_preserves_user_message_in_history() {
+    async fn stream_error_preserves_user_message_in_history() {
         let backend = SequencedBackend::new(vec![vec![Err(anyhow::anyhow!("connection refused"))]]);
         let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
 
@@ -947,7 +946,7 @@ mod tests {
         let history = agent.history();
         assert!(
             !history.is_empty(),
-            "history must not be cleared on backend error"
+            "history must not be cleared on stream error"
         );
         assert!(
             history.iter().any(|m| m.role == Role::User
@@ -955,6 +954,61 @@ mod tests {
                     .iter()
                     .any(|b| matches!(b, ContentBlock::Text(t) if t == "hello"))),
             "user message must be retained"
+        );
+    }
+
+    struct FailingBackend {
+        error_message: String,
+    }
+
+    #[async_trait]
+    impl LlmBackend for FailingBackend {
+        async fn send_message(
+            &self,
+            _: &[Message],
+            _: &RequestConfig,
+        ) -> Result<BoxStream<Result<StreamEvent>>> {
+            Err(anyhow::anyhow!("{}", self.error_message))
+        }
+    }
+
+    #[tokio::test]
+    async fn backend_send_error_preserves_user_message_in_history() {
+        let backend = FailingBackend {
+            error_message: "connection refused".to_string(),
+        };
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("hello".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::Error(msg) if msg.contains("connection refused"))),
+            "expected Error event with connection refused message"
+        );
+        let history = agent.history();
+        assert!(
+            !history.is_empty(),
+            "history must not be cleared on send_message error"
+        );
+        assert!(
+            history.iter().any(|m| m.role == Role::User
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Text(t) if t == "hello"))),
+            "user message must be retained"
+        );
+        assert!(
+            history.iter().any(|m| m.role == Role::User
+                && m.content.iter().any(
+                    |b| matches!(b, ContentBlock::Text(t) if t.contains("[ERROR]") && t.contains("connection refused"))
+                )),
+            "error message with [ERROR] prefix must be in history"
         );
     }
 
@@ -1007,13 +1061,13 @@ mod tests {
         let history = agent.history();
         let has_error_in_history = history.iter().any(|m| {
             m.role == Role::User
-                && m.content
-                    .iter()
-                    .any(|b| matches!(b, ContentBlock::Text(t) if t.contains("max_tokens reached")))
+                && m.content.iter().any(
+                    |b| matches!(b, ContentBlock::Text(t) if t == "[ERROR] max_tokens reached"),
+                )
         });
         assert!(
             has_error_in_history,
-            "error message must be added to history so the agent knows why a stoppage occurred"
+            "error message with [ERROR] prefix must be added to history so the agent knows why a stoppage occurred"
         );
     }
 
@@ -1060,6 +1114,31 @@ mod tests {
                     .iter()
                     .any(|b| matches!(b, ContentBlock::Text(t) if t == "run"))),
             "original user message must be retained"
+        );
+        let tool_use_count = history
+            .iter()
+            .flat_map(|m| &m.content)
+            .filter(|b| matches!(b, ContentBlock::ToolUse { .. }))
+            .count();
+        assert_eq!(
+            tool_use_count, 3,
+            "completed tool call iterations must be preserved in history"
+        );
+        let tool_result_count = history
+            .iter()
+            .flat_map(|m| &m.content)
+            .filter(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            .count();
+        assert_eq!(
+            tool_result_count, 3,
+            "completed tool result iterations must be preserved in history"
+        );
+        assert!(
+            history.iter().any(|m| m.role == Role::User
+                && m.content.iter().any(
+                    |b| matches!(b, ContentBlock::Text(t) if t.contains("[ERROR]") && t.contains("Max tool iterations"))
+                )),
+            "error message with [ERROR] prefix must be in history"
         );
     }
 


### PR DESCRIPTION
## Problem

When any error occurred during a conversation (e.g. `max_tokens` reached, backend connection failure, mid-stream error), the agent was truncating the conversation history back to its pre-send state using `history.truncate(pre_send_len)`. This caused the agent to lose all context accumulated during the current turn and behave as if it was at the very beginning of the conversation.

Users had to exit and re-join with the same session ID to recover the conversation, because the session DB still had the history — it was only the in-memory history that got wiped.

## Solution

Instead of truncating history on error, the agent now:

1. **Preserves all accumulated history** — user messages, assistant responses, tool calls, and tool results all remain in the conversation
2. **Saves any partial assistant response** — if the model was mid-stream when the error occurred (e.g. `max_tokens`), the partial text is saved as an assistant message
3. **Adds the error to history** — the error message is added as a `[ERROR]` user message so the agent knows why the stoppage occurred and can react appropriately on the next turn
4. **Persists to session DB** — error messages and partial responses are saved to the session database so they survive restarts

## Changes

- `src/agent.rs`: Replaced all three `history.truncate(pre_send_len)` calls with error-preserving logic across the three error paths:
  - Max tool iterations exceeded
  - Backend `send_message()` returns error
  - Mid-stream error (e.g. `max_tokens` reached)

## Tests (TDD)

5 new regression tests, 1 updated test:

| Test | What it verifies |
|------|-----------------|
| `backend_error_on_second_iteration_preserves_history` | Updated from `_clears_history` — verifies history is preserved, not wiped |
| `backend_send_error_preserves_user_message_in_history` | Backend connection error keeps user message |
| `stream_error_preserves_partial_text_in_history` | Mid-stream error saves partial assistant text |
| `error_message_is_added_to_history_as_user_message` | Error text is added to history for agent context |
| `max_iterations_error_preserves_history` | Max iterations error preserves full conversation |

Closes #94