### PR TITLE
Add Ollama backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ cargo fmt                            # Format
 
 Four-layer decoupled design:
 
-1. **Backend Layer** (`src/backend/`) — `LlmBackend` trait abstraction over LLM providers. Two implementations: `vertex` (Vertex AI + Claude via SSE, with `sse.rs` for SSE stream parsing) and `zai` (z.ai). Emits `StreamEvent` (TextDelta | ToolUseStart/Delta/Done | Usage | Done).
+1. **Backend Layer** (`src/backend/`) — `LlmBackend` trait abstraction over LLM providers. Three implementations: `vertex` (Vertex AI + Claude via SSE, with `sse.rs` for SSE stream parsing), `zai` (z.ai), and `ollama` (Ollama Cloud/self-hosted via NDJSON, with `ndjson.rs` for NDJSON stream parsing). Emits `StreamEvent` (TextDelta | ToolUseStart/Delta/Done | Usage | Done).
 
 2. **Agent Core** (`src/agent.rs`) — Owns conversation history, context files, and skills. Wraps backend streams into `AgentEvent` (TokenReceived | ToolUseReceived | ToolResult | ToolConfirmationRequired | ResponseComplete | Error | Usage). Display-agnostic. Drives agentic tool-use loops up to `max_tool_iterations`. Supports session switching (`load_session`) while preserving non-persisted context prefix (context files, skill definitions).
 
@@ -72,7 +72,7 @@ Key types live in `src/types.rs`. Configuration loading and CLI merge logic is i
 Config file at `~/.config/illustrious-manager/config.toml` (auto-created on first run):
 
 ```toml
-backend = "vertex"                    # "vertex" or "zai"
+backend = "vertex"                    # "vertex", "zai", or "ollama"
 # sessions_dir = "/path/to/sessions" # defaults to ~/.config/illustrious-manager/sessions
 
 [vertex]
@@ -83,6 +83,11 @@ model = "claude-sonnet-4-20250514"
 [zai]
 api_key = ""                          # z.ai API key (required for zai backend)
 model = "glm-5.1"
+
+[ollama]
+api_key = ""                          # Ollama API key (required for ollama backend)
+model = "gpt-oss:120b"
+# base_url = "https://ollama.com/api/chat"  # change for self-hosted Ollama
 
 # [tools]
 # confirmation = "WriteOnly"          # Always | WriteOnly | Never

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use crate::config::AppConfig;
 use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 
+pub mod ndjson;
+pub mod ollama;
 pub mod sse;
 pub mod vertex;
 pub mod zai;
@@ -47,8 +49,23 @@ pub async fn from_config(config: &AppConfig) -> Result<BackendSelection> {
                 model: zai_config.model.clone(),
             })
         }
+        "ollama" => {
+            let ollama_config = config.ollama.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "ollama backend configuration is missing. Add a [ollama] section to your config file."
+                )
+            })?;
+            let backend = ollama::OllamaBackend::new(ollama_config)?;
+            Ok(BackendSelection {
+                backend: Box::new(backend),
+                model: ollama_config.model.clone(),
+            })
+        }
         _ => {
-            anyhow::bail!("Invalid backend '{}'", config.backend);
+            anyhow::bail!(
+                "Invalid backend '{}'. Supported backends are: vertex, zai, ollama",
+                config.backend
+            );
         }
     }
 }

--- a/src/backend/ndjson.rs
+++ b/src/backend/ndjson.rs
@@ -1,0 +1,172 @@
+use std::collections::VecDeque;
+
+use anyhow::Result;
+use futures::stream::unfold;
+use futures::{Stream, StreamExt};
+
+use crate::types::{BoxStream, StreamEvent};
+
+pub fn create_ndjson_event_stream<S, B, E, P>(
+    byte_stream: S,
+    parser: P,
+) -> BoxStream<Result<StreamEvent>>
+where
+    S: Stream<Item = Result<B, E>> + Unpin + Send + 'static,
+    B: AsRef<[u8]>,
+    E: std::fmt::Display + 'static,
+    P: FnMut(&str) -> Result<Vec<StreamEvent>> + Send + 'static,
+{
+    let event_stream = unfold(
+        (byte_stream, String::new(), parser, VecDeque::new()),
+        move |(mut byte_stream, mut buffer, mut parser, mut event_queue)| async move {
+            loop {
+                if let Some(event) = event_queue.pop_front() {
+                    return Some((Ok(event), (byte_stream, buffer, parser, event_queue)));
+                }
+
+                if let Some(pos) = buffer.find('\n') {
+                    let line = buffer[..pos].trim().to_string();
+                    buffer = buffer[pos + 1..].to_string();
+
+                    if !line.is_empty() {
+                        match parser(&line) {
+                            Ok(events) => {
+                                event_queue.extend(events);
+                                continue;
+                            }
+                            Err(e) => {
+                                return Some((Err(e), (byte_stream, buffer, parser, event_queue)));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                match byte_stream.next().await {
+                    Some(Ok(bytes)) => {
+                        buffer.push_str(&String::from_utf8_lossy(bytes.as_ref()));
+                    }
+                    Some(Err(e)) => {
+                        return Some((
+                            Err(anyhow::anyhow!("Stream read error: {}", e)),
+                            (byte_stream, buffer, parser, event_queue),
+                        ));
+                    }
+                    None => {
+                        if !buffer.trim().is_empty() {
+                            let remaining = buffer.trim().to_string();
+                            buffer.clear();
+                            match parser(&remaining) {
+                                Ok(events) => {
+                                    event_queue.extend(events);
+                                    continue;
+                                }
+                                Err(e) => {
+                                    return Some((
+                                        Err(e),
+                                        (byte_stream, buffer, parser, event_queue),
+                                    ));
+                                }
+                            }
+                        }
+                        return None;
+                    }
+                }
+            }
+        },
+    );
+
+    Box::pin(event_stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+
+    use super::*;
+
+    fn text_event(text: &str) -> StreamEvent {
+        StreamEvent::TextDelta(text.to_string())
+    }
+
+    #[tokio::test]
+    async fn single_line_produces_single_event() {
+        let chunks: Vec<Result<&[u8], std::io::Error>> = vec![Ok(b"{\"msg\":\"hi\"}\n")];
+        let byte_stream = stream::iter(chunks);
+        let events: Vec<_> =
+            create_ndjson_event_stream(byte_stream, |line| Ok(vec![text_event(line)]))
+                .collect::<Vec<_>>()
+                .await;
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0].as_ref().unwrap(),
+            StreamEvent::TextDelta(t) if t.contains("msg")
+        ));
+    }
+
+    #[tokio::test]
+    async fn multi_line_in_one_chunk_produces_multiple_events() {
+        let data = "{\"a\":1}\n{\"b\":2}\n";
+        let chunks: Vec<Result<&[u8], std::io::Error>> = vec![Ok(data.as_bytes())];
+        let byte_stream = stream::iter(chunks);
+        let events: Vec<_> =
+            create_ndjson_event_stream(byte_stream, |line| Ok(vec![text_event(line)]))
+                .collect::<Vec<_>>()
+                .await;
+
+        assert_eq!(events.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn partial_line_buffered_across_chunks() {
+        let chunks: Vec<Result<&[u8], std::io::Error>> = vec![Ok(b"{\"part"), Ok(b"ial\":1}\n")];
+        let byte_stream = stream::iter(chunks);
+        let events: Vec<_> =
+            create_ndjson_event_stream(byte_stream, |line| Ok(vec![text_event(line)]))
+                .collect::<Vec<_>>()
+                .await;
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0].as_ref().unwrap(),
+            StreamEvent::TextDelta(t) if t == "{\"partial\":1}"
+        ));
+    }
+
+    #[tokio::test]
+    async fn trailing_line_without_newline_still_emits() {
+        let chunks: Vec<Result<&[u8], std::io::Error>> = vec![Ok(b"{\"final\":true}")];
+        let byte_stream = stream::iter(chunks);
+        let events: Vec<_> =
+            create_ndjson_event_stream(byte_stream, |line| Ok(vec![text_event(line)]))
+                .collect::<Vec<_>>()
+                .await;
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0].as_ref().unwrap(),
+            StreamEvent::TextDelta(t) if t == "{\"final\":true}"
+        ));
+    }
+
+    #[tokio::test]
+    async fn parser_error_propagates() {
+        let chunks: Vec<Result<&[u8], std::io::Error>> = vec![Ok(b"bad\n")];
+        let byte_stream = stream::iter(chunks);
+        let events: Vec<_> =
+            create_ndjson_event_stream(byte_stream, |_line| Err(anyhow::anyhow!("parse failure")))
+                .collect::<Vec<_>>()
+                .await;
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].as_ref().is_err());
+        assert!(
+            events[0]
+                .as_ref()
+                .unwrap_err()
+                .to_string()
+                .contains("parse failure")
+        );
+    }
+}

--- a/src/backend/ollama.rs
+++ b/src/backend/ollama.rs
@@ -7,6 +7,8 @@ use super::ndjson::create_ndjson_event_stream;
 use crate::config::OllamaConfig;
 use crate::types::{BoxStream, ContentBlock, Message, RequestConfig, Role, StreamEvent};
 
+const DEFAULT_CLOUD_ENDPOINT: &str = "https://ollama.com/api/chat";
+
 #[derive(Default)]
 pub struct OllamaParser;
 
@@ -32,14 +34,25 @@ impl OllamaParser {
         }
 
         if let Some(tool_calls) = json["message"]["tool_calls"].as_array() {
-            for tool_call in tool_calls {
+            for (idx, tool_call) in tool_calls.iter().enumerate() {
                 let function = &tool_call["function"];
-                let name = function["name"].as_str().unwrap_or("").to_string();
-                let id = tool_call
+                let name = match function["name"].as_str() {
+                    Some(n) if !n.is_empty() => n.to_string(),
+                    _ => {
+                        bail!(
+                            "Malformed tool call at index {}: missing or empty function name",
+                            idx
+                        );
+                    }
+                };
+                let id = match tool_call
                     .get("id")
                     .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                    .filter(|s| !s.is_empty())
+                {
+                    Some(s) => s.to_string(),
+                    None => format!("tool_{idx}"),
+                };
 
                 let arguments = if function["arguments"].is_object() {
                     serde_json::to_string(&function["arguments"])
@@ -84,8 +97,10 @@ pub struct OllamaBackend {
 
 impl OllamaBackend {
     pub fn new(config: &OllamaConfig) -> Result<Self> {
-        if config.api_key.is_empty() {
-            bail!("API key cannot be empty for ollama backend");
+        if config.base_url == DEFAULT_CLOUD_ENDPOINT && config.api_key.is_empty() {
+            bail!(
+                "API key is required for Ollama Cloud. Set it in your config, or set base_url to your self-hosted endpoint."
+            );
         }
         Ok(Self {
             client: Client::new(),
@@ -574,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn new_rejects_empty_api_key() {
+    fn new_rejects_empty_api_key_for_cloud_endpoint() {
         let result = OllamaBackend::new(&OllamaConfig {
             api_key: "".to_string(),
             model: "gpt-oss:120b".to_string(),
@@ -582,6 +597,16 @@ mod tests {
         });
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn new_allows_empty_api_key_for_self_hosted() {
+        let result = OllamaBackend::new(&OllamaConfig {
+            api_key: "".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "http://localhost:11434/api/chat".to_string(),
+        });
+        assert!(result.is_ok(), "should accept empty key for self-hosted");
     }
 
     #[test]
@@ -594,5 +619,60 @@ mod tests {
         assert!(backend.is_ok());
         let b = backend.unwrap();
         assert_eq!(b.endpoint, "https://ollama.com/api/chat");
+    }
+
+    #[test]
+    fn parser_missing_tool_name_bails() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"tool_calls":[{"id":"c1","function":{"arguments":{}}}]}}"#;
+        let result = parser.parse_chunk(chunk);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing or empty function name")
+        );
+    }
+
+    #[test]
+    fn parser_empty_tool_name_bails() {
+        let mut parser = OllamaParser::new();
+        let chunk =
+            r#"{"message":{"tool_calls":[{"id":"c1","function":{"name":"","arguments":{}}}]}}"#;
+        let result = parser.parse_chunk(chunk);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("missing or empty function name")
+        );
+    }
+
+    #[test]
+    fn parser_missing_id_generates_fallback() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 3);
+        if let StreamEvent::ToolUseStart { id, name } = &events[0] {
+            assert_eq!(name, "bash");
+            assert_eq!(id, "tool_0", "should generate fallback ID with index");
+        } else {
+            panic!("expected ToolUseStart");
+        }
+    }
+
+    #[test]
+    fn parser_chunk_with_both_text_and_tool_calls() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"content":"Thinking...","tool_calls":[{"id":"c1","function":{"name":"bash","arguments":{"command":"ls"}}}]}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 4);
+        assert!(matches!(&events[0], StreamEvent::TextDelta(t) if t == "Thinking..."));
+        assert!(matches!(&events[1], StreamEvent::ToolUseStart { .. }));
+        assert!(matches!(&events[2], StreamEvent::ToolUseDelta(_)));
+        assert!(matches!(&events[3], StreamEvent::ToolUseDone));
     }
 }

--- a/src/backend/ollama.rs
+++ b/src/backend/ollama.rs
@@ -1,0 +1,598 @@
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use reqwest::Client;
+
+use super::LlmBackend;
+use super::ndjson::create_ndjson_event_stream;
+use crate::config::OllamaConfig;
+use crate::types::{BoxStream, ContentBlock, Message, RequestConfig, Role, StreamEvent};
+
+#[derive(Default)]
+pub struct OllamaParser;
+
+impl OllamaParser {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn parse_chunk(&mut self, data: &str) -> Result<Vec<StreamEvent>> {
+        let mut events = Vec::new();
+
+        let json: serde_json::Value = serde_json::from_str(data)
+            .with_context(|| format!("Failed to parse NDJSON line: {}", data))?;
+
+        if let Some(error_msg) = json.get("error").and_then(|v| v.as_str()) {
+            bail!("Ollama error: {}", error_msg);
+        }
+
+        if let Some(content) = json["message"]["content"].as_str()
+            && !content.is_empty()
+        {
+            events.push(StreamEvent::TextDelta(content.to_string()));
+        }
+
+        if let Some(tool_calls) = json["message"]["tool_calls"].as_array() {
+            for tool_call in tool_calls {
+                let function = &tool_call["function"];
+                let name = function["name"].as_str().unwrap_or("").to_string();
+                let id = tool_call
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let arguments = if function["arguments"].is_object() {
+                    serde_json::to_string(&function["arguments"])
+                        .unwrap_or_else(|_| "{}".to_string())
+                } else if let Some(args_str) = function["arguments"].as_str() {
+                    args_str.to_string()
+                } else {
+                    "{}".to_string()
+                };
+
+                events.push(StreamEvent::ToolUseStart { id, name });
+                events.push(StreamEvent::ToolUseDelta(arguments));
+                events.push(StreamEvent::ToolUseDone);
+            }
+        }
+
+        if json["done"].as_bool() == Some(true) {
+            let input_tokens = json["prompt_eval_count"].as_u64().unwrap_or(0) as u32;
+            let output_tokens = json["eval_count"].as_u64().unwrap_or(0) as u32;
+            let stop_reason = json["done_reason"].as_str().unwrap_or("stop").to_string();
+
+            if input_tokens > 0 || output_tokens > 0 {
+                events.push(StreamEvent::Usage {
+                    input_tokens,
+                    output_tokens,
+                    stop_reason: stop_reason.clone(),
+                });
+            }
+            events.push(StreamEvent::Done);
+        }
+
+        Ok(events)
+    }
+}
+
+#[derive(Debug)]
+pub struct OllamaBackend {
+    client: Client,
+    api_key: String,
+    endpoint: String,
+}
+
+impl OllamaBackend {
+    pub fn new(config: &OllamaConfig) -> Result<Self> {
+        if config.api_key.is_empty() {
+            bail!("API key cannot be empty for ollama backend");
+        }
+        Ok(Self {
+            client: Client::new(),
+            api_key: config.api_key.clone(),
+            endpoint: config.base_url.clone(),
+        })
+    }
+
+    fn build_request_body(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> serde_json::Value {
+        let mut messages_json: Vec<serde_json::Value> = Vec::new();
+
+        for m in messages {
+            match m.role {
+                Role::User => {
+                    let has_tool_results = m
+                        .content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolResult { .. }));
+
+                    if has_tool_results {
+                        for block in &m.content {
+                            match block {
+                                ContentBlock::ToolResult {
+                                    tool_use_id,
+                                    content,
+                                    ..
+                                } => {
+                                    messages_json.push(serde_json::json!({
+                                        "role": "tool",
+                                        "tool_call_id": tool_use_id,
+                                        "content": content
+                                    }));
+                                }
+                                ContentBlock::Text(text) => {
+                                    messages_json.push(serde_json::json!({
+                                        "role": "user",
+                                        "content": text
+                                    }));
+                                }
+                                _ => {}
+                            }
+                        }
+                    } else {
+                        let content: String = m
+                            .content
+                            .iter()
+                            .filter_map(|block| match block {
+                                ContentBlock::Text(text) => Some(text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("");
+                        messages_json.push(serde_json::json!({
+                            "role": "user",
+                            "content": content
+                        }));
+                    }
+                }
+                Role::Assistant => {
+                    let has_tool_use = m
+                        .content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolUse { .. }));
+
+                    if has_tool_use {
+                        let mut text_parts: Vec<String> = Vec::new();
+                        let mut tool_calls: Vec<serde_json::Value> = Vec::new();
+
+                        for block in &m.content {
+                            match block {
+                                ContentBlock::Text(text) => text_parts.push(text.clone()),
+                                ContentBlock::ToolUse { id, name, input } => {
+                                    tool_calls.push(serde_json::json!({
+                                        "id": id,
+                                        "type": "function",
+                                        "function": {
+                                            "name": name,
+                                            "arguments": input
+                                        }
+                                    }));
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        let mut msg = serde_json::json!({"role": "assistant"});
+                        if !text_parts.is_empty() {
+                            msg["content"] = serde_json::json!(text_parts.join(""));
+                        }
+                        msg["tool_calls"] = serde_json::json!(tool_calls);
+                        messages_json.push(msg);
+                    } else {
+                        let content: String = m
+                            .content
+                            .iter()
+                            .filter_map(|block| match block {
+                                ContentBlock::Text(text) => Some(text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("");
+                        messages_json.push(serde_json::json!({
+                            "role": "assistant",
+                            "content": content
+                        }));
+                    }
+                }
+            }
+        }
+
+        let mut body = serde_json::json!({
+            "model": config.model,
+            "messages": messages_json,
+            "stream": true,
+            "options": {
+                "num_predict": config.max_tokens
+            }
+        });
+
+        if !config.tools.is_empty() {
+            let tools_json: Vec<serde_json::Value> = config
+                .tools
+                .iter()
+                .map(|tool| {
+                    serde_json::json!({
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                            "description": tool.description,
+                            "parameters": tool.input_schema
+                        }
+                    })
+                })
+                .collect();
+            body["tools"] = serde_json::json!(tools_json);
+        }
+
+        body
+    }
+}
+
+#[async_trait]
+impl LlmBackend for OllamaBackend {
+    async fn send_message(
+        &self,
+        messages: &[Message],
+        config: &RequestConfig,
+    ) -> Result<BoxStream<Result<StreamEvent>>> {
+        let body = self.build_request_body(messages, config);
+
+        let mut request = self
+            .client
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json");
+
+        if !self.api_key.is_empty() {
+            request = request.bearer_auth(&self.api_key);
+        }
+
+        let response = request
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send request to Ollama")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| String::from("<failed to read response body>"));
+            bail!("Ollama returned {}: {}", status, body);
+        }
+
+        let byte_stream = response.bytes_stream();
+        let mut parser = OllamaParser::new();
+        let event_stream =
+            create_ndjson_event_stream(byte_stream, move |line| parser.parse_chunk(line));
+        Ok(event_stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_text_delta() {
+        let mut parser = OllamaParser::new();
+        let events = parser
+            .parse_chunk(r#"{"message":{"content":"Hello"}}"#)
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], StreamEvent::TextDelta(t) if t == "Hello"));
+    }
+
+    #[test]
+    fn parser_empty_content_produces_no_text_delta() {
+        let mut parser = OllamaParser::new();
+        let events = parser.parse_chunk(r#"{"message":{"content":""}}"#).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn parser_single_tool_call() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"tool_calls":[{"id":"call_1","function":{"name":"bash","arguments":{"command":"ls"}}}]}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 3);
+        assert!(
+            matches!(&events[0], StreamEvent::ToolUseStart { id, name } if id == "call_1" && name == "bash")
+        );
+        assert!(matches!(&events[1], StreamEvent::ToolUseDelta(args) if args.contains("ls")));
+        assert!(matches!(&events[2], StreamEvent::ToolUseDone));
+    }
+
+    #[test]
+    fn parser_multiple_tool_calls_in_one_chunk() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"tool_calls":[{"id":"c1","function":{"name":"bash","arguments":{"command":"ls"}}},{"id":"c2","function":{"name":"read_file","arguments":{"path":"foo.rs"}}}]}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 6);
+        assert!(matches!(&events[0], StreamEvent::ToolUseStart { name, .. } if name == "bash"));
+        assert!(matches!(&events[1], StreamEvent::ToolUseDelta(_)));
+        assert!(matches!(&events[2], StreamEvent::ToolUseDone));
+        assert!(
+            matches!(&events[3], StreamEvent::ToolUseStart { name, .. } if name == "read_file")
+        );
+        assert!(matches!(&events[4], StreamEvent::ToolUseDelta(_)));
+        assert!(matches!(&events[5], StreamEvent::ToolUseDone));
+    }
+
+    #[test]
+    fn parser_done_chunk_with_usage() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"done":true,"prompt_eval_count":10,"eval_count":20,"done_reason":"stop"}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(
+            matches!(&events[0], StreamEvent::Usage { input_tokens: 10, output_tokens: 20, stop_reason } if stop_reason == "stop")
+        );
+        assert!(matches!(&events[1], StreamEvent::Done));
+    }
+
+    #[test]
+    fn parser_done_chunk_without_usage_still_emits_done() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"done":true}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], StreamEvent::Done));
+    }
+
+    #[test]
+    fn parser_error_chunk() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"error":"model not found"}"#;
+        let result = parser.parse_chunk(chunk);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("model not found"));
+    }
+
+    #[test]
+    fn parser_done_reason_propagated_as_stop_reason() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"done":true,"prompt_eval_count":5,"eval_count":3,"done_reason":"length"}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert!(
+            matches!(&events[0], StreamEvent::Usage { stop_reason, .. } if stop_reason == "length")
+        );
+    }
+
+    #[test]
+    fn parser_invalid_json_returns_error() {
+        let mut parser = OllamaParser::new();
+        let result = parser.parse_chunk("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn request_body_has_model_stream_and_options() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        assert_eq!(body["model"], "gpt-oss:120b");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["options"]["num_predict"], 4096);
+    }
+
+    #[test]
+    fn request_body_includes_tools_array() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![crate::types::ToolDefinition {
+                name: "bash".to_string(),
+                description: "Execute bash commands".to_string(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"}
+                    },
+                    "required": ["command"]
+                }),
+            }],
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        let tools = body["tools"].as_array().expect("tools should be array");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["function"]["name"], "bash");
+        assert_eq!(tools[0]["function"]["description"], "Execute bash commands");
+        assert_eq!(tools[0]["function"]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn request_body_no_tools_field_when_empty() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+        assert!(
+            body.get("tools").is_none(),
+            "should not include tools field when empty"
+        );
+    }
+
+    #[test]
+    fn request_body_assistant_tool_calls_arguments_as_object() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+        };
+        let messages = vec![Message {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "tool_0".to_string(),
+                name: "bash".to_string(),
+                input: serde_json::json!({"command": "ls"}),
+            }],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(msgs[0]["role"], "assistant");
+
+        let tool_calls = msgs[0]["tool_calls"].as_array().expect("tool_calls array");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0]["function"]["name"], "bash");
+
+        let args = &tool_calls[0]["function"]["arguments"];
+        assert!(
+            args.is_object(),
+            "arguments must be a JSON object, not a string, got: {}",
+            args
+        );
+        assert_eq!(args["command"], "ls");
+    }
+
+    #[test]
+    fn request_body_tool_result_maps_to_role_tool() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "tool_0".to_string(),
+                content: "file1.txt\nfile2.txt".to_string(),
+                is_error: false,
+            }],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0]["role"], "tool");
+        assert_eq!(msgs[0]["tool_call_id"], "tool_0");
+        assert_eq!(msgs[0]["content"], "file1.txt\nfile2.txt");
+    }
+
+    #[test]
+    fn request_body_full_tool_use_round_trip() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+        };
+        let messages = vec![
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::Text("run ls".to_string())],
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::ToolUse {
+                    id: "tool_0".to_string(),
+                    name: "bash".to_string(),
+                    input: serde_json::json!({"command": "ls"}),
+                }],
+            },
+            Message {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "tool_0".to_string(),
+                    content: "file1.txt".to_string(),
+                    is_error: false,
+                }],
+            },
+        ];
+
+        let body = backend.build_request_body(&messages, &config);
+        let msgs = body["messages"].as_array().expect("messages array");
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[0]["role"], "user");
+        assert_eq!(msgs[1]["role"], "assistant");
+        assert!(msgs[1]["tool_calls"].as_array().is_some());
+        assert_eq!(msgs[2]["role"], "tool");
+        assert_eq!(msgs[2]["tool_call_id"], "tool_0");
+        assert_eq!(msgs[2]["content"], "file1.txt");
+    }
+
+    #[test]
+    fn new_rejects_empty_api_key() {
+        let result = OllamaBackend::new(&OllamaConfig {
+            api_key: "".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        });
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn new_accepts_valid_config() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "my-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        });
+        assert!(backend.is_ok());
+        let b = backend.unwrap();
+        assert_eq!(b.endpoint, "https://ollama.com/api/chat");
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -369,7 +369,9 @@ pub fn validate(config: &AppConfig, config_path: Option<&Path>) -> Result<()> {
         }
         "ollama" => {
             if let Some(ref ollama_config) = config.ollama {
-                if ollama_config.api_key.is_empty() {
+                if ollama_config.api_key.is_empty()
+                    && ollama_config.base_url == default_ollama_base_url()
+                {
                     let path = match config_path {
                         Some(p) => p.display().to_string(),
                         None => default_config_path()
@@ -379,7 +381,7 @@ pub fn validate(config: &AppConfig, config_path: Option<&Path>) -> Result<()> {
                             }),
                     };
                     bail!(
-                        "API key is required for ollama backend. Set it in your config file at:\n  {}",
+                        "API key is required for Ollama Cloud. Set it in your config file at:\n  {}\nOr set base_url to your self-hosted endpoint.",
                         path
                     );
                 }
@@ -705,7 +707,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_ollama_backend_with_empty_api_key_errors() {
+    fn validate_ollama_backend_with_empty_api_key_for_cloud_errors() {
         let config = AppConfig {
             backend: "ollama".to_string(),
             vertex: VertexConfig {
@@ -725,6 +727,28 @@ mod tests {
         let result = validate(&config, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn validate_ollama_backend_with_empty_api_key_for_self_hosted_succeeds() {
+        let config = AppConfig {
+            backend: "ollama".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+            ollama: Some(OllamaConfig {
+                api_key: "".to_string(),
+                model: "gpt-oss:120b".to_string(),
+                base_url: "http://localhost:11434/api/chat".to_string(),
+            }),
+            tools: ToolsConfig::default(),
+            sessions_dir: std::env::temp_dir(),
+        };
+        let result = validate(&config, None);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,7 @@ const DEFAULT_REGION: &str = "us-east5";
 const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
 const DEFAULT_BACKEND: &str = "vertex";
 
-const CONFIG_TEMPLATE: &str = r#"# Which backend to use: "vertex" or "zai"
+const CONFIG_TEMPLATE: &str = r#"# Which backend to use: "vertex", "zai", or "ollama"
 backend = "vertex"
 # where the session database files are stored. Defaults to $HOME/.config/illustrious-manager/sessions
 # or a local `illustrious-manager-sessions` directory if $HOME is not found.
@@ -112,6 +112,14 @@ model = "claude-sonnet-4-20250514"
 api_key = ""
 # Model to use
 model = "glm-5.1"
+
+[ollama]
+# Required: your Ollama API key
+api_key = ""
+# Model to use
+model = "gpt-oss:120b"
+# Base URL for Ollama API (change for self-hosted)
+# base_url = "https://ollama.com/api/chat"
 
 # [tools]
 # When to prompt for confirmation before executing a tool: Always, WriteOnly, or Never
@@ -136,6 +144,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub zai: Option<ZaiConfig>,
     #[serde(default)]
+    pub ollama: Option<OllamaConfig>,
+    #[serde(default)]
     pub tools: ToolsConfig,
 }
 
@@ -146,6 +156,24 @@ pub struct VertexConfig {
     pub region: String,
     #[serde(default = "default_model")]
     pub model: String,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct OllamaConfig {
+    #[serde(skip_serializing)]
+    pub api_key: String,
+    #[serde(default = "default_ollama_model")]
+    pub model: String,
+    #[serde(default = "default_ollama_base_url")]
+    pub base_url: String,
+}
+
+fn default_ollama_model() -> String {
+    "gpt-oss:120b".to_string()
+}
+
+fn default_ollama_base_url() -> String {
+    "https://ollama.com/api/chat".to_string()
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
@@ -236,6 +264,13 @@ pub fn apply_overrides(
                 && let Some(ref mut zai) = config.zai
             {
                 zai.model = m.to_string();
+            }
+        }
+        "ollama" => {
+            if let Some(m) = model
+                && let Some(ref mut ollama) = config.ollama
+            {
+                ollama.model = m.to_string();
             }
         }
         _ => {}
@@ -332,9 +367,31 @@ pub fn validate(config: &AppConfig, config_path: Option<&Path>) -> Result<()> {
                 );
             }
         }
+        "ollama" => {
+            if let Some(ref ollama_config) = config.ollama {
+                if ollama_config.api_key.is_empty() {
+                    let path = match config_path {
+                        Some(p) => p.display().to_string(),
+                        None => default_config_path()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|_| {
+                                "~/.config/illustrious-manager/config.toml".to_string()
+                            }),
+                    };
+                    bail!(
+                        "API key is required for ollama backend. Set it in your config file at:\n  {}",
+                        path
+                    );
+                }
+            } else {
+                bail!(
+                    "ollama backend configuration is missing. Add a [ollama] section to your config file."
+                );
+            }
+        }
         _ => {
             bail!(
-                "Invalid backend '{}'. Supported backends are: vertex, zai",
+                "Invalid backend '{}'. Supported backends are: vertex, zai, ollama",
                 config.backend
             );
         }
@@ -408,6 +465,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -426,6 +484,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -443,6 +502,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -464,6 +524,7 @@ mod tests {
                 api_key: "".to_string(),
                 model: "glm-5.1".to_string(),
             }),
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -485,6 +546,7 @@ mod tests {
                 api_key: "test-key".to_string(),
                 model: "glm-5.1".to_string(),
             }),
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -502,6 +564,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -520,6 +583,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -546,6 +610,7 @@ mod tests {
                 api_key: "secret-key".to_string(),
                 model: "glm-5.1".to_string(),
             }),
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
@@ -565,6 +630,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig {
                 confirmation: ConfirmationMode::Always,
                 sandbox_root: "/tmp/sandbox".to_string(),
@@ -590,6 +656,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: sessions_dir.clone(),
         };
@@ -610,10 +677,126 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
         };
         let msg = generate_intro_message(&config);
         assert!(msg.starts_with("# "), "should start with markdown heading");
+    }
+
+    #[test]
+    fn validate_ollama_backend_with_missing_config_errors() {
+        let config = AppConfig {
+            backend: "ollama".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+            ollama: None,
+            tools: ToolsConfig::default(),
+            sessions_dir: std::env::temp_dir(),
+        };
+        let result = validate(&config, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("[ollama]"));
+    }
+
+    #[test]
+    fn validate_ollama_backend_with_empty_api_key_errors() {
+        let config = AppConfig {
+            backend: "ollama".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+            ollama: Some(OllamaConfig {
+                api_key: "".to_string(),
+                model: "gpt-oss:120b".to_string(),
+                base_url: "https://ollama.com/api/chat".to_string(),
+            }),
+            tools: ToolsConfig::default(),
+            sessions_dir: std::env::temp_dir(),
+        };
+        let result = validate(&config, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn validate_ollama_backend_with_valid_config_succeeds() {
+        let config = AppConfig {
+            backend: "ollama".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+            ollama: Some(OllamaConfig {
+                api_key: "test-key".to_string(),
+                model: "gpt-oss:120b".to_string(),
+                base_url: "https://ollama.com/api/chat".to_string(),
+            }),
+            tools: ToolsConfig::default(),
+            sessions_dir: std::env::temp_dir(),
+        };
+        let result = validate(&config, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apply_overrides_ollama_model() {
+        let mut config = AppConfig {
+            backend: "ollama".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+            ollama: Some(OllamaConfig {
+                api_key: "test-key".to_string(),
+                model: "gpt-oss:120b".to_string(),
+                base_url: "https://ollama.com/api/chat".to_string(),
+            }),
+            tools: ToolsConfig::default(),
+            sessions_dir: std::env::temp_dir(),
+        };
+        apply_overrides(&mut config, None, None, Some("custom-model"));
+        assert_eq!(
+            config.ollama.as_ref().unwrap().model,
+            "custom-model",
+            "model override should be applied to ollama config"
+        );
+    }
+
+    #[test]
+    fn generate_intro_message_contains_ollama_backend_settings() {
+        let config = AppConfig {
+            backend: "ollama".to_string(),
+            vertex: VertexConfig {
+                project: "".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-sonnet-4-20250514".to_string(),
+            },
+            zai: None,
+            ollama: Some(OllamaConfig {
+                api_key: "secret-key".to_string(),
+                model: "gpt-oss:120b".to_string(),
+                base_url: "https://ollama.com/api/chat".to_string(),
+            }),
+            tools: ToolsConfig::default(),
+            sessions_dir: std::env::temp_dir(),
+        };
+        let msg = generate_intro_message(&config);
+        assert!(msg.contains("ollama"), "should mention backend name");
+        assert!(msg.contains("gpt-oss:120b"), "should mention ollama model");
+        assert!(msg.contains("ollama.com"), "should mention base_url");
+        assert!(!msg.contains("secret-key"), "should not leak API key");
     }
 }

--- a/src/frontend/tui/conversation_area.rs
+++ b/src/frontend/tui/conversation_area.rs
@@ -605,6 +605,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::path::PathBuf::from("/sessions"),
         };

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -1395,6 +1395,7 @@ mod tests {
                 model: "claude-sonnet-4-20250514".to_string(),
             },
             zai: None,
+            ollama: None,
             tools: ToolsConfig::default(),
             sessions_dir: std::path::PathBuf::from("/sessions"),
         };


### PR DESCRIPTION
Closes #92

Add a third `LlmBackend` implementation for Ollama Cloud (and self-hosted Ollama via configurable `base_url`). Mirrors the existing `zai` backend's structure but uses NDJSON streaming and Ollama's tool-call shape.

Implementation plan posted as a comment below.