### PR TITLE
feat: JSON output format for single-shot mode

### DIFF
--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -6,28 +6,63 @@ use std::io::{self, BufRead, IsTerminal, Write};
 use crate::logging::Logger;
 use crate::types::{AgentEvent, BoxStream, ConfirmationResponse};
 
+#[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
 pub async fn run(
     stream: BoxStream<AgentEvent>,
     confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,
+    format: OutputFormat,
     logger: Option<&mut Logger>,
 ) -> Result<()> {
     let is_tty = std::io::stdin().is_terminal();
     let stdout = io::stdout();
     let mut handle = stdout.lock();
     let mut stdin = io::BufReader::new(std::io::stdin());
-    run_with_writer(stream, &mut handle, confirm_tx, is_tty, &mut stdin, logger).await
+    run_with_writer(
+        stream,
+        &mut handle,
+        confirm_tx,
+        format,
+        is_tty,
+        &mut stdin,
+        logger,
+    )
+    .await
 }
 
 async fn run_with_writer<W: Write, R: BufRead>(
     mut stream: BoxStream<AgentEvent>,
     writer: &mut W,
     confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,
+    format: OutputFormat,
     is_tty: bool,
     stdin: &mut R,
     mut logger: Option<&mut Logger>,
 ) -> Result<()> {
+    match format {
+        OutputFormat::Text => {
+            run_text(&mut stream, writer, confirm_tx, is_tty, stdin, &mut logger).await
+        }
+        OutputFormat::Json => {
+            run_json(&mut stream, writer, confirm_tx, is_tty, stdin, &mut logger).await
+        }
+    }
+}
+
+async fn run_text<W: Write, R: BufRead>(
+    stream: &mut BoxStream<AgentEvent>,
+    writer: &mut W,
+    confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,
+    is_tty: bool,
+    stdin: &mut R,
+    logger: &mut Option<&mut Logger>,
+) -> Result<()> {
     while let Some(event) = stream.next().await {
-        if let Some(ref mut log) = logger {
+        if let Some(log) = logger.as_deref_mut() {
             log.log_event(&event)?;
             log.flush()?;
         }
@@ -60,31 +95,93 @@ async fn run_with_writer<W: Write, R: BufRead>(
             }
             AgentEvent::Usage { .. } => {}
             AgentEvent::ToolConfirmationRequired { name, input, .. } => {
-                if !is_tty {
-                    eprintln!(
-                        "Error: tool confirmation required but stdin is not a TTY (tool: {})",
-                        name
-                    );
-                    let _ = confirm_tx.unbounded_send(ConfirmationResponse::Rejected);
-                    anyhow::bail!("tool confirmation required in non-TTY mode");
-                }
-                eprint!("Allow tool '{}' with input {}? [y/N] ", name, input);
-                io::stderr().flush()?;
-                let mut response = String::new();
-                // blocking call, acceptable for single-shot CLI
-                stdin.read_line(&mut response)?;
-                let decision = if response.trim().eq_ignore_ascii_case("y") {
-                    ConfirmationResponse::Approved
-                } else {
-                    ConfirmationResponse::Rejected
-                };
-                confirm_tx
-                    .unbounded_send(decision)
-                    .map_err(|_| anyhow::anyhow!("agent confirmation channel closed"))?;
+                handle_confirmation(writer, confirm_tx.clone(), is_tty, stdin, &name, &input)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_json<W: Write, R: BufRead>(
+    stream: &mut BoxStream<AgentEvent>,
+    writer: &mut W,
+    confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,
+    is_tty: bool,
+    stdin: &mut R,
+    logger: &mut Option<&mut Logger>,
+) -> Result<()> {
+    let mut result_text = String::new();
+    let mut is_error = false;
+
+    while let Some(event) = stream.next().await {
+        if let Some(log) = logger.as_deref_mut() {
+            log.log_event(&event)?;
+            log.flush()?;
+        }
+        match event {
+            AgentEvent::TokenReceived(text) => {
+                result_text.push_str(&text);
+            }
+            AgentEvent::ResponseComplete(_) => {
+                break;
+            }
+            AgentEvent::Error(msg) => {
+                is_error = true;
+                result_text = msg;
+                break;
+            }
+            AgentEvent::ToolUseReceived { .. }
+            | AgentEvent::ToolResult { .. }
+            | AgentEvent::Usage { .. } => {}
+            AgentEvent::ToolConfirmationRequired { name, input, .. } => {
+                handle_confirmation(writer, confirm_tx.clone(), is_tty, stdin, &name, &input)?;
             }
         }
     }
 
+    let output = serde_json::json!({
+        "is_error": is_error,
+        "result": result_text,
+    });
+    writeln!(writer, "{}", output)?;
+    writer.flush()?;
+
+    if is_error {
+        anyhow::bail!("LLM error: {}", result_text);
+    }
+
+    Ok(())
+}
+
+fn handle_confirmation<W: Write, R: BufRead>(
+    writer: &mut W,
+    confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,
+    is_tty: bool,
+    stdin: &mut R,
+    name: &str,
+    input: &serde_json::Value,
+) -> Result<()> {
+    if !is_tty {
+        eprintln!(
+            "Error: tool confirmation required but stdin is not a TTY (tool: {})",
+            name
+        );
+        let _ = confirm_tx.unbounded_send(ConfirmationResponse::Rejected);
+        anyhow::bail!("tool confirmation required in non-TTY mode");
+    }
+    eprint!("Allow tool '{}' with input {}? [y/N] ", name, input);
+    io::stderr().flush()?;
+    let mut response = String::new();
+    stdin.read_line(&mut response)?;
+    let decision = if response.trim().eq_ignore_ascii_case("y") {
+        ConfirmationResponse::Approved
+    } else {
+        ConfirmationResponse::Rejected
+    };
+    confirm_tx
+        .unbounded_send(decision)
+        .map_err(|_| anyhow::anyhow!("agent confirmation channel closed"))?;
+    let _ = writer;
     Ok(())
 }
 
@@ -101,6 +198,8 @@ mod tests {
         mpsc::unbounded()
     }
 
+    // --- Text format tests ---
+
     #[tokio::test]
     async fn token_received_writes_text_to_writer() {
         let events = vec![
@@ -112,9 +211,17 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, _rx) = make_confirm_channel();
 
-        run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None)
-            .await
-            .expect("stdout run should succeed");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("stdout run should succeed");
 
         assert_eq!(
             String::from_utf8(buf).expect("buffer should contain valid UTF-8"),
@@ -132,9 +239,17 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, _rx) = make_confirm_channel();
 
-        run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None)
-            .await
-            .expect("stdout run should succeed");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("stdout run should succeed");
 
         assert_eq!(
             String::from_utf8(buf).expect("buffer should contain valid UTF-8"),
@@ -149,7 +264,16 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, _rx) = make_confirm_channel();
 
-        let result = run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None).await;
+        let result = run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await;
 
         assert!(result.is_err());
         assert!(
@@ -175,9 +299,17 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, _rx) = make_confirm_channel();
 
-        run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None)
-            .await
-            .expect("should succeed");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("should succeed");
 
         let output = String::from_utf8(buf).expect("valid UTF-8");
         assert!(output.contains("[tool: bash]"), "should contain tool name");
@@ -201,9 +333,17 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, _rx) = make_confirm_channel();
 
-        run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None)
-            .await
-            .expect("should succeed");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("should succeed");
 
         let output = String::from_utf8(buf).expect("valid UTF-8");
         assert!(
@@ -230,9 +370,17 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, _rx) = make_confirm_channel();
 
-        run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None)
-            .await
-            .expect("should succeed");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("should succeed");
 
         let output = String::from_utf8(buf).expect("valid UTF-8");
         assert!(
@@ -256,7 +404,16 @@ mod tests {
         let mut buf = Vec::new();
         let (tx, mut rx) = make_confirm_channel();
 
-        let result = run_with_writer(s, &mut buf, tx, false, &mut io::empty(), None).await;
+        let result = run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await;
 
         assert!(result.is_err(), "should error in non-TTY mode");
         assert!(
@@ -287,9 +444,17 @@ mod tests {
         let (tx, mut rx) = make_confirm_channel();
         let mut fake_stdin = io::Cursor::new(b"y\n".as_ref());
 
-        run_with_writer(s, &mut buf, tx, true, &mut fake_stdin, None)
-            .await
-            .expect("should succeed in TTY mode");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            true,
+            &mut fake_stdin,
+            None,
+        )
+        .await
+        .expect("should succeed in TTY mode");
 
         let response = rx.try_recv().expect("channel should have a value");
         assert_eq!(
@@ -314,9 +479,17 @@ mod tests {
         let (tx, mut rx) = make_confirm_channel();
         let mut fake_stdin = io::Cursor::new(b"n\n".as_ref());
 
-        run_with_writer(s, &mut buf, tx, true, &mut fake_stdin, None)
-            .await
-            .expect("should succeed in TTY mode");
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Text,
+            true,
+            &mut fake_stdin,
+            None,
+        )
+        .await
+        .expect("should succeed in TTY mode");
 
         let response = rx.try_recv().expect("channel should have a value");
         assert_eq!(
@@ -324,5 +497,131 @@ mod tests {
             ConfirmationResponse::Rejected,
             "should send Rejected for 'n'"
         );
+    }
+
+    // --- JSON format tests ---
+
+    #[tokio::test]
+    async fn json_format_success_emits_is_error_false_and_result() {
+        let events = vec![
+            AgentEvent::TokenReceived("hello".to_string()),
+            AgentEvent::TokenReceived(" world".to_string()),
+            AgentEvent::ResponseComplete("hello world".to_string()),
+        ];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+        let (tx, _rx) = make_confirm_channel();
+
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Json,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("json run should succeed");
+
+        let output = String::from_utf8(buf).expect("valid UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).expect("valid JSON");
+        assert_eq!(parsed["is_error"], false);
+        assert_eq!(parsed["result"], "hello world");
+    }
+
+    #[tokio::test]
+    async fn json_format_error_emits_is_error_true_and_message() {
+        let events = vec![AgentEvent::Error("something failed".to_string())];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+        let (tx, _rx) = make_confirm_channel();
+
+        let result = run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Json,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "should return Err on error event");
+
+        let output = String::from_utf8(buf).expect("valid UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).expect("valid JSON");
+        assert_eq!(parsed["is_error"], true);
+        assert_eq!(parsed["result"], "something failed");
+    }
+
+    #[tokio::test]
+    async fn json_format_tool_events_are_not_written_to_output() {
+        let events = vec![
+            AgentEvent::ToolUseReceived {
+                id: "t1".to_string(),
+                name: "bash".to_string(),
+                input: serde_json::json!({"command": "ls"}),
+            },
+            AgentEvent::ToolResult {
+                name: "bash".to_string(),
+                content: "file.txt".to_string(),
+                is_error: false,
+            },
+            AgentEvent::TokenReceived("done".to_string()),
+            AgentEvent::ResponseComplete("done".to_string()),
+        ];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+        let (tx, _rx) = make_confirm_channel();
+
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Json,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        let output = String::from_utf8(buf).expect("valid UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).expect("valid JSON");
+        assert_eq!(parsed["is_error"], false);
+        assert_eq!(parsed["result"], "done");
+        assert!(
+            !output.contains("[tool:"),
+            "tool events should not appear in JSON output"
+        );
+    }
+
+    #[tokio::test]
+    async fn json_format_non_tty_confirmation_sends_rejection_and_errors() {
+        let events = vec![AgentEvent::ToolConfirmationRequired {
+            id: "t1".to_string(),
+            name: "bash".to_string(),
+            input: serde_json::json!({"command": "rm -rf /"}),
+        }];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+        let (tx, mut rx) = make_confirm_channel();
+
+        let result = run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Json,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "should error in non-TTY mode");
+        let response = rx.try_recv().expect("channel should have a value");
+        assert_eq!(response, ConfirmationResponse::Rejected);
     }
 }

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -6,7 +6,7 @@ use std::io::{self, BufRead, IsTerminal, Write};
 use crate::logging::Logger;
 use crate::types::{AgentEvent, BoxStream, ConfirmationResponse};
 
-#[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
 pub enum OutputFormat {
     Text,
     Json,
@@ -95,13 +95,17 @@ async fn run_text<W: Write, R: BufRead>(
             }
             AgentEvent::Usage { .. } => {}
             AgentEvent::ToolConfirmationRequired { name, input, .. } => {
-                handle_confirmation(writer, confirm_tx.clone(), is_tty, stdin, &name, &input)?;
+                handle_confirmation(confirm_tx.clone(), is_tty, stdin, &name, &input)?;
             }
         }
     }
     Ok(())
 }
 
+// In JSON mode the `result` field contains only the final assistant turn — the
+// text emitted after the last tool result. Intermediate "thinking" tokens that
+// appear before a tool call are discarded so that scripts receive a clean,
+// singular output rather than concatenated reasoning + final answer.
 async fn run_json<W: Write, R: BufRead>(
     stream: &mut BoxStream<AgentEvent>,
     writer: &mut W,
@@ -112,6 +116,7 @@ async fn run_json<W: Write, R: BufRead>(
 ) -> Result<()> {
     let mut result_text = String::new();
     let mut is_error = false;
+    let mut in_tool_iteration = false;
 
     while let Some(event) = stream.next().await {
         if let Some(log) = logger.as_deref_mut() {
@@ -120,7 +125,18 @@ async fn run_json<W: Write, R: BufRead>(
         }
         match event {
             AgentEvent::TokenReceived(text) => {
-                result_text.push_str(&text);
+                if !in_tool_iteration {
+                    result_text.push_str(&text);
+                }
+            }
+            AgentEvent::ToolUseReceived { .. } => {
+                // Entering a tool call — discard any pre-tool text and restart
+                // accumulation after the tool completes.
+                result_text.clear();
+                in_tool_iteration = true;
+            }
+            AgentEvent::ToolResult { .. } => {
+                in_tool_iteration = false;
             }
             AgentEvent::ResponseComplete(_) => {
                 break;
@@ -130,11 +146,15 @@ async fn run_json<W: Write, R: BufRead>(
                 result_text = msg;
                 break;
             }
-            AgentEvent::ToolUseReceived { .. }
-            | AgentEvent::ToolResult { .. }
-            | AgentEvent::Usage { .. } => {}
+            AgentEvent::Usage { .. } => {}
+            AgentEvent::ToolConfirmationRequired { name, .. } if !is_tty => {
+                let _ = confirm_tx.unbounded_send(ConfirmationResponse::Rejected);
+                is_error = true;
+                result_text = format!("tool confirmation required in non-TTY mode (tool: {name})");
+                break;
+            }
             AgentEvent::ToolConfirmationRequired { name, input, .. } => {
-                handle_confirmation(writer, confirm_tx.clone(), is_tty, stdin, &name, &input)?;
+                handle_confirmation(confirm_tx.clone(), is_tty, stdin, &name, &input)?;
             }
         }
     }
@@ -153,8 +173,7 @@ async fn run_json<W: Write, R: BufRead>(
     Ok(())
 }
 
-fn handle_confirmation<W: Write, R: BufRead>(
-    writer: &mut W,
+fn handle_confirmation<R: BufRead>(
     confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,
     is_tty: bool,
     stdin: &mut R,
@@ -181,7 +200,6 @@ fn handle_confirmation<W: Write, R: BufRead>(
     confirm_tx
         .unbounded_send(decision)
         .map_err(|_| anyhow::anyhow!("agent confirmation channel closed"))?;
-    let _ = writer;
     Ok(())
 }
 
@@ -598,8 +616,60 @@ mod tests {
         );
     }
 
+    // Regression: multi-iteration responses must only include the final assistant
+    // turn in `result`, not intermediate reasoning emitted before a tool call.
     #[tokio::test]
-    async fn json_format_non_tty_confirmation_sends_rejection_and_errors() {
+    async fn json_format_multi_iteration_result_contains_only_final_turn() {
+        let events = vec![
+            // Pre-tool reasoning — must NOT appear in result
+            AgentEvent::TokenReceived("I will use bash.".to_string()),
+            AgentEvent::ToolUseReceived {
+                id: "t1".to_string(),
+                name: "bash".to_string(),
+                input: serde_json::json!({"command": "ls"}),
+            },
+            AgentEvent::ToolResult {
+                name: "bash".to_string(),
+                content: "file.txt".to_string(),
+                is_error: false,
+            },
+            // Post-tool final answer — the only text that should appear in result
+            AgentEvent::TokenReceived("The directory contains file.txt.".to_string()),
+            AgentEvent::ResponseComplete("The directory contains file.txt.".to_string()),
+        ];
+        let s: BoxStream<AgentEvent> = Box::pin(stream::iter(events));
+        let mut buf = Vec::new();
+        let (tx, _rx) = make_confirm_channel();
+
+        run_with_writer(
+            s,
+            &mut buf,
+            tx,
+            OutputFormat::Json,
+            false,
+            &mut io::empty(),
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+        let output = String::from_utf8(buf).expect("valid UTF-8");
+        let parsed: serde_json::Value = serde_json::from_str(output.trim()).expect("valid JSON");
+        assert_eq!(parsed["is_error"], false);
+        assert_eq!(parsed["result"], "The directory contains file.txt.");
+        assert!(
+            !parsed["result"]
+                .as_str()
+                .expect("result is a string")
+                .contains("I will use bash"),
+            "pre-tool reasoning must not appear in result"
+        );
+    }
+
+    // Regression: non-TTY confirmation in JSON mode must still emit a JSON
+    // envelope so callers can always parse stdout as JSON on any exit.
+    #[tokio::test]
+    async fn json_format_non_tty_confirmation_emits_json_and_errors() {
         let events = vec![AgentEvent::ToolConfirmationRequired {
             id: "t1".to_string(),
             name: "bash".to_string(),
@@ -621,6 +691,19 @@ mod tests {
         .await;
 
         assert!(result.is_err(), "should error in non-TTY mode");
+
+        let output = String::from_utf8(buf).expect("valid UTF-8");
+        let parsed: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("stdout must be valid JSON even on error");
+        assert_eq!(parsed["is_error"], true, "is_error must be true");
+        assert!(
+            parsed["result"]
+                .as_str()
+                .expect("result is a string")
+                .contains("non-TTY"),
+            "result should describe the non-TTY error"
+        );
+
         let response = rx.try_recv().expect("channel should have a value");
         assert_eq!(response, ConfirmationResponse::Rejected);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,9 @@ struct Cli {
     #[arg(long)]
     single_shot: bool,
 
+    #[arg(long, default_value = "text")]
+    output_format: frontend::stdout::OutputFormat,
+
     #[arg(long)]
     config: Option<PathBuf>,
 
@@ -71,6 +74,9 @@ fn determine_mode(cli: &Cli) -> Result<Mode> {
         })?;
         Ok(Mode::SingleShot { prompt })
     } else {
+        if cli.output_format != frontend::stdout::OutputFormat::Text {
+            anyhow::bail!("--output-format requires --single-shot");
+        }
         Ok(Mode::Repl {
             initial_prompt: cli.prompt.clone(),
         })
@@ -149,7 +155,13 @@ async fn main() -> Result<()> {
             }
             let (confirm_tx, confirm_rx) = mpsc::unbounded::<ConfirmationResponse>();
             let stream = agent.send(prompt, Some(confirm_rx)).await?;
-            frontend::stdout::run(stream, confirm_tx, logger.as_mut()).await?;
+            frontend::stdout::run(
+                stream,
+                confirm_tx,
+                cli.output_format.clone(),
+                logger.as_mut(),
+            )
+            .await?;
         }
         Mode::Repl { initial_prompt } => {
             frontend::tui::run(agent.clone(), initial_prompt, logger, &app_config).await?;
@@ -244,5 +256,35 @@ mod tests {
     fn session_id_flag_defaults_to_none() {
         let cli = Cli::try_parse_from(["illustrious-manager"]).unwrap();
         assert!(cli.session_id.is_none());
+    }
+
+    #[test]
+    fn output_format_defaults_to_text() {
+        let cli = Cli::try_parse_from(["illustrious-manager"]).unwrap();
+        assert_eq!(cli.output_format, frontend::stdout::OutputFormat::Text);
+    }
+
+    #[test]
+    fn output_format_json_is_parsed() {
+        let cli = Cli::try_parse_from([
+            "illustrious-manager",
+            "--single-shot",
+            "--output-format",
+            "json",
+            "hello",
+        ])
+        .unwrap();
+        assert_eq!(cli.output_format, frontend::stdout::OutputFormat::Json);
+    }
+
+    #[test]
+    fn output_format_json_without_single_shot_errors() {
+        let cli = Cli::try_parse_from(["illustrious-manager", "--output-format", "json", "hello"])
+            .unwrap();
+        let err = determine_mode(&cli).unwrap_err().to_string();
+        assert!(
+            err.contains("--output-format"),
+            "Error should mention --output-format"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,13 +155,7 @@ async fn main() -> Result<()> {
             }
             let (confirm_tx, confirm_rx) = mpsc::unbounded::<ConfirmationResponse>();
             let stream = agent.send(prompt, Some(confirm_rx)).await?;
-            frontend::stdout::run(
-                stream,
-                confirm_tx,
-                cli.output_format.clone(),
-                logger.as_mut(),
-            )
-            .await?;
+            frontend::stdout::run(stream, confirm_tx, cli.output_format, logger.as_mut()).await?;
         }
         Mode::Repl { initial_prompt } => {
             frontend::tui::run(agent.clone(), initial_prompt, logger, &app_config).await?;
@@ -229,13 +223,13 @@ mod tests {
     #[test]
     fn debug_flag_is_parsed_when_present() {
         let cli = Cli::try_parse_from(["illustrious-manager", "--debug"]).unwrap();
-        assert_eq!(cli.debug, true);
+        assert!(cli.debug);
     }
 
     #[test]
     fn debug_flag_is_false_when_not_present() {
         let cli = Cli::try_parse_from(["illustrious-manager"]).unwrap();
-        assert_eq!(cli.debug, false);
+        assert!(!cli.debug);
     }
 
     #[test]


### PR DESCRIPTION
Closes #70

Adds `--output-format json` flag (valid only with `--single-shot`). Emits a single JSON line at the end of the run:

```json
{"is_error": false, "result": "the agent's response"}
```

On error: `{"is_error": true, "result": "error message"}`

Tool events are suppressed in JSON mode. Text mode is unchanged. Passing `--output-format json` without `--single-shot` is an error.