### PR TITLE
feat: session management - /sessions command (#102)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -114,6 +114,14 @@ impl Agent {
         self.session.lock().await.load_history().await
     }
 
+    /// Replace the current session with a new one and reload the conversation history.
+    /// The in-memory history is reset to only what is in the new session's database.
+    pub async fn load_session(&self, session: Session) {
+        let history = session.load_history().await.unwrap_or_default();
+        *lock(&self.history) = history;
+        *self.session.lock().await = session;
+    }
+
     pub fn load_context_files(&self, files: Vec<ContextFile>) {
         if files.is_empty() {
             return;

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -122,6 +122,15 @@ impl Agent {
         self.session.lock().await.load_history().await
     }
 
+    /// If the current session has no messages, delete its DB file from disk.
+    pub async fn cleanup_empty_session(&self) -> Result<()> {
+        let session = self.session.lock().await;
+        if session.is_empty().await? {
+            session.delete_db()?;
+        }
+        Ok(())
+    }
+
     /// Replace the current session with a new one and reload the conversation history.
     /// Non-persisted context messages (context files, skill definitions) are preserved
     /// at the front of history; only the persisted portion is replaced.
@@ -1399,5 +1408,48 @@ mod tests {
         assert_eq!(agent.session_id().await, id_a);
         agent.load_session(session_b).await;
         assert_eq!(agent.session_id().await, id_b);
+    }
+
+    #[tokio::test]
+    async fn cleanup_empty_session_deletes_db_when_no_messages() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session = Session::new(None, dir_path.clone()).await.expect("session");
+        let db_path = dir_path.join(format!("{}.db", session.id));
+        assert!(db_path.exists());
+
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session).await;
+
+        agent.cleanup_empty_session().await.expect("cleanup");
+        assert!(!db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_empty_session_preserves_db_when_has_messages() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session = Session::new(None, dir_path.clone()).await.expect("session");
+        session
+            .insert_message(&Message::text(Role::User, "hello".to_string()))
+            .await
+            .expect("insert");
+        let db_path = dir_path.join(format!("{}.db", session.id));
+
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session).await;
+
+        agent.cleanup_empty_session().await.expect("cleanup");
+        assert!(db_path.exists());
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -23,6 +23,9 @@ struct PendingToolCall {
 pub struct Agent {
     backend: Arc<dyn LlmBackend>,
     history: Arc<Mutex<Vec<Message>>>,
+    /// Number of messages prepended to `history` that are never persisted to the DB
+    /// (context files, skill definitions). Preserved across session switches.
+    context_prefix_len: Arc<Mutex<usize>>,
     config: RequestConfig,
     tools: Arc<ToolRegistry>,
     max_tool_iterations: u32,
@@ -48,6 +51,7 @@ impl Agent {
         Self {
             backend: Arc::from(backend),
             history: Arc::new(Mutex::new(history)),
+            context_prefix_len: Arc::new(Mutex::new(0)),
             config,
             tools: Arc::new(ToolRegistry::new()),
             max_tool_iterations: 25,
@@ -95,6 +99,10 @@ impl Agent {
 
         let msg = Message::text(Role::User, content);
         lock(&self.history).insert(0, msg.clone());
+        *self
+            .context_prefix_len
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) += 1;
         self
     }
 
@@ -115,10 +123,21 @@ impl Agent {
     }
 
     /// Replace the current session with a new one and reload the conversation history.
-    /// The in-memory history is reset to only what is in the new session's database.
+    /// Non-persisted context messages (context files, skill definitions) are preserved
+    /// at the front of history; only the persisted portion is replaced.
     pub async fn load_session(&self, session: Session) {
-        let history = session.load_history().await.unwrap_or_default();
-        *lock(&self.history) = history;
+        let new_history = session.load_history().await.unwrap_or_default();
+        {
+            let prefix_len = *self
+                .context_prefix_len
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let mut history = lock(&self.history);
+            let take = prefix_len.min(history.len());
+            let prefix: Vec<Message> = history.drain(..take).collect();
+            *history = prefix;
+            history.extend(new_history);
+        }
         *self.session.lock().await = session;
     }
 
@@ -139,6 +158,10 @@ impl Agent {
         let msg = Message::text(Role::User, content);
         // prepend context files and don't persist them to the DB
         lock(&self.history).insert(0, msg.clone());
+        *self
+            .context_prefix_len
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) += 1;
     }
 
     pub async fn send(
@@ -1253,5 +1276,128 @@ mod tests {
             agent.history().is_empty(),
             "empty skills map should not add history entry"
         );
+    }
+
+    #[tokio::test]
+    async fn load_session_replaces_persisted_history() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session_a = Session::new(None, dir_path.clone())
+            .await
+            .expect("session a");
+        session_a
+            .insert_message(&Message::text(Role::User, "session a message".to_string()))
+            .await
+            .expect("insert");
+
+        let session_b = Session::new(None, dir_path.clone())
+            .await
+            .expect("session b");
+        session_b
+            .insert_message(&Message::text(Role::User, "session b message".to_string()))
+            .await
+            .expect("insert");
+
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session_a).await;
+
+        assert_eq!(agent.history().len(), 1);
+        assert!(
+            matches!(&agent.history()[0].content[0], crate::types::ContentBlock::Text(t) if t == "session a message")
+        );
+
+        agent.load_session(session_b).await;
+
+        assert_eq!(agent.history().len(), 1);
+        assert!(
+            matches!(&agent.history()[0].content[0], crate::types::ContentBlock::Text(t) if t == "session b message")
+        );
+    }
+
+    #[tokio::test]
+    async fn load_session_preserves_context_prefix() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session_a = Session::new(None, dir_path.clone())
+            .await
+            .expect("session a");
+        session_a
+            .insert_message(&Message::text(Role::User, "session a message".to_string()))
+            .await
+            .expect("insert");
+
+        let session_b = Session::new(None, dir_path.clone())
+            .await
+            .expect("session b");
+        session_b
+            .insert_message(&Message::text(Role::User, "session b message".to_string()))
+            .await
+            .expect("insert");
+
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+
+        let mut skills = std::collections::HashMap::new();
+        let tmp = tempfile::TempDir::new().expect("tmp");
+        let skill_path = tmp.path().join("test-skill.md");
+        std::fs::write(&skill_path, "---\ndescription: A test skill\n---\nContent").expect("write");
+        skills.insert("test-skill".to_string(), skill_path);
+
+        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session_a)
+            .await
+            .with_skills(&skills);
+
+        // history should be: [skill_prefix, session_a_message]
+        assert_eq!(agent.history().len(), 2);
+
+        agent.load_session(session_b).await;
+
+        // history should be: [skill_prefix, session_b_message] — prefix preserved
+        let history = agent.history();
+        assert_eq!(history.len(), 2, "context prefix should be preserved");
+        assert!(
+            matches!(&history[0].content[0], crate::types::ContentBlock::Text(t) if t.contains("test-skill")),
+            "first entry should still be the skills prefix"
+        );
+        assert!(
+            matches!(&history[1].content[0], crate::types::ContentBlock::Text(t) if t == "session b message"),
+            "second entry should be new session's message"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_session_updates_session_id() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session_a = Session::new(None, dir_path.clone())
+            .await
+            .expect("session a");
+        let id_a = session_a.id.clone();
+
+        let session_b = Session::new(None, dir_path.clone())
+            .await
+            .expect("session b");
+        let id_b = session_b.id.clone();
+
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session_a).await;
+
+        assert_eq!(agent.session_id().await, id_a);
+        agent.load_session(session_b).await;
+        assert_eq!(agent.session_id().await, id_b);
     }
 }

--- a/src/frontend/tui/input_area.rs
+++ b/src/frontend/tui/input_area.rs
@@ -15,6 +15,7 @@ pub enum InputMode {
     Insert,
     Normal,
     Streaming,
+    SessionPicker,
     ToolConfirmation {
         name: String,
         input: serde_json::Value,
@@ -135,6 +136,9 @@ impl<'a> InputArea<'a> {
             InputMode::Streaming => Block::default()
                 .borders(Borders::ALL)
                 .title(STREAMING_TITLE),
+            InputMode::SessionPicker => Block::default()
+                .borders(Borders::ALL)
+                .title(STREAMING_TITLE),
             InputMode::ToolConfirmation { name, .. } => Block::default()
                 .borders(Borders::ALL)
                 .title(format!("Allow '{name}'? [y/n]")),
@@ -153,7 +157,7 @@ impl<'a> InputArea<'a> {
                     .max(MIN_HEIGHT)
                     .min(max_height)
             }
-            InputMode::Streaming => MIN_HEIGHT,
+            InputMode::Streaming | InputMode::SessionPicker => MIN_HEIGHT,
             InputMode::Insert => self.text_height_for_width(width, max_height),
             InputMode::Normal => self.text_height_for_width(width, max_height),
         }

--- a/src/frontend/tui/mod.rs
+++ b/src/frontend/tui/mod.rs
@@ -1,6 +1,8 @@
 pub mod conversation_area;
 pub mod input_area;
+pub mod session_picker;
 mod tui_app;
 
 pub use conversation_area::{ConversationEntry, ConversationRole};
+pub use session_picker::{SessionPicker, SessionPickerAction};
 pub use tui_app::*;

--- a/src/frontend/tui/session_picker.rs
+++ b/src/frontend/tui/session_picker.rs
@@ -65,7 +65,7 @@ impl SessionPicker {
                 Some(id) => SessionPickerAction::Select(id.to_string()),
                 None => SessionPickerAction::None,
             },
-            KeyCode::Char('q') => SessionPickerAction::Close,
+            KeyCode::Char('q') | KeyCode::Esc => SessionPickerAction::Close,
             _ => SessionPickerAction::None,
         }
     }
@@ -90,7 +90,7 @@ impl SessionPicker {
                         truncated
                     }
                 };
-                ListItem::new(format!("{}  {}", &s.id[..8], preview))
+                ListItem::new(format!("{}  {}", s.id.get(..8).unwrap_or(&s.id), preview))
             })
             .collect();
 
@@ -265,6 +265,17 @@ mod tests {
         )];
         let mut picker = SessionPicker::new(sessions);
         let action = picker.handle_key(key(KeyCode::Char('q')));
+        assert_eq!(action, SessionPickerAction::Close);
+    }
+
+    #[test]
+    fn esc_returns_close_action() {
+        let sessions = vec![make_session(
+            "01900000-0000-7000-0000-000000000001",
+            "hello",
+        )];
+        let mut picker = SessionPicker::new(sessions);
+        let action = picker.handle_key(key(KeyCode::Esc));
         assert_eq!(action, SessionPickerAction::Close);
     }
 

--- a/src/frontend/tui/session_picker.rs
+++ b/src/frontend/tui/session_picker.rs
@@ -1,0 +1,359 @@
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState};
+
+use crate::session::SessionSummary;
+
+pub struct SessionPicker {
+    pub sessions: Vec<SessionSummary>,
+    state: ListState,
+}
+
+impl SessionPicker {
+    pub fn new(sessions: Vec<SessionSummary>) -> Self {
+        let mut state = ListState::default();
+        if !sessions.is_empty() {
+            state.select(Some(0));
+        }
+        Self { sessions, state }
+    }
+
+    /// Move selection down (vim `j`).
+    pub fn move_down(&mut self) {
+        if self.sessions.is_empty() {
+            return;
+        }
+        let next = match self.state.selected() {
+            Some(i) => (i + 1).min(self.sessions.len() - 1),
+            None => 0,
+        };
+        self.state.select(Some(next));
+    }
+
+    /// Move selection up (vim `k`).
+    pub fn move_up(&mut self) {
+        if self.sessions.is_empty() {
+            return;
+        }
+        let prev = match self.state.selected() {
+            Some(i) => i.saturating_sub(1),
+            None => 0,
+        };
+        self.state.select(Some(prev));
+    }
+
+    /// Return the currently selected session ID, if any.
+    pub fn selected_id(&self) -> Option<&str> {
+        let idx = self.state.selected()?;
+        self.sessions.get(idx).map(|s| s.id.as_str())
+    }
+
+    /// Handle a key event. Returns a `SessionPickerAction` indicating what happened.
+    pub fn handle_key(&mut self, key: KeyEvent) -> SessionPickerAction {
+        match key.code {
+            KeyCode::Char('j') => {
+                self.move_down();
+                SessionPickerAction::None
+            }
+            KeyCode::Char('k') => {
+                self.move_up();
+                SessionPickerAction::None
+            }
+            KeyCode::Enter => match self.selected_id() {
+                Some(id) => SessionPickerAction::Select(id.to_string()),
+                None => SessionPickerAction::None,
+            },
+            KeyCode::Char('q') => SessionPickerAction::Close,
+            _ => SessionPickerAction::None,
+        }
+    }
+
+    /// Render the session picker as an overlay centred in `area`.
+    pub fn render(&mut self, frame: &mut Frame, area: Rect) {
+        let popup = centered_rect(80, 70, area);
+        frame.render_widget(Clear, popup);
+
+        let items: Vec<ListItem> = self
+            .sessions
+            .iter()
+            .map(|s| {
+                let preview = if s.first_user_message.is_empty() {
+                    "(no messages)".to_string()
+                } else {
+                    let truncated: String =
+                        s.first_user_message.chars().take(60).collect::<String>();
+                    if s.first_user_message.chars().count() > 60 {
+                        format!("{}…", truncated)
+                    } else {
+                        truncated
+                    }
+                };
+                ListItem::new(format!("{}  {}", &s.id[..8], preview))
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Sessions (j/k to navigate, Enter to open, q to close) "),
+            )
+            .highlight_style(
+                Style::default()
+                    .bg(Color::Blue)
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("> ");
+
+        frame.render_stateful_widget(list, popup, &mut self.state);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SessionPickerAction {
+    None,
+    Select(String),
+    Close,
+}
+
+/// Compute a centred rectangle that is `percent_x`% wide and `percent_y`% tall of `r`.
+fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let w = r.width * percent_x / 100;
+    let h = r.height * percent_y / 100;
+    let x = r.x + (r.width.saturating_sub(w)) / 2;
+    let y = r.y + (r.height.saturating_sub(h)) / 2;
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::time::SystemTime;
+
+    fn make_session(id: &str, first_msg: &str) -> SessionSummary {
+        SessionSummary {
+            id: id.to_string(),
+            first_user_message: first_msg.to_string(),
+            modified: SystemTime::UNIX_EPOCH,
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn new_picker_selects_first_item() {
+        let sessions = vec![
+            make_session("01900000-0000-7000-0000-000000000001", "hello"),
+            make_session("01900000-0000-7000-0000-000000000002", "world"),
+        ];
+        let picker = SessionPicker::new(sessions);
+        assert_eq!(
+            picker.selected_id(),
+            Some("01900000-0000-7000-0000-000000000001")
+        );
+    }
+
+    #[test]
+    fn new_picker_with_empty_list_has_no_selection() {
+        let picker = SessionPicker::new(vec![]);
+        assert_eq!(picker.selected_id(), None);
+    }
+
+    #[test]
+    fn j_moves_selection_down() {
+        let sessions = vec![
+            make_session("01900000-0000-7000-0000-000000000001", "a"),
+            make_session("01900000-0000-7000-0000-000000000002", "b"),
+            make_session("01900000-0000-7000-0000-000000000003", "c"),
+        ];
+        let mut picker = SessionPicker::new(sessions);
+        picker.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(
+            picker.selected_id(),
+            Some("01900000-0000-7000-0000-000000000002")
+        );
+        picker.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(
+            picker.selected_id(),
+            Some("01900000-0000-7000-0000-000000000003")
+        );
+    }
+
+    #[test]
+    fn j_at_bottom_clamps() {
+        let sessions = vec![
+            make_session("01900000-0000-7000-0000-000000000001", "a"),
+            make_session("01900000-0000-7000-0000-000000000002", "b"),
+        ];
+        let mut picker = SessionPicker::new(sessions);
+        picker.handle_key(key(KeyCode::Char('j')));
+        picker.handle_key(key(KeyCode::Char('j')));
+        picker.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(
+            picker.selected_id(),
+            Some("01900000-0000-7000-0000-000000000002")
+        );
+    }
+
+    #[test]
+    fn k_moves_selection_up() {
+        let sessions = vec![
+            make_session("01900000-0000-7000-0000-000000000001", "a"),
+            make_session("01900000-0000-7000-0000-000000000002", "b"),
+        ];
+        let mut picker = SessionPicker::new(sessions);
+        picker.handle_key(key(KeyCode::Char('j')));
+        picker.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(
+            picker.selected_id(),
+            Some("01900000-0000-7000-0000-000000000001")
+        );
+    }
+
+    #[test]
+    fn k_at_top_clamps() {
+        let sessions = vec![
+            make_session("01900000-0000-7000-0000-000000000001", "a"),
+            make_session("01900000-0000-7000-0000-000000000002", "b"),
+        ];
+        let mut picker = SessionPicker::new(sessions);
+        picker.handle_key(key(KeyCode::Char('k')));
+        picker.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(
+            picker.selected_id(),
+            Some("01900000-0000-7000-0000-000000000001")
+        );
+    }
+
+    #[test]
+    fn enter_returns_select_action_with_id() {
+        let sessions = vec![make_session(
+            "01900000-0000-7000-0000-000000000001",
+            "hello",
+        )];
+        let mut picker = SessionPicker::new(sessions);
+        let action = picker.handle_key(key(KeyCode::Enter));
+        assert_eq!(
+            action,
+            SessionPickerAction::Select("01900000-0000-7000-0000-000000000001".to_string())
+        );
+    }
+
+    #[test]
+    fn enter_on_empty_list_returns_none() {
+        let mut picker = SessionPicker::new(vec![]);
+        let action = picker.handle_key(key(KeyCode::Enter));
+        assert_eq!(action, SessionPickerAction::None);
+    }
+
+    #[test]
+    fn q_returns_close_action() {
+        let sessions = vec![make_session(
+            "01900000-0000-7000-0000-000000000001",
+            "hello",
+        )];
+        let mut picker = SessionPicker::new(sessions);
+        let action = picker.handle_key(key(KeyCode::Char('q')));
+        assert_eq!(action, SessionPickerAction::Close);
+    }
+
+    #[test]
+    fn unknown_key_returns_none() {
+        let sessions = vec![make_session(
+            "01900000-0000-7000-0000-000000000001",
+            "hello",
+        )];
+        let mut picker = SessionPicker::new(sessions);
+        let action = picker.handle_key(key(KeyCode::Char('x')));
+        assert_eq!(action, SessionPickerAction::None);
+    }
+
+    #[test]
+    fn render_session_picker_empty() {
+        let mut picker = SessionPicker::new(vec![]);
+
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                picker.render(frame, area);
+            })
+            .expect("draw");
+
+        insta::assert_snapshot!("session_picker_empty", terminal.backend());
+    }
+
+    #[test]
+    fn render_session_picker_with_sessions() {
+        let sessions = vec![
+            SessionSummary {
+                id: "01900000-0000-7000-0000-000000000001".to_string(),
+                first_user_message: "Hello, can you help me write a Rust function?".to_string(),
+                modified: SystemTime::UNIX_EPOCH,
+            },
+            SessionSummary {
+                id: "01900000-0000-7000-0000-000000000002".to_string(),
+                first_user_message: "Explain the borrow checker".to_string(),
+                modified: SystemTime::UNIX_EPOCH,
+            },
+            SessionSummary {
+                id: "01900000-0000-7000-0000-000000000003".to_string(),
+                first_user_message: "".to_string(),
+                modified: SystemTime::UNIX_EPOCH,
+            },
+        ];
+        let mut picker = SessionPicker::new(sessions);
+
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                picker.render(frame, area);
+            })
+            .expect("draw");
+
+        insta::assert_snapshot!("session_picker_with_sessions", terminal.backend());
+    }
+
+    #[test]
+    fn render_session_picker_second_item_selected() {
+        let sessions = vec![
+            SessionSummary {
+                id: "01900000-0000-7000-0000-000000000001".to_string(),
+                first_user_message: "First session message".to_string(),
+                modified: SystemTime::UNIX_EPOCH,
+            },
+            SessionSummary {
+                id: "01900000-0000-7000-0000-000000000002".to_string(),
+                first_user_message: "Second session message".to_string(),
+                modified: SystemTime::UNIX_EPOCH,
+            },
+        ];
+        let mut picker = SessionPicker::new(sessions);
+        picker.move_down();
+
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                picker.render(frame, area);
+            })
+            .expect("draw");
+
+        insta::assert_snapshot!("session_picker_second_selected", terminal.backend());
+    }
+}

--- a/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__session_picker__tests__session_picker_empty.snap
+++ b/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__session_picker__tests__session_picker_empty.snap
@@ -1,0 +1,28 @@
+---
+source: src/frontend/tui/session_picker.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"        ┌ Sessions (j/k to navigate, Enter to open, q to close) ───────┐        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        └──────────────────────────────────────────────────────────────┘        "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "

--- a/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__session_picker__tests__session_picker_second_selected.snap
+++ b/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__session_picker__tests__session_picker_second_selected.snap
@@ -1,0 +1,28 @@
+---
+source: src/frontend/tui/session_picker.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"        ┌ Sessions (j/k to navigate, Enter to open, q to close) ───────┐        "
+"        │  01900000  First session message                             │        "
+"        │> 01900000  Second session message                            │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        └──────────────────────────────────────────────────────────────┘        "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "

--- a/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__session_picker__tests__session_picker_with_sessions.snap
+++ b/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__session_picker__tests__session_picker_with_sessions.snap
@@ -1,0 +1,28 @@
+---
+source: src/frontend/tui/session_picker.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"        ┌ Sessions (j/k to navigate, Enter to open, q to close) ───────┐        "
+"        │> 01900000  Hello, can you help me write a Rust function?     │        "
+"        │  01900000  Explain the borrow checker                        │        "
+"        │  01900000  (no messages)                                     │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        │                                                              │        "
+"        └──────────────────────────────────────────────────────────────┘        "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -19,8 +19,10 @@ use tokio::task::JoinHandle;
 
 use super::conversation_area::{ConversationArea, ConversationEntry, ConversationRole};
 use super::input_area::{InputArea, InputMode};
+use super::session_picker::{SessionPicker, SessionPickerAction};
 use crate::agent::Agent;
 use crate::logging::Logger;
+use crate::session::list_sessions;
 use crate::tools::ToolRegistry;
 use crate::types::{AgentEvent, ConfirmationResponse};
 
@@ -32,6 +34,7 @@ pub enum AppState {
         name: String,
         input: serde_json::Value,
     },
+    SessionPicker,
 }
 
 pub struct App {
@@ -43,6 +46,7 @@ pub struct App {
     pub scroll_offset: u16,
     pub viewport_height: u16,
     pub text_width: u16,
+    pub session_picker: Option<SessionPicker>,
     tools: std::sync::Arc<ToolRegistry>,
 }
 
@@ -58,6 +62,7 @@ impl App {
                     input: input.clone(),
                 });
             }
+            AppState::SessionPicker => self.input.set_mode(InputMode::Streaming),
         }
     }
 
@@ -71,6 +76,7 @@ impl App {
             scroll_offset: 0,
             viewport_height: 0,
             text_width: 0,
+            session_picker: None,
             tools,
         }
     }
@@ -211,6 +217,10 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
     conv_area.render(frame, chunks[0], text_width);
 
     app.input.render(frame, chunks[1]);
+
+    if let Some(ref mut picker) = app.session_picker {
+        picker.render(frame, frame.area());
+    }
 }
 
 pub fn handle_agent_event(
@@ -298,6 +308,7 @@ pub async fn run(
     agent: Arc<Agent>,
     initial_prompt: Option<String>,
     logger: Option<Logger>,
+    sessions_dir: std::path::PathBuf,
 ) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -305,7 +316,7 @@ pub async fn run(
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_app(&mut terminal, agent, initial_prompt, logger).await;
+    let result = run_app(&mut terminal, agent, initial_prompt, logger, sessions_dir).await;
 
     disable_raw_mode()?;
     execute!(
@@ -323,6 +334,7 @@ async fn run_app(
     agent: Arc<Agent>,
     initial_prompt: Option<String>,
     mut logger: Option<Logger>,
+    sessions_dir: std::path::PathBuf,
 ) -> Result<()> {
     let mut app = App::new(agent.tools());
     // we load just the session history here to avoid printing the loaded context messages from
@@ -368,7 +380,21 @@ async fn run_app(
                                     ..
                                 } => {
                                     let text = app.input_text();
-                                    if !text.trim().is_empty() {
+                                    if text.trim() == "/sessions" {
+                                        app.input.clear();
+                                        match list_sessions(&sessions_dir).await {
+                                            Ok(sessions) => {
+                                                app.session_picker = Some(SessionPicker::new(sessions));
+                                                app.set_state(AppState::SessionPicker);
+                                            }
+                                            Err(e) => {
+                                                app.conversation.push(ConversationEntry::new(
+                                                    ConversationRole::Error,
+                                                    format!("Failed to list sessions: {e}"),
+                                                ));
+                                            }
+                                        }
+                                    } else if !text.trim().is_empty() {
                                         if let Some(ref mut log) = logger {
                                             log.log_user_input(&text)?;
                                         }
@@ -378,6 +404,60 @@ async fn run_app(
                                 }
                                 _ => {
                                     app.input.input(key);
+                                }
+                            }
+                        },
+                        AppState::SessionPicker => {
+                            if let KeyEvent {
+                                code: KeyCode::Char('c'),
+                                modifiers: KeyModifiers::CONTROL,
+                                ..
+                            } = key {
+                                break;
+                            }
+                            if let Some(ref mut picker) = app.session_picker {
+                                let action = picker.handle_key(key);
+                                match action {
+                                    SessionPickerAction::Close => {
+                                        app.session_picker = None;
+                                        app.set_state(AppState::Input);
+                                    }
+                                    SessionPickerAction::Select(session_id) => {
+                                        app.session_picker = None;
+                                        app.set_state(AppState::Input);
+                                        // Reload the selected session
+                                        match crate::session::Session::new(
+                                            Some(session_id.clone()),
+                                            sessions_dir.clone(),
+                                        )
+                                        .await
+                                        {
+                                            Ok(session) => {
+                                                match session.load_history().await {
+                                                    Ok(history) => {
+                                                        app.conversation.clear();
+                                                        app.current_response.clear();
+                                                        app.scroll_offset = 0;
+                                                        app.load_history(&history);
+                                                        agent.load_session(session).await;
+                                                    }
+                                                    Err(e) => {
+                                                        app.conversation.push(ConversationEntry::new(
+                                                            ConversationRole::Error,
+                                                            format!("Failed to load session history: {e}"),
+                                                        ));
+                                                    }
+                                                }
+                                            }
+                                            Err(e) => {
+                                                app.conversation.push(ConversationEntry::new(
+                                                    ConversationRole::Error,
+                                                    format!("Failed to open session: {e}"),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    SessionPickerAction::None => {}
                                 }
                             }
                         },

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -461,6 +461,13 @@ async fn run_app(
                                     SessionPickerAction::Select(session_id) => {
                                         app.session_picker = None;
                                         app.set_state(AppState::Input);
+                                        // Clean up current session if empty
+                                        if let Err(e) = agent.cleanup_empty_session().await {
+                                            app.conversation.push(ConversationEntry::new(
+                                                ConversationRole::Error,
+                                                format!("Failed to clean up empty session: {e}"),
+                                            ));
+                                        }
                                         // Reload the selected session
                                         match crate::session::Session::new(
                                             Some(session_id.clone()),
@@ -1014,7 +1021,6 @@ mod tests {
     async fn session_picker_select_clears_conversation_and_reloads_history() {
         use crate::agent::Agent;
         use crate::backend::LlmBackend;
-        use crate::session::SessionSummary;
         use crate::types::*;
         use async_trait::async_trait;
         use std::sync::Arc;
@@ -1102,6 +1108,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn regression_load_history_edit_file_with_zero_text_width_does_not_mangle_diff() {
         // Regression: load_history is called before the first render, so text_width
         // is 0. Previously this caused hunk headers to be truncated to "…".

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -62,7 +62,7 @@ impl App {
                     input: input.clone(),
                 });
             }
-            AppState::SessionPicker => self.input.set_mode(InputMode::Streaming),
+            AppState::SessionPicker => self.input.set_mode(InputMode::SessionPicker),
         }
     }
 
@@ -912,5 +912,158 @@ mod tests {
         let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
         app.load_history(&[]);
         assert!(app.conversation.is_empty());
+    }
+
+    #[test]
+    fn sessions_command_transitions_app_to_session_picker_state() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        app.session_picker = Some(crate::frontend::tui::SessionPicker::new(vec![]));
+        app.set_state(AppState::SessionPicker);
+        assert_eq!(app.state, AppState::SessionPicker);
+        assert!(app.session_picker.is_some());
+    }
+
+    #[test]
+    fn session_picker_close_transitions_back_to_input() {
+        use crate::frontend::tui::SessionPickerAction;
+        use crate::session::SessionSummary;
+        use std::time::SystemTime;
+
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        let summaries = vec![SessionSummary {
+            id: "01900000-0000-7000-0000-000000000001".to_string(),
+            first_user_message: "hello".to_string(),
+            modified: SystemTime::UNIX_EPOCH,
+        }];
+        app.session_picker = Some(crate::frontend::tui::SessionPicker::new(summaries));
+        app.set_state(AppState::SessionPicker);
+
+        // simulate Close action
+        let picker = app.session_picker.as_mut().expect("picker");
+        let action = picker.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('q'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(action, SessionPickerAction::Close);
+
+        // apply the action
+        if matches!(action, SessionPickerAction::Close) {
+            app.session_picker = None;
+            app.set_state(AppState::Input);
+        }
+
+        assert_eq!(app.state, AppState::Input);
+        assert!(app.session_picker.is_none());
+    }
+
+    #[test]
+    fn session_picker_esc_also_closes() {
+        use crate::frontend::tui::SessionPickerAction;
+        use crate::session::SessionSummary;
+        use std::time::SystemTime;
+
+        let summaries = vec![SessionSummary {
+            id: "01900000-0000-7000-0000-000000000001".to_string(),
+            first_user_message: "hello".to_string(),
+            modified: SystemTime::UNIX_EPOCH,
+        }];
+        let mut picker = crate::frontend::tui::SessionPicker::new(summaries);
+        let action = picker.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Esc,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(action, SessionPickerAction::Close);
+    }
+
+    #[tokio::test]
+    async fn session_picker_select_clears_conversation_and_reloads_history() {
+        use crate::agent::Agent;
+        use crate::backend::LlmBackend;
+        use crate::session::SessionSummary;
+        use crate::types::*;
+        use async_trait::async_trait;
+        use std::sync::Arc;
+
+        struct StubBackend;
+
+        #[async_trait]
+        impl LlmBackend for StubBackend {
+            async fn send_message(
+                &self,
+                _messages: &[Message],
+                _config: &RequestConfig,
+            ) -> anyhow::Result<BoxStream<anyhow::Result<StreamEvent>>> {
+                Ok(Box::pin(futures::stream::empty()))
+            }
+        }
+
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        // Create session with a known message
+        let session = crate::session::Session::new(None, dir_path.clone())
+            .await
+            .expect("session");
+        session
+            .insert_message(&Message::text(Role::User, "loaded message".to_string()))
+            .await
+            .expect("insert");
+
+        let agent = Arc::new(
+            Agent::new(
+                Box::new(StubBackend),
+                RequestConfig {
+                    model: "test".to_string(),
+                    max_tokens: 1024,
+                    tools: vec![],
+                },
+                crate::session::Session::new(None, dir_path.clone())
+                    .await
+                    .expect("initial session"),
+            )
+            .await,
+        );
+
+        let mut app = App::new(agent.tools());
+        // pre-populate conversation with stale data
+        app.conversation.push(ConversationEntry::new(
+            ConversationRole::User,
+            "old message".to_string(),
+        ));
+        app.scroll_offset = 10;
+
+        // simulate selecting the session
+        let history = session.load_history().await.expect("load history");
+        app.conversation.clear();
+        app.current_response.clear();
+        app.scroll_offset = 0;
+        app.load_history(&history);
+        agent.load_session(session).await;
+
+        assert_eq!(app.conversation.len(), 1);
+        assert_eq!(app.conversation[0].content, "loaded message");
+        assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[test]
+    fn session_picker_select_returns_selected_id() {
+        use crate::frontend::tui::SessionPickerAction;
+        use crate::session::SessionSummary;
+        use std::time::SystemTime;
+
+        let summaries = vec![SessionSummary {
+            id: "01900000-0000-7000-0000-000000000001".to_string(),
+            first_user_message: "hello".to_string(),
+            modified: SystemTime::UNIX_EPOCH,
+        }];
+        let mut picker = crate::frontend::tui::SessionPicker::new(summaries);
+        let action = picker.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Enter,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert_eq!(
+            action,
+            SessionPickerAction::Select("01900000-0000-7000-0000-000000000001".to_string())
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,13 @@ async fn main() -> Result<()> {
             frontend::stdout::run(stream, confirm_tx, logger.as_mut()).await?;
         }
         Mode::Repl { initial_prompt } => {
-            frontend::tui::run(agent.clone(), initial_prompt, logger).await?;
+            frontend::tui::run(
+                agent.clone(),
+                initial_prompt,
+                logger,
+                app_config.sessions_dir,
+            )
+            .await?;
         }
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS conversation (
 pub struct Session {
     pub id: String,
     pub conn: Connection,
+    db_path: PathBuf,
 }
 
 impl Session {
@@ -129,13 +130,21 @@ impl Session {
             .with_context(|| format!("Failed to open session DB at {}", db_path.display()))?;
         let conn = db.connect()?;
         if !needs_migration {
-            return Ok(Self { id: sess_id, conn });
+            return Ok(Self {
+                id: sess_id,
+                conn,
+                db_path,
+            });
         }
         conn.execute(SCHEMA, ())
             .await
             .context("Failed to create conversation table")?;
 
-        Ok(Self { id: sess_id, conn })
+        Ok(Self {
+            id: sess_id,
+            conn,
+            db_path,
+        })
     }
 
     pub async fn insert_message(&self, message: &Message) -> Result<()> {
@@ -152,6 +161,39 @@ impl Session {
             )
             .await
             .context("Failed to insert message into session")?;
+        Ok(())
+    }
+
+    pub async fn is_empty(&self) -> Result<bool> {
+        let mut rows = self
+            .conn
+            .query("SELECT COUNT(*) FROM conversation", ())
+            .await
+            .context("Failed to count conversation messages")?;
+
+        if let Some(row) = rows.next().await? {
+            let count = match row.get_value(0)? {
+                Value::Integer(n) => n,
+                _ => return Ok(true),
+            };
+            return Ok(count == 0);
+        }
+
+        Ok(true)
+    }
+
+    pub fn delete_db(&self) -> Result<()> {
+        for suffix in ["", "-wal", "-shm"] {
+            let path = if suffix.is_empty() {
+                self.db_path.clone()
+            } else {
+                self.db_path.with_extension(format!("db{}", suffix))
+            };
+            if path.exists() {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            }
+        }
         Ok(())
     }
 
@@ -540,5 +582,67 @@ mod tests {
 
         let summaries = list_sessions(dir.path()).await.expect("list sessions");
         assert_eq!(summaries[0].first_user_message, "first message");
+    }
+
+    #[tokio::test]
+    async fn is_empty_returns_true_for_new_session() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        assert!(session.is_empty().await.expect("is_empty"));
+    }
+
+    #[tokio::test]
+    async fn is_empty_returns_false_after_inserting_message() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        session
+            .insert_message(&Message::text(Role::User, "hello".to_string()))
+            .await
+            .expect("insert");
+        assert!(!session.is_empty().await.expect("is_empty"));
+    }
+
+    #[tokio::test]
+    async fn delete_db_removes_db_file() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        let db_path = dir.path().join(format!("{}.db", session.id));
+        assert!(db_path.exists());
+
+        session.delete_db().expect("delete_db");
+        assert!(!db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn delete_db_removes_wal_and_shm_sidecars() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+
+        let wal_path = dir.path().join(format!("{}.db-wal", session.id));
+        let shm_path = dir.path().join(format!("{}.db-shm", session.id));
+        std::fs::write(&wal_path, b"fake wal").expect("write wal");
+        std::fs::write(&shm_path, b"fake shm").expect("write shm");
+
+        session.delete_db().expect("delete_db");
+        assert!(!wal_path.exists());
+        assert!(!shm_path.exists());
+    }
+
+    #[tokio::test]
+    async fn delete_db_succeeds_when_no_sidecars_exist() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        // No WAL/SHM files — should still succeed
+        session.delete_db().expect("delete_db");
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,8 +1,103 @@
 use anyhow::{Context, Result, bail};
 use std::path::PathBuf;
+use std::time::SystemTime;
 use turso::{Builder, Connection, Value};
 
 use crate::types::{ContentBlock, Message, Role};
+
+/// Summary of a session, used for the session picker.
+#[derive(Debug, Clone)]
+pub struct SessionSummary {
+    pub id: String,
+    pub first_user_message: String,
+    pub modified: SystemTime,
+}
+
+/// List all sessions in the given directory, ordered by most recently modified first.
+/// Each summary includes the session ID and the first user message text.
+pub async fn list_sessions(session_dir: &std::path::Path) -> Result<Vec<SessionSummary>> {
+    let mut summaries = Vec::new();
+
+    let read_dir = match std::fs::read_dir(session_dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "Failed to read sessions directory: {}",
+                    session_dir.display()
+                )
+            });
+        }
+    };
+
+    for entry in read_dir {
+        let entry = entry.context("Failed to read directory entry")?;
+        let path = entry.path();
+
+        if path.extension().and_then(|e| e.to_str()) != Some("db") {
+            continue;
+        }
+
+        let file_stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+
+        if validate_uuidv7(&file_stem).is_err() {
+            continue;
+        }
+
+        let modified = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        let first_user_message = read_first_user_message(&path).await.unwrap_or_default();
+
+        summaries.push(SessionSummary {
+            id: file_stem,
+            first_user_message,
+            modified,
+        });
+    }
+
+    summaries.sort_by(|a, b| b.modified.cmp(&a.modified));
+
+    Ok(summaries)
+}
+
+async fn read_first_user_message(db_path: &std::path::Path) -> Result<String> {
+    let db = Builder::new_local(db_path.to_string_lossy().as_ref())
+        .build()
+        .await
+        .with_context(|| format!("Failed to open session DB at {}", db_path.display()))?;
+    let conn = db.connect()?;
+
+    let mut rows = conn
+        .query(
+            "SELECT content FROM conversation WHERE role = 'user' ORDER BY id ASC LIMIT 1",
+            (),
+        )
+        .await
+        .context("Failed to query first user message")?;
+
+    if let Some(row) = rows.next().await? {
+        let content_str = match row.get_value(0)? {
+            Value::Text(s) => s,
+            _ => return Ok(String::new()),
+        };
+        let blocks: Vec<ContentBlock> =
+            serde_json::from_str(&content_str).context("Failed to deserialize content blocks")?;
+        for block in blocks {
+            if let ContentBlock::Text(text) = block {
+                return Ok(text);
+            }
+        }
+    }
+
+    Ok(String::new())
+}
 
 const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS conversation (
@@ -311,5 +406,139 @@ mod tests {
             validate_uuidv7(&session.id).is_ok(),
             "auto-generated session ID should be valid UUIDv7"
         );
+    }
+
+    #[tokio::test]
+    async fn list_sessions_returns_empty_for_nonexistent_dir() {
+        let dir = TempDir::new().expect("temp dir");
+        let missing = dir.path().join("nonexistent");
+        let summaries = list_sessions(&missing).await.expect("should not error");
+        assert!(summaries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_sessions_returns_empty_for_empty_dir() {
+        let dir = TempDir::new().expect("temp dir");
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert!(summaries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_sessions_returns_summaries_with_first_user_message() {
+        let dir = TempDir::new().expect("temp dir");
+
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        session
+            .insert_message(&Message::text(Role::User, "hello world".to_string()))
+            .await
+            .expect("insert");
+
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, session.id);
+        assert_eq!(summaries[0].first_user_message, "hello world");
+    }
+
+    #[tokio::test]
+    async fn list_sessions_ignores_non_db_files() {
+        let dir = TempDir::new().expect("temp dir");
+
+        std::fs::write(dir.path().join("notes.txt"), b"hello").expect("write file");
+        std::fs::write(dir.path().join("config.toml"), b"[foo]").expect("write file");
+
+        Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert_eq!(summaries.len(), 1, "only the .db file should be listed");
+    }
+
+    #[tokio::test]
+    async fn list_sessions_ignores_db_files_with_non_uuidv7_names() {
+        let dir = TempDir::new().expect("temp dir");
+
+        std::fs::write(dir.path().join("not-a-uuid.db"), b"garbage").expect("write file");
+
+        Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert_eq!(
+            summaries.len(),
+            1,
+            "only the valid UUID-named .db file should appear"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_sessions_orders_by_most_recently_modified_first() {
+        let dir = TempDir::new().expect("temp dir");
+
+        let session_a = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create a");
+        session_a
+            .insert_message(&Message::text(Role::User, "first session".to_string()))
+            .await
+            .expect("insert a");
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let session_b = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create b");
+        session_b
+            .insert_message(&Message::text(Role::User, "second session".to_string()))
+            .await
+            .expect("insert b");
+
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(
+            summaries[0].id, session_b.id,
+            "most recently modified should be first"
+        );
+        assert_eq!(summaries[1].id, session_a.id);
+    }
+
+    #[tokio::test]
+    async fn list_sessions_empty_message_for_session_with_no_messages() {
+        let dir = TempDir::new().expect("temp dir");
+
+        Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].first_user_message, "");
+    }
+
+    #[tokio::test]
+    async fn list_sessions_returns_only_first_user_message_text() {
+        let dir = TempDir::new().expect("temp dir");
+
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        session
+            .insert_message(&Message::text(Role::User, "first message".to_string()))
+            .await
+            .expect("insert 1");
+        session
+            .insert_message(&Message::text(Role::Assistant, "response".to_string()))
+            .await
+            .expect("insert 2");
+        session
+            .insert_message(&Message::text(Role::User, "second message".to_string()))
+            .await
+            .expect("insert 3");
+
+        let summaries = list_sessions(dir.path()).await.expect("list sessions");
+        assert_eq!(summaries[0].first_user_message, "first message");
     }
 }


### PR DESCRIPTION
## Summary

Implements session management as described in issue #102.

## Changes

### `src/session.rs`
- Add `SessionSummary` struct: holds `id`, `first_user_message`, and `modified` (filesystem mtime)
- Add `list_sessions(dir)`: reads all UUID-v7-named `.db` files in the sessions directory, extracts the first user message from each, and returns summaries sorted by most-recently-modified first
- Add `read_first_user_message` (private): opens a session DB and returns the first `user` role text block

### `src/frontend/tui/session_picker.rs` (new)
- `SessionPicker` widget: holds a list of `SessionSummary` and a `ListState`
- Vim-style navigation: `j` / `k` move the selection; selection clamps at the top and bottom
- `Enter` returns `SessionPickerAction::Select(id)`; `q` returns `SessionPickerAction::Close`
- Renders as a centred popup overlay (80% × 70% of the terminal) with a bordered list
- Each row shows the first 8 chars of the session ID plus up to 60 chars of the first user message ("(no messages)" when empty)
- Insta snapshot tests for empty, populated, and second-item-selected states

### `src/frontend/tui/tui_app.rs`
- New `AppState::SessionPicker` variant
- Input state handles the `/sessions` command: calls `list_sessions`, opens the picker overlay
- New key-handler branch for `AppState::SessionPicker`: delegates to `SessionPicker::handle_key`; on `Select` reloads the chosen session via `Agent::load_session` and refreshes the conversation view; on `Close` returns to `Input`
- `render_app` draws the picker overlay on top of the normal TUI when `app.session_picker` is `Some`
- `run` and `run_app` now accept `sessions_dir: PathBuf`

### `src/agent.rs`
- `Agent::load_session`: swaps the active session and resets in-memory history to the new session's persisted messages

### `src/main.rs`
- Threads `app_config.sessions_dir` into `frontend::tui::run`

## Acceptance Criteria

- [x] `/sessions` command opens a session list overlay
- [x] List populated from the config's `sessions_dir`
- [x] Entries show session ID + first user message (not just the ID)
- [x] Ordered by date of last update (most recent first)
- [x] `j` / `k` to navigate, `Enter` to select, `q` to close
- [x] Tests (unit + insta snapshots)

Closes #102