### PR TITLE
Add mach6 development workflow skills

### DIFF
--- a/.claude/skills/mach6-implement/SKILL.md
+++ b/.claude/skills/mach6-implement/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: mach6-implement
+description: "Implement a plan from a PR, or fix review findings / CI failures. Usage: mach6-implement 42 [finding-numbers] or mach6-implement 42 ci"
+argument-hint: "<pr-number> [finding-numbers | ci]"
+---
+
+# mach6-implement — Implement Plans, Fix Findings, or Fix CI
+
+**User input:** $ARGUMENTS
+
+This skill has two modes:
+- **Implement mode** (just a PR number): reads the plan comment and implements it
+- **Fix mode** (with finding numbers or `ci`): fixes specific review findings or CI failures
+
+## Global Rules
+
+1. **GitHub as shared memory** — Plans, reviews, and assessments are on the PR as comments with HTML markers.
+2. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
+3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
+
+## Step 1: Parse input
+
+Extract:
+- **PR number** (required)
+- **Finding numbers** to fix (optional — e.g., `1,2,3`)
+- **`ci`** flag (optional — fix CI failures instead of review findings)
+
+If only a PR number is given → **implement mode**.
+If finding numbers or `ci` → **fix mode**.
+
+## Step 2: Checkout
+
+```bash
+gh pr checkout <pr-number>
+git pull
+```
+
+---
+
+## Implement Mode (PR number only)
+
+### Step 3i: Read the plan and full PR context
+
+Read ALL PR comments and the PR body to get complete context:
+```bash
+gh pr view <pr-number> --json title,body,comments
+```
+
+Find the plan comment (contains `<!-- mach6-plan -->` marker) from the comments. If no plan comment exists, tell the user and suggest running `/skill:mach6-plan` first.
+
+Also read any progress updates, prior review findings, assessments, and discussion — all of this context informs implementation.
+
+### Step 4i: Read the codebase
+
+Read all files mentioned in the plan. Understand the existing code before making changes.
+
+### Step 5i: Implement
+
+Implement each deliverable directly using the available tools (read, edit, write, bash, search, grep, find, ls).
+
+**For each deliverable in the plan**:
+- Identify the specific files to modify and what changes are needed
+- Read existing code for understanding
+- Make the changes using edit_file, write_file, and bash tools
+- Run tests and linting after making changes
+- **If the plan includes tests for this deliverable, tests MUST be written as part of the implementation — not deferred**
+
+**Test coverage is part of the deliverable, not an afterthought.** If the plan specifies tests for a deliverable, implement them directly. If the target package lacks test infrastructure, add it.
+
+**Dependency ordering:** If deliverables are independent (don't modify the same files), you may work on them in any order. If they have dependencies, implement them sequentially — later features may depend on earlier ones.
+
+**Small plans (1-2 simple deliverables):** These should be straightforward to implement directly.
+
+### Step 6i: Verify
+
+After implementing all deliverables:
+- Run the project's test suite
+- Run any linting/formatting tools
+- Build the project if applicable
+- Verify each deliverable from the plan is addressed
+- If any issues remain, address the gaps
+
+Suggest next step: `/skill:mach6-push` then `/skill:mach6-review <pr-number>` for review.
+
+---
+
+## Fix Mode (finding numbers or `ci`)
+
+### Step 3f: Gather context
+
+#### If `ci` was specified:
+
+```bash
+gh pr checks <pr-number>
+gh run view <run-id> --log-failed
+```
+
+Read the failed CI logs and identify issues. Extract test failures, stack traces, error messages. If all checks pass, report this and stop.
+
+#### If finding numbers were specified:
+
+Read ALL PR comments to get full context:
+```bash
+gh pr view <pr-number> --json title,body,comments
+```
+
+Find the review (`<!-- mach6-review -->`) and assessment (`<!-- mach6-assessment -->`) comments, then extract the specific findings to fix. Prior progress comments and discussion may also provide useful context.
+
+#### If no finding numbers and not `ci`:
+
+Read ALL PR comments, find review/assessment comments, present genuine findings, and ask which to fix.
+
+### Step 4f: Batch sizing
+
+- **Simple fixes** (typos, naming, imports): ~10 per batch
+- **Moderate fixes** (logic changes, refactors): ~6 per batch
+- **Complex fixes** (architecture, new features): ~3 per batch
+
+If more than batch size, fix first batch and tell user to re-run.
+
+### Step 5f: Implement fixes
+
+Implement fixes directly using the available tools (read, edit, write, bash, search, grep, find, ls).
+
+**For each finding** (or batch of related findings):
+- Understand the finding description and the assessment's classification/reasoning
+- Identify the specific files and code locations involved
+- Make the fixes using edit_file, write_file, and bash tools
+- Run tests after fixing
+
+**Simple fixes** (typos, naming, one-line changes): Fix these directly.
+
+Defer out-of-scope items to new issues.
+
+### Step 6f: Verify
+
+After implementing all fixes:
+- Run tests and linting
+- Verify each fix addresses its finding
+- If any issues remain, address the gaps
+
+Suggest next step: `/skill:mach6-push` then `/skill:mach6-review <pr-number>` for re-review.

--- a/.claude/skills/mach6-issue/SKILL.md
+++ b/.claude/skills/mach6-issue/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: mach6-issue
+description: "Assess an existing GitHub issue (explore codebase, identify scope/risks/ambiguities, post assessment) or create a new structured issue. Usage: mach6-issue 42 (assess) or mach6-issue (create) or mach6-issue <description> (create with context)"
+argument-hint: "[issue-number | description]"
+---
+
+# mach6-issue — Assess or Create Issue
+
+**User input:** $ARGUMENTS
+
+## Global Rules
+
+1. **GitHub as shared memory** — Plans, reviews, assessments, and progress are posted as PR/issue comments so any future session can pick up context.
+2. **HTML markers** — Use `<!-- mach6-assessment -->`, `<!-- mach6-plan -->`, `<!-- mach6-review -->`, `<!-- mach6-progress -->` as the first line of comment bodies for reliable discovery.
+3. **No `#N` in comment bodies** — GitHub auto-links `#N` to issues/PRs. Use "finding 3", "item 3", "stage 2" etc. instead.
+4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets (.env, credentials, tokens, keys).
+5. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning or implementing.
+
+## Determine Mode
+
+If the input is a number, run **ASSESS** mode. Otherwise, run **CREATE** mode.
+
+---
+
+## ASSESS Mode
+
+**Assess an existing GitHub issue — explore the codebase, identify scope/risks/ambiguities, post assessment.**
+
+### Step 1: Read the issue
+
+```bash
+gh issue view <number>
+gh issue view <number> --comments
+```
+
+Parse: problem statement, constraints, requirements, acceptance criteria, prior discussion, linked PRs.
+
+### Step 2: Explore the codebase
+
+Explore the codebase directly using the available tools (search, grep, find, read, ls) to understand:
+- **Relevant code**: Find existing code related to the issue, trace implementation patterns
+- **Architecture**: Map relevant architecture layers, abstractions, data flow
+- **Prior work**: Check for related branches, PRs, or commits
+
+Identify 5-10 key files and read them thoroughly.
+
+### Step 3: Assess
+
+Present to the user:
+1. **Summary**: The issue in your own words
+2. **Current state**: What exists today that's relevant
+3. **Gaps**: What's missing, broken, or unclear
+4. **Ambiguities**: Underspecified aspects or open questions
+5. **Scope**: Size and complexity estimate
+6. **Risks**: Pitfalls, edge cases, architectural concerns
+
+### Step 4: Post assessment
+
+Post as an issue comment:
+
+```bash
+gh issue comment <number> --body "<!-- mach6-assessment -->
+## Issue Assessment
+
+<assessment content>
+
+---
+*Automated assessment by mach6*"
+```
+
+Suggest next step: `/skill:mach6-plan <number>`
+
+---
+
+## CREATE Mode
+
+**Create a new structured GitHub issue from context or description.**
+
+### Step 1: Gather context
+
+If a description was provided, use it as the starting point. Otherwise, ask the user what they want to create an issue for.
+
+Check if the repository has issue templates:
+```bash
+ls .github/ISSUE_TEMPLATE/ 2>/dev/null
+```
+If templates exist, read them and select the most appropriate one.
+
+Explore the codebase if needed to understand the relevant area.
+
+### Step 2: Draft the issue
+
+Create a structured issue with:
+- **Title**: Clear, concise, action-oriented (under 80 chars, imperative form)
+- **Summary**: 2-3 sentences describing the problem or feature
+- **Current Behavior** (for bugs/improvements): What happens now
+- **Proposed Behavior**: What should happen
+- **Acceptance Criteria**: Bullet list of verifiable conditions that define "done"
+- **Context**: Links to related PRs, issues, or discussions
+- **Technical Notes**: Implementation hints, relevant files, architectural considerations
+- **Labels**: Suggest appropriate labels based on the issue type
+
+Present the draft to the user for approval.
+
+### Step 3: Create the issue
+
+```bash
+gh issue create --title "<title>" --body "<body>" [--label "<labels>"]
+```
+
+Report the issue number and URL. Suggest next step: `/skill:mach6-plan <number>`

--- a/.claude/skills/mach6-plan/SKILL.md
+++ b/.claude/skills/mach6-plan/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: mach6-plan
+description: "Explore codebase, create implementation plan, create feature branch with dummy commit, open draft PR, post plan as PR comment. Everything lives on the PR from this point forward. Usage: mach6-plan 42"
+argument-hint: "<issue-number>"
+---
+
+# mach6-plan — Plan, Branch, and Open PR
+
+**User input:** $ARGUMENTS
+
+This command is strictly for **planning**. Do NOT implement any code changes — no file edits, no file writes.
+
+## Global Rules
+
+1. **GitHub as shared memory** — Plans, reviews, assessments, and progress are posted as PR/issue comments so any future session can pick up context.
+2. **HTML markers** — Use `<!-- mach6-plan -->` as the first line of plan comment bodies for reliable discovery.
+3. **No `#N` in comment bodies** — GitHub auto-links `#N` to issues/PRs. Use "finding 3", "item 3", "stage 2" etc. instead.
+4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
+5. **Project conventions** — Check for CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md, and CONTRIBUTING.md before planning.
+
+## Step 1: Read the issue
+
+```bash
+gh issue view <number>
+gh issue view <number> --comments
+```
+
+Parse everything: problem statement, constraints, requirements, acceptance criteria, prior discussion, any existing assessment comments (look for `<!-- mach6-assessment -->`).
+
+## Step 2: Read project conventions
+
+Check for and read (first found):
+- CONTRIBUTING.md, DEVELOPMENT.md, .github/CONTRIBUTING.md
+- CLAUDE.md, AGENTS.md, .dreb/CONTEXT.md
+
+Extract planning-relevant guidance: project layers, testing expectations, coding conventions.
+
+## Step 3: Explore the codebase
+
+Explore the codebase directly using the available tools (search, grep, find, read, ls) to understand:
+- **Similar features**: Find existing code that solves related problems, trace implementation patterns
+- **Architecture**: Map relevant architecture layers, abstractions, data flow
+- **Integration points**: Identify where new code connects to existing systems
+
+Include project conventions in your exploration. Identify 5-10 key files and read them thoroughly.
+
+## Step 4: Draft the plan
+
+Create an implementation plan with:
+- Clear analysis of the problem
+- **Deliverables**: What will be produced (be specific)
+- **Acceptance criteria**: How to verify the work is done
+- **Files to create or modify**: List each with what changes
+- **Testing approach**: What tests to write, what to verify
+- **Risks and open questions**: Anything that might derail implementation
+
+The plan should be **high-level on implementation details** (avoid cascading spec errors from over-specifying) but **specific on deliverables and acceptance criteria**.
+
+**Project-layer coverage:** Cross-check the plan against discovered project layers. Every affected layer should be addressed.
+
+**Test coverage is mandatory, not optional.** Every new behavior, command handler, formatting function, or event wiring must include tests in the plan. If the target package lacks test infrastructure, the plan must include setting it up as a deliverable — this cannot be deferred. The testing approach should specify:
+- Which test files to create or modify
+- What behaviors to verify (happy paths, error paths, edge cases)
+- What test infrastructure/helpers are needed (mocks, factories, fixtures)
+
+Present the plan to the user. Discuss and revise if they have feedback.
+
+## Step 5: Create branch and draft PR
+
+```bash
+# Derive branch name from issue
+# Format: feature/issue-<N>-<slug> (slug = 3-5 words from title, lowercase, hyphens)
+git checkout -b feature/issue-<N>-<slug>
+
+# Create an empty commit so the PR can be opened
+git commit --allow-empty -m "chore: open PR for issue <N>"
+
+git push -u origin feature/issue-<N>-<slug>
+
+# Open draft PR
+gh pr create --draft --title "<title>" --body "Closes #<N>
+
+<brief description>
+
+Implementation plan posted as a comment below."
+```
+
+## Step 6: Post plan to PR
+
+```bash
+gh pr comment <pr-number> --body "<!-- mach6-plan -->
+## Implementation Plan
+
+<full plan content>
+
+---
+*Plan created by mach6*"
+```
+
+Suggest next step: implement the plan, then `/skill:mach6-push` when ready.

--- a/.claude/skills/mach6-publish/SKILL.md
+++ b/.claude/skills/mach6-publish/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: mach6-publish
+description: "Pre-merge checks, version bump, merge PR, git tag, GitHub release. Version bump happens BEFORE merge (on the feature branch) because master requires PRs. Usage: mach6-publish 42"
+argument-hint: "<pr-number>"
+---
+
+# mach6-publish — Version Bump, Merge, Tag, and Release
+
+**User input:** $ARGUMENTS
+
+## Global Rules
+
+1. **GitHub as shared memory** — All context lives on the PR.
+2. **No `#N` in comment bodies** — Use "finding 3", "item 3" etc. instead.
+3. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets.
+
+## Step 1: Pre-merge checks
+
+```bash
+gh pr checkout <pr-number>
+git pull
+gh pr view <pr-number> --json mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,comments,body
+gh pr checks <pr-number>
+```
+
+Read ALL PR comments to understand the full history — plans, reviews, assessments, progress updates, and discussion.
+
+Verify:
+- [ ] CI is passing
+- [ ] No merge conflicts
+- [ ] All review findings addressed (check for genuine items in latest assessment)
+
+If there are blocking issues, report them and suggest fixes:
+- **Failed CI**: `/skill:mach6-implement <pr-number> ci`
+- **Merge conflicts**: Suggest resolving manually or rebasing
+- **Unaddressed findings**: `/skill:mach6-implement <pr-number>`
+
+### Pre-merge checklist
+
+Check for contributing guidelines first:
+```bash
+# Read first found: CONTRIBUTING.md, DEVELOPMENT.md, .github/CONTRIBUTING.md, AGENTS.md
+```
+
+Then check if these need attention:
+- [ ] Documentation updated (if behavior changed) — check README, docs/, docstrings, help text
+- [ ] Changelog updated (if project maintains one — check CHANGELOG.md, CHANGES.md)
+- [ ] Tests passing locally
+
+Present the checklist to the user. If items need attention, address them before proceeding.
+
+## Step 2: Version bump (on the feature branch — BEFORE merge)
+
+**This step is mandatory for projects with versioning.** The version bump MUST happen on the feature branch and be pushed as part of the PR, because the default branch requires PRs for all changes — you cannot push commits directly to it.
+
+1. Detect versioning:
+   ```bash
+   # Check for version files: package.json, Cargo.toml, pyproject.toml, version.txt, etc.
+   ```
+
+2. Determine the current version and what the new version should be. If the bump level isn't obvious from the PR context, **ask the user**:
+   - **Patch**: Bug fixes, minor improvements
+   - **Minor**: New features, non-breaking changes
+   - **Major**: Breaking changes
+
+3. Apply the version bump. Check AGENTS.md / CONTRIBUTING.md for project-specific version bump procedures (e.g., sync scripts, build steps that embed the version).
+
+4. Commit and push on the feature branch:
+   ```bash
+   git add <version-files>
+   git commit -m "chore: bump version to <new-version>"
+   git push
+   ```
+
+5. Wait for CI to pass on the version bump commit before proceeding to merge.
+
+If the project doesn't use versioning, skip this step.
+
+## Step 3: Update documentation
+
+Proactively review and update ALL documentation affected by the PR's changes. This is not limited to mach6 docs — check everything in the repo.
+
+1. Identify changed features by reading the PR diff:
+   ```bash
+   gh pr diff <pr-number>
+   ```
+
+2. Scan all documentation for references to changed features:
+   - README.md files across all packages
+   - docs/ directory (all .md files)
+   - AGENTS.md, CLAUDE.md, CONTRIBUTING.md, .dreb/CONTEXT.md
+   - Example files and their READMEs
+   - Help text and CLI flag documentation
+   - CHANGELOG.md or CHANGES.md
+
+3. For each doc, verify:
+   - CLI flags, settings, and commands match current code
+   - Code snippets and examples are accurate
+   - Cross-references point to real files and valid anchors
+   - No stale descriptions of removed or changed features
+   - Environment variables listed match current code
+
+4. Fix all inaccuracies found. Commit and push:
+   ```bash
+   git add <doc-files>
+   git commit -m "docs: update documentation for <version>"
+   git push
+   ```
+
+5. Wait for CI to pass on the docs commit.
+
+If no documentation changes are needed (rare), skip this step.
+
+## Step 4: Merge
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+Use `--squash` by default. If the user prefers a different merge strategy, they can specify.
+
+Then update local:
+```bash
+git checkout $(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+git pull
+```
+
+Clean up local feature branch if it still exists:
+```bash
+git branch -d <branch-name> 2>/dev/null
+```
+
+## Step 5: Tag and release
+
+Ask the user if they want to create a GitHub release:
+- **Yes**: Proceed with tagging and release
+- **No**: Skip — just create the tag
+
+### Always create the git tag
+
+The tag is created on the default branch after merge, using the version from Step 2:
+
+```bash
+git tag v<version>
+git push --tags
+```
+
+### If releasing
+
+1. Check existing releases for style:
+   ```bash
+   gh release list --limit 5
+   gh release view <latest-tag>  # if releases exist
+   ```
+
+2. Draft release notes from the PR description and comment thread. Match existing release note style.
+
+3. Present draft to user for approval, then create:
+   ```bash
+   gh release create v<version> --title "v<version>" --notes "<release-notes>"
+   ```
+
+## Step 6: Report
+
+Report: what was merged, tagged, released. Link to the PR and release.

--- a/.claude/skills/mach6-push/SKILL.md
+++ b/.claude/skills/mach6-push/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: mach6-push
+description: "Commit changes, push to remote, and post a progress comment on the associated PR or issue. Stages files by name (never git add -A), matches existing commit style, auto-detects PR from branch. Usage: mach6-push [optional commit message]"
+argument-hint: "[commit message]"
+---
+
+# mach6-push — Commit, Push, Progress Comment
+
+**User input:** $ARGUMENTS
+
+## Global Rules
+
+1. **GitHub as shared memory** — Progress is posted as PR/issue comments so any future session can pick up context.
+2. **HTML markers** — Use `<!-- mach6-progress -->` as the first line of progress comment bodies.
+3. **No `#N` in comment bodies** — Use "finding 3", "item 3", "stage 2" etc. instead.
+4. **Safe git** — Never use `git add -A` or `git add .`. Stage files by name. Never stage secrets (.env, credentials, tokens, keys).
+
+## Step 1: Stage changes
+
+Run `git status` and `git diff` to understand the current state.
+
+- If you have context from this session about which files were modified, stage those by name.
+- If files are already staged and look correct, proceed.
+- If unclear (fresh session, no context), review all changes and ask the user what to stage.
+- **Never** use `git add -A` or `git add .`
+- **Never** stage secrets (.env, credentials, tokens, keys)
+
+## Step 2: Commit
+
+Check recent commit style:
+```bash
+git log --oneline -10
+```
+
+Generate a commit message that:
+- Follows the repository's existing style
+- Summarizes the nature of the changes
+- Uses the user's override message if provided
+
+```bash
+git commit -m "<message>"
+```
+
+## Step 3: Push
+
+```bash
+git push
+```
+
+If no upstream is set, use `git push -u origin <branch>`.
+
+## Step 4: Post progress comment
+
+Detect the associated PR or issue:
+
+1. **Session context first**: If an earlier mach6 command in this session targeted a specific PR or issue, use that.
+2. **PR detection**: Try `gh pr view --json number,url` on current branch. If a PR exists, comment on it.
+3. **Branch name fallback**: Check branch name for issue number pattern (e.g., `feature/issue-55-*`). If found, comment on that issue.
+4. **Skip gracefully**: If neither works, skip commenting and inform the user.
+
+If session context points to an issue but a PR also exists on the current branch, prefer the PR.
+
+Post a progress comment:
+```bash
+gh pr comment <number> --body "<!-- mach6-progress -->
+## Progress Update
+
+<summary of changes in this batch>
+
+**Commit:** \`<hash>\`
+
+---
+*Progress tracked by mach6*"
+```
+
+Report: what was committed, where pushed, where the comment was posted (with link).
+
+Suggest next step based on context:
+- If on a feature branch with a PR: `/skill:mach6-review <pr-number>`
+- If on a feature branch without a PR: `/skill:mach6-plan <issue-number>` to create one
+- If on the default branch: issue-oriented next steps

--- a/.claude/skills/mach6-review/SKILL.md
+++ b/.claude/skills/mach6-review/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: mach6-review
+description: "Review a PR for code quality, errors, tests, completeness, and simplicity. Post findings as a PR comment, then do an independent assessment to separate genuine issues from nitpicks and false positives. Usage: mach6-review 42 [aspects]"
+argument-hint: "<pr-number> [code|errors|tests|completeness|simplify]"
+---
+
+# mach6-review — Multi-Aspect PR Review
+
+**User input:** $ARGUMENTS
+
+## Global Rules
+
+1. **GitHub as shared memory** — Reviews and assessments are posted as PR comments so any future session can pick up context.
+2. **HTML markers** — Use `<!-- mach6-review -->` and `<!-- mach6-assessment -->` as the first line of comment bodies.
+3. **No `#N` in comment bodies** — Use "finding 3", "item 3", "stage 2" etc. instead.
+
+**Important: Do NOT fix any issues in this session. Fixes happen via `/skill:mach6-implement`.**
+
+## Step 1: Parse input
+
+Extract:
+- **PR number** (required)
+- **Review aspects** (optional) — if specified, only run matching review aspects
+
+## Step 2: Prepare
+
+```bash
+gh pr checkout <pr-number>
+git pull
+```
+
+Mark the PR as ready for review (it was opened as a draft by mach6-plan):
+```bash
+gh pr ready <pr-number>
+```
+
+Gather PR context — read ALL comments, not just specific markers:
+```bash
+gh pr view <pr-number> --json title,body,comments,files
+gh pr diff <pr-number>
+```
+
+Read the PR description, ALL comments (plans, progress updates, prior reviews, discussion), and the linked issue. This full context must inform your review.
+
+## Step 3: Select and run review aspects
+
+**Available review aspects:**
+
+| Aspect | Question | When to run |
+|---|---|---|
+| `code` | "Does this code do what it should, correctly and idiomatically?" | Always |
+| `errors` | "What can go wrong silently at runtime?" | If error handling / fallback logic touched |
+| `tests` | "What behaviors are untested or poorly tested?" | If test files changed or testable code added |
+| `completeness` | "Does this PR deliver everything the linked issue requires?" | If PR links to an issue |
+| `simplify` | "Can this be expressed more clearly without changing behavior?" | Always (runs last, after others) |
+
+**Targeted review:** If the user specified aspects, only review matching aspects:
+- `code` → code quality review
+- `errors` → error handling review
+- `tests` → test coverage review
+- `completeness` → completeness review
+- `simplify` → simplification review
+
+For each aspect you run:
+- Read the actual changed files for full context
+- Look at surrounding code, not just the diff lines
+- Be specific about what you find
+- Use confidence scoring (0-100, only report findings ≥ 80)
+
+## Step 4: Post review findings
+
+Compile all findings into a single structured comment:
+
+```bash
+gh pr comment <pr-number> --body "<!-- mach6-review -->
+## Code Review
+
+### Critical
+<findings with severity: critical, if any>
+
+### Important
+<findings with severity: high, if any>
+
+### Suggestions
+<findings with severity: medium or low, if any>
+
+### Strengths
+<notable positive observations>
+
+**Aspects reviewed:** <list of aspects>
+
+---
+*Reviewed by mach6*"
+```
+
+## Step 5: Independent assessment
+
+Do your own independent assessment of the findings:
+
+- Read the actual code for each finding and verify independently
+- Classify each finding as:
+  - **Genuine issue** — Real problem, should fix before merge. Explain why.
+  - **Nitpick** — Stylistic, doesn't affect correctness. Explain why it doesn't matter.
+  - **False positive** — Not actually an issue. Explain why the code is correct.
+  - **Deferred** — Real issue but out of scope. Should track separately.
+
+If a finding was already addressed in prior commits or PR discussion, classify as false positive with a note.
+
+**Important guidance on "deferred" classifications:** Test coverage gaps should NOT be automatically deferred. If a PR adds new testable code, tests should ship with it — even if that means adding test infrastructure to a package that lacks it. Only defer tests when the gap is truly unrelated to the PR's changes (e.g., pre-existing untested code that the PR happens to touch). When tests are deferred, note whether a tracking issue exists or needs to be created.
+
+After classifying all findings, produce an **action plan** listing what to fix, in what order.
+
+## Step 6: Post assessment
+
+```bash
+gh pr comment <pr-number> --body "<!-- mach6-assessment -->
+## Review Assessment
+
+### Classifications
+
+| Finding | Classification | Reasoning |
+|---|---|---|
+| <summary> | genuine/nitpick/false-positive/deferred | <1-2 sentences> |
+
+### Action Plan
+
+<numbered list of what to fix, ordered by priority>
+
+---
+*Assessment by mach6*"
+```
+
+## Step 7: CLI summary
+
+Present to the user:
+- Per-finding breakdown: summary, classification, reasoning
+- Counts: genuine, nitpicks, false positives, deferred
+- Action plan
+
+If any findings were classified as **deferred**, ask the user if they want to create issues for them:
+```bash
+gh issue create --title "<title>" --body "<body referencing PR and finding>"
+```
+
+Suggest next step:
+- If genuine issues: `/skill:mach6-implement <pr-number> <finding-numbers>`
+- If all clear: `/skill:mach6-publish <pr-number>`


### PR DESCRIPTION
Surprise! 👋

This PR adds the [mach6](https://github.com/aebrer/dreb/blob/master/packages/coding-agent/docs/mach6.md) development workflow skills to your harness. mach6 is a structured GitHub-centric workflow that covers the full issue-to-release lifecycle:

- **mach6-issue** — Assess existing issues or create structured new ones
- **mach6-plan** — Explore the codebase, draft an implementation plan, open a draft PR, and post the plan
- **mach6-implement** — Implement a plan or fix review findings / CI failures
- **mach6-review** — Review a PR for code quality, errors, tests, completeness, and simplicity
- **mach6-push** — Safely commit, push, and post progress comments
- **mach6-publish** — Run pre-merge checks, version bump, merge, tag, and release

These have been adapted from the upstream dreb versions to work with illustrious-manager's existing toolset (no subagents or task-tracking tools required). They live alongside your existing `code-review` skill in `.claude/skills/`.

No code changes to the harness itself — purely additive skills. Feel free to accept, modify, or reject as you see fit!