### PR TITLE
Make Tool::execute async

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -417,7 +417,7 @@ async fn execute_tool_calls(
 
         let (result_content, is_error) = if approved {
             match tools.lookup(&call.name) {
-                Ok(tool) => match tool.execute(input) {
+                Ok(tool) => match tool.execute(input).await {
                     Ok(result) => {
                         let content = result
                             .content
@@ -544,6 +544,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl Tool for EchoTool {
         fn name(&self) -> &str {
             &self.name
@@ -557,7 +558,7 @@ mod tests {
         fn is_write_tool(&self) -> bool {
             self.is_write
         }
-        fn execute(&self, _input: serde_json::Value) -> Result<ToolExecResult, ToolError> {
+        async fn execute(&self, _input: serde_json::Value) -> Result<ToolExecResult, ToolError> {
             Ok(ToolExecResult {
                 content: vec![ContentBlock::Text(self.output.clone())],
                 is_error: false,

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -1,5 +1,6 @@
 use crate::config::ConfirmationMode;
 use crate::types::ContentBlock;
+use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -68,6 +69,7 @@ impl BashTool {
     }
 }
 
+#[async_trait]
 impl Tool for BashTool {
     fn name(&self) -> &str {
         "bash"
@@ -102,7 +104,7 @@ impl Tool for BashTool {
         format!("```\n{}\n```", text)
     }
 
-    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
         let command = input
             .get("command")
             .and_then(|v| v.as_str())
@@ -192,8 +194,8 @@ mod tests {
         )
     }
 
-    #[test]
-    fn allowlisted_command_executes_without_confirmation() {
+    #[tokio::test]
+    async fn allowlisted_command_executes_without_confirmation() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Always,
@@ -202,6 +204,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo hello"}))
+            .await
             .expect("should succeed");
         assert!(!result.is_error);
         match &result.content[0] {
@@ -210,8 +213,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn denylisted_command_is_rejected() {
+    #[tokio::test]
+    async fn denylisted_command_is_rejected() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -220,6 +223,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "rm -rf /"}))
+            .await
             .expect("execute must not err");
         assert!(result.is_error);
         match &result.content[0] {
@@ -228,8 +232,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unlisted_command_with_never_policy_executes() {
+    #[tokio::test]
+    async fn unlisted_command_with_never_policy_executes() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -238,12 +242,13 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "pwd"}))
+            .await
             .expect("should succeed");
         assert!(!result.is_error);
     }
 
-    #[test]
-    fn unlisted_command_with_always_policy_and_approved_executes() {
+    #[tokio::test]
+    async fn unlisted_command_with_always_policy_and_approved_executes() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Always,
@@ -252,12 +257,13 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "pwd"}))
+            .await
             .expect("should succeed");
         assert!(!result.is_error);
     }
 
-    #[test]
-    fn unlisted_command_with_always_policy_and_denied_returns_error() {
+    #[tokio::test]
+    async fn unlisted_command_with_always_policy_and_denied_returns_error() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Always,
@@ -266,12 +272,13 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "pwd"}))
+            .await
             .expect("execute must not err");
         assert!(result.is_error);
     }
 
-    #[test]
-    fn unlisted_command_with_write_only_policy_and_denied_returns_error() {
+    #[tokio::test]
+    async fn unlisted_command_with_write_only_policy_and_denied_returns_error() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::WriteOnly,
@@ -280,12 +287,13 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "pwd"}))
+            .await
             .expect("execute must not err");
         assert!(result.is_error);
     }
 
-    #[test]
-    fn piped_command_with_denylisted_segment_is_rejected() {
+    #[tokio::test]
+    async fn piped_command_with_denylisted_segment_is_rejected() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -294,6 +302,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "cat file.txt | rm -rf /"}))
+            .await
             .expect("execute must not err");
         assert!(result.is_error);
         match &result.content[0] {
@@ -302,8 +311,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn piped_command_with_all_allowlisted_segments_executes_without_confirmation() {
+    #[tokio::test]
+    async fn piped_command_with_all_allowlisted_segments_executes_without_confirmation() {
         let temp_dir = TempDir::new().expect("temp dir");
         // confirm_fn panics to prove it is not called
         let tool = make_tool(
@@ -313,17 +322,19 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo hello | cat"}))
+            .await
             .expect("should succeed");
         assert!(!result.is_error);
     }
 
-    #[test]
-    fn command_runs_with_sandbox_root_as_cwd() {
+    #[tokio::test]
+    async fn command_runs_with_sandbox_root_as_cwd() {
         let temp_dir = TempDir::new().expect("temp dir");
         let sandbox = temp_dir.path().canonicalize().expect("canonicalize");
         let tool = make_tool(ConfirmationMode::Never, sandbox.clone(), Box::new(|_| true));
         let result = tool
             .execute(serde_json::json!({"command": "pwd"}))
+            .await
             .expect("should succeed");
         assert!(!result.is_error);
         match &result.content[0] {
@@ -338,8 +349,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn command_failure_returns_is_error_true_with_stderr() {
+    #[tokio::test]
+    async fn command_failure_returns_is_error_true_with_stderr() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -348,6 +359,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo 'err msg' >&2; exit 1"}))
+            .await
             .expect("execute must not err");
         assert!(result.is_error);
         match &result.content[0] {
@@ -356,20 +368,22 @@ mod tests {
         }
     }
 
-    #[test]
-    fn missing_command_field_returns_invalid_input_error() {
+    #[tokio::test]
+    async fn missing_command_field_returns_invalid_input_error() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
             temp_dir.path().to_path_buf(),
             Box::new(|_| true),
         );
-        let result = tool.execute(serde_json::json!({"not_command": "echo hello"}));
+        let result = tool
+            .execute(serde_json::json!({"not_command": "echo hello"}))
+            .await;
         assert!(matches!(result, Err(ToolError::InvalidInput { .. })));
     }
 
-    #[test]
-    fn and_operator_denylist_bypass_is_blocked() {
+    #[tokio::test]
+    async fn and_operator_denylist_bypass_is_blocked() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -378,6 +392,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo hello && rm -rf /"}))
+            .await
             .expect("execute must not err");
         assert!(
             result.is_error,
@@ -385,8 +400,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn semicolon_denylist_bypass_is_blocked() {
+    #[tokio::test]
+    async fn semicolon_denylist_bypass_is_blocked() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -395,6 +410,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo hello; rm -rf /"}))
+            .await
             .expect("execute must not err");
         assert!(
             result.is_error,
@@ -402,8 +418,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn newline_denylist_bypass_is_blocked() {
+    #[tokio::test]
+    async fn newline_denylist_bypass_is_blocked() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -412,6 +428,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo hello\nrm -rf /"}))
+            .await
             .expect("execute must not err");
         assert!(
             result.is_error,
@@ -419,8 +436,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn subshell_denylist_bypass_is_blocked() {
+    #[tokio::test]
+    async fn subshell_denylist_bypass_is_blocked() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -429,6 +446,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo $(rm -rf /)"}))
+            .await
             .expect("execute must not err");
         assert!(
             result.is_error,
@@ -436,8 +454,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn backtick_denylist_bypass_is_blocked() {
+    #[tokio::test]
+    async fn backtick_denylist_bypass_is_blocked() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -446,6 +464,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo `rm -rf /`"}))
+            .await
             .expect("execute must not err");
         assert!(
             result.is_error,
@@ -453,8 +472,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn silent_command_produces_no_output_sentinel() {
+    #[tokio::test]
+    async fn silent_command_produces_no_output_sentinel() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -463,6 +482,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "true"}))
+            .await
             .expect("should succeed");
         assert!(!result.is_error);
         match &result.content[0] {
@@ -474,8 +494,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn markdown_input_wraps_command_in_sh_code_block() {
+    #[tokio::test]
+    async fn markdown_input_wraps_command_in_sh_code_block() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -487,8 +507,8 @@ mod tests {
         assert!(md.contains("ls -la"), "should include command");
     }
 
-    #[test]
-    fn markdown_output_wraps_result_in_code_block() {
+    #[tokio::test]
+    async fn markdown_output_wraps_result_in_code_block() {
         let temp_dir = TempDir::new().expect("temp dir");
         let tool = make_tool(
             ConfirmationMode::Never,
@@ -497,6 +517,7 @@ mod tests {
         );
         let result = tool
             .execute(serde_json::json!({"command": "echo hello"}))
+            .await
             .expect("should succeed");
         let md = tool.markdown_output(&result);
         assert!(md.contains("```"), "should wrap in code block");

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -1,6 +1,7 @@
 use crate::tools::sandbox::SandboxPolicy;
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
+use async_trait::async_trait;
 use serde_json::Value;
 use std::path::Path;
 
@@ -19,6 +20,7 @@ impl EditFile {
     }
 }
 
+#[async_trait]
 impl Tool for EditFile {
     fn name(&self) -> &str {
         "edit_file"
@@ -84,7 +86,7 @@ impl Tool for EditFile {
     fn is_write_tool(&self) -> bool {
         true
     }
-    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
         use std::fs;
 
         let path_str =
@@ -175,8 +177,8 @@ mod tests {
         (temp_dir, file_path)
     }
 
-    #[test]
-    fn successful_replacement_writes_correct_content() {
+    #[tokio::test]
+    async fn successful_replacement_writes_correct_content() {
         let (_temp_dir, file_path) = create_test_file("hello world\nfoo bar\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -187,15 +189,15 @@ mod tests {
             "new_string": "goodbye world"
         });
 
-        let result = tool.execute(input).expect("Execution should succeed");
+        let result = tool.execute(input).await.expect("Execution should succeed");
         assert!(!result.is_error, "Result should not be an error");
 
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
         assert_eq!(content, "goodbye world\nfoo bar\n");
     }
 
-    #[test]
-    fn old_string_not_found_returns_error() {
+    #[tokio::test]
+    async fn old_string_not_found_returns_error() {
         let (_temp_dir, file_path) = create_test_file("hello world\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -206,15 +208,15 @@ mod tests {
             "new_string": "replacement"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         assert!(
             result.is_err(),
             "Should return error when old_string not found"
         );
     }
 
-    #[test]
-    fn old_string_matches_multiple_locations_returns_error() {
+    #[tokio::test]
+    async fn old_string_matches_multiple_locations_returns_error() {
         let (_temp_dir, file_path) = create_test_file("hello world\nhello there\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -225,15 +227,15 @@ mod tests {
             "new_string": "goodbye"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         assert!(
             result.is_err(),
             "Should return error when old_string matches multiple locations"
         );
     }
 
-    #[test]
-    fn path_outside_sandbox_returns_error() {
+    #[tokio::test]
+    async fn path_outside_sandbox_returns_error() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
 
@@ -248,15 +250,15 @@ mod tests {
             "new_string": "replacement"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         assert!(
             result.is_err(),
             "Should return error for path outside sandbox"
         );
     }
 
-    #[test]
-    fn file_doesnt_exist_returns_error() {
+    #[tokio::test]
+    async fn file_doesnt_exist_returns_error() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = EditFile::new(sandbox);
@@ -267,15 +269,15 @@ mod tests {
             "new_string": "new"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         assert!(
             result.is_err(),
             "Should return error when file doesn't exist"
         );
     }
 
-    #[test]
-    fn empty_old_string_returns_error() {
+    #[tokio::test]
+    async fn empty_old_string_returns_error() {
         let (_temp_dir, file_path) = create_test_file("content\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -286,12 +288,12 @@ mod tests {
             "new_string": "replacement"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         assert!(result.is_err(), "Should return error for empty old_string");
     }
 
-    #[test]
-    fn new_string_can_be_empty() {
+    #[tokio::test]
+    async fn new_string_can_be_empty() {
         let (_temp_dir, file_path) = create_test_file("hello world\nfoo bar\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -302,15 +304,15 @@ mod tests {
             "new_string": ""
         });
 
-        let result = tool.execute(input).expect("Execution should succeed");
+        let result = tool.execute(input).await.expect("Execution should succeed");
         assert!(!result.is_error, "Result should not be an error");
 
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
         assert_eq!(content, "foo bar\n");
     }
 
-    #[test]
-    fn markdown_input_formats_as_diff() {
+    #[tokio::test]
+    async fn markdown_input_formats_as_diff() {
         let (_temp_dir, file_path) = create_test_file("hello world\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -327,8 +329,8 @@ mod tests {
         assert!(md.contains("`test.txt`"), "should show file path");
     }
 
-    #[test]
-    fn markdown_output_returns_result_text() {
+    #[tokio::test]
+    async fn markdown_output_returns_result_text() {
         let (_temp_dir, file_path) = create_test_file("hello world\n");
         let sandbox = SandboxPolicy::new(file_path.parent().unwrap());
         let tool = EditFile::new(sandbox);
@@ -338,7 +340,7 @@ mod tests {
             "old_string": "hello world",
             "new_string": "goodbye"
         });
-        let result = tool.execute(input).expect("should succeed");
+        let result = tool.execute(input).await.expect("should succeed");
         let md = tool.markdown_output(&result);
         assert!(
             md.contains("Successfully replaced"),

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -8,6 +8,7 @@ pub mod skill;
 pub mod write_file;
 
 use crate::types::ContentBlock;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -53,11 +54,12 @@ pub struct ToolResult {
 pub use crate::types::ToolDefinition;
 
 /// Trait that all tools must implement
+#[async_trait]
 pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn input_schema(&self) -> &Value;
-    fn execute(&self, input: Value) -> Result<ToolResult, ToolError>;
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError>;
     fn is_write_tool(&self) -> bool {
         false
     }
@@ -160,6 +162,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl Tool for MockTool {
         fn name(&self) -> &str {
             &self.name
@@ -173,7 +176,7 @@ mod tests {
             &self.schema
         }
 
-        fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
             Ok(ToolResult {
                 content: vec![ContentBlock::Text(format!("executed with: {}", input))],
                 is_error: false,
@@ -195,6 +198,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl Tool for FailingTool {
         fn name(&self) -> &str {
             &self.name
@@ -208,7 +212,7 @@ mod tests {
             &self.schema
         }
 
-        fn execute(&self, _input: Value) -> Result<ToolResult, ToolError> {
+        async fn execute(&self, _input: Value) -> Result<ToolResult, ToolError> {
             Err(ToolError::Execution {
                 tool_name: self.name.clone(),
                 message: "Tool execution failed".to_string(),
@@ -216,8 +220,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn register_tool_then_lookup_by_name() {
+    #[tokio::test]
+    async fn register_tool_then_lookup_by_name() {
         let mut registry = ToolRegistry::new();
         let tool = MockTool::new("test_tool", "A test tool");
 
@@ -232,8 +236,8 @@ mod tests {
         assert_eq!(retrieved_tool.description(), "A test tool");
     }
 
-    #[test]
-    fn definitions_returns_vec_of_tool_definitions() {
+    #[tokio::test]
+    async fn definitions_returns_vec_of_tool_definitions() {
         let mut registry = ToolRegistry::new();
         let tool1 = MockTool::new("tool1", "First tool");
         let tool2 = MockTool::new("tool2", "Second tool");
@@ -264,8 +268,8 @@ mod tests {
         assert_eq!(def2.description, "Second tool");
     }
 
-    #[test]
-    fn lookup_unregistered_tool_returns_error() {
+    #[tokio::test]
+    async fn lookup_unregistered_tool_returns_error() {
         let registry = ToolRegistry::new();
         let result = registry.lookup("nonexistent");
 
@@ -278,8 +282,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn register_duplicate_tool_returns_error() {
+    #[tokio::test]
+    async fn register_duplicate_tool_returns_error() {
         let mut registry = ToolRegistry::new();
         let tool1 = MockTool::new("duplicate", "First");
         let tool2 = MockTool::new("duplicate", "Second");
@@ -298,12 +302,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tool_execute_returns_success_result() {
+    #[tokio::test]
+    async fn tool_execute_returns_success_result() {
         let tool = MockTool::new("executor", "Executes things");
         let input = serde_json::json!({"arg1": "test"});
 
-        let result = tool.execute(input).expect("Execution should succeed");
+        let result = tool.execute(input).await.expect("Execution should succeed");
 
         assert!(!result.is_error);
         assert_eq!(result.content.len(), 1);
@@ -318,12 +322,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tool_execute_can_return_error_result() {
+    #[tokio::test]
+    async fn tool_execute_can_return_error_result() {
         let tool = FailingTool::new("failing_tool");
         let input = serde_json::json!({});
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
 
         match result {
             Err(ToolError::Execution { tool_name, message }) => {
@@ -335,8 +339,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn tool_result_serializes_correctly() {
+    #[tokio::test]
+    async fn tool_result_serializes_correctly() {
         let result = ToolResult {
             content: vec![ContentBlock::Text("output".to_string())],
             is_error: false,
@@ -349,8 +353,8 @@ mod tests {
         assert!(parsed["content"].is_array());
     }
 
-    #[test]
-    fn tool_definition_serializes_correctly() {
+    #[tokio::test]
+    async fn tool_definition_serializes_correctly() {
         let def = ToolDefinition {
             name: "test_tool".to_string(),
             description: "A test tool".to_string(),
@@ -365,8 +369,8 @@ mod tests {
         assert_eq!(parsed["input_schema"]["type"], "object");
     }
 
-    #[test]
-    fn tool_error_not_found_display_formatting() {
+    #[tokio::test]
+    async fn tool_error_not_found_display_formatting() {
         let err = ToolError::NotFound {
             tool_name: "my_tool".to_string(),
         };
@@ -374,16 +378,16 @@ mod tests {
         assert_eq!(err.to_string(), "Tool 'my_tool' not found");
     }
 
-    #[test]
-    fn tool_error_already_registered_display_formatting() {
+    #[tokio::test]
+    async fn tool_error_already_registered_display_formatting() {
         let err = ToolError::AlreadyRegistered {
             tool_name: "my_tool".to_string(),
         };
         assert_eq!(format!("{}", err), "Tool 'my_tool' already registered");
     }
 
-    #[test]
-    fn default_markdown_input_formats_as_json_code_block() {
+    #[tokio::test]
+    async fn default_markdown_input_formats_as_json_code_block() {
         let tool = MockTool::new("test", "A test tool");
         let input = serde_json::json!({"arg1": "value"});
         let md = tool.markdown_input(&input);
@@ -391,11 +395,12 @@ mod tests {
         assert!(md.contains("arg1"), "should contain the field name");
     }
 
-    #[test]
-    fn default_markdown_output_returns_text_content() {
+    #[tokio::test]
+    async fn default_markdown_output_returns_text_content() {
         let tool = MockTool::new("test", "A test tool");
         let result = tool
             .execute(serde_json::json!({"arg1": "hello"}))
+            .await
             .expect("should succeed");
         let md = tool.markdown_output(&result);
         assert!(

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -1,4 +1,5 @@
 use crate::types::ContentBlock;
+use async_trait::async_trait;
 use search_semantically::SearchEngine;
 use serde_json::Value;
 use std::path::PathBuf;
@@ -50,6 +51,7 @@ impl SearchTool {
     }
 }
 
+#[async_trait]
 impl Tool for SearchTool {
     fn name(&self) -> &str {
         "search"
@@ -63,7 +65,7 @@ impl Tool for SearchTool {
         &self.schema
     }
 
-    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
         let query = input["query"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput {
@@ -99,22 +101,22 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    #[test]
-    fn search_tool_has_correct_name() {
+    #[tokio::test]
+    async fn search_tool_has_correct_name() {
         let temp = TempDir::new().expect("temp dir");
         let tool = SearchTool::new(temp.path().to_path_buf());
         assert_eq!(tool.name(), "search");
     }
 
-    #[test]
-    fn search_tool_has_description() {
+    #[tokio::test]
+    async fn search_tool_has_description() {
         let temp = TempDir::new().expect("temp dir");
         let tool = SearchTool::new(temp.path().to_path_buf());
         assert!(!tool.description().is_empty());
     }
 
-    #[test]
-    fn search_tool_input_schema_has_query() {
+    #[tokio::test]
+    async fn search_tool_input_schema_has_query() {
         let temp = TempDir::new().expect("temp dir");
         let tool = SearchTool::new(temp.path().to_path_buf());
         let schema = tool.input_schema();
@@ -125,18 +127,18 @@ mod tests {
         assert!(required.iter().any(|r| r == "query"));
     }
 
-    #[test]
-    fn search_tool_is_not_a_write_tool() {
+    #[tokio::test]
+    async fn search_tool_is_not_a_write_tool() {
         let temp = TempDir::new().expect("temp dir");
         let tool = SearchTool::new(temp.path().to_path_buf());
         assert!(!tool.is_write_tool());
     }
 
-    #[test]
-    fn search_tool_requires_query_field() {
+    #[tokio::test]
+    async fn search_tool_requires_query_field() {
         let temp = TempDir::new().expect("temp dir");
         let tool = SearchTool::new(temp.path().to_path_buf());
-        let result = tool.execute(serde_json::json!({}));
+        let result = tool.execute(serde_json::json!({})).await;
         assert!(result.is_err());
         match result {
             Err(ToolError::InvalidInput { message }) => {
@@ -146,8 +148,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn search_tool_registered_in_registry() {
+    #[tokio::test]
+    async fn search_tool_registered_in_registry() {
         let temp = TempDir::new().expect("temp dir");
         let mut registry = crate::tools::ToolRegistry::new();
         let tool = SearchTool::new(temp.path().to_path_buf());
@@ -156,8 +158,8 @@ mod tests {
         assert_eq!(def.name(), "search");
     }
 
-    #[test]
-    fn rebuild_deletes_index_db() {
+    #[tokio::test]
+    async fn rebuild_deletes_index_db() {
         let temp = TempDir::new().expect("temp dir");
         let index_dir = temp.path().join(".search-index");
         std::fs::create_dir_all(&index_dir).expect("dir");
@@ -171,8 +173,8 @@ mod tests {
         assert!(!index_dir.join("search.db-wal").exists());
     }
 
-    #[test]
-    fn execute_returns_results_for_populated_project() {
+    #[tokio::test]
+    async fn execute_returns_results_for_populated_project() {
         let temp = TempDir::new().expect("temp dir");
         std::fs::write(
             temp.path().join("main.rs"),
@@ -185,6 +187,7 @@ mod tests {
             .execute(serde_json::json!({
                 "query": "calculate_total"
             }))
+            .await
             .expect("execute should succeed");
 
         assert!(!result.is_error);
@@ -203,8 +206,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn execute_with_rebuild_fresh_search() {
+    #[tokio::test]
+    async fn execute_with_rebuild_fresh_search() {
         let temp = TempDir::new().expect("temp dir");
         std::fs::write(
             temp.path().join("lib.rs"),
@@ -219,13 +222,14 @@ mod tests {
                 "query": "process_data",
                 "rebuild": true
             }))
+            .await
             .expect("execute with rebuild should succeed");
 
         assert!(!result.is_error);
     }
 
-    #[test]
-    fn execute_empty_project_returns_no_results() {
+    #[tokio::test]
+    async fn execute_empty_project_returns_no_results() {
         let temp = TempDir::new().expect("temp dir");
 
         let tool = SearchTool::new(temp.path().to_path_buf());
@@ -233,6 +237,7 @@ mod tests {
             .execute(serde_json::json!({
                 "query": "anything"
             }))
+            .await
             .expect("execute should succeed");
 
         assert!(!result.is_error);

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -1,5 +1,6 @@
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
+use async_trait::async_trait;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -16,6 +17,7 @@ impl SkillTool {
     }
 }
 
+#[async_trait]
 impl Tool for SkillTool {
     fn name(&self) -> &str {
         "skill"
@@ -42,7 +44,7 @@ impl Tool for SkillTool {
         &SCHEMA
     }
 
-    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
         let name =
             input
                 .get("name")
@@ -146,8 +148,8 @@ mod tests {
         f.write_all(content.as_bytes()).expect("write SKILL.md");
     }
 
-    #[test]
-    fn discover_skills_finds_skills_in_home() {
+    #[tokio::test]
+    async fn discover_skills_finds_skills_in_home() {
         let pwd = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
         make_skill(home.path(), "my-skill", "# My Skill\nContent here");
@@ -157,8 +159,8 @@ mod tests {
         assert!(skills.contains_key("my-skill"), "should find home skill");
     }
 
-    #[test]
-    fn discover_skills_finds_skills_in_pwd() {
+    #[tokio::test]
+    async fn discover_skills_finds_skills_in_pwd() {
         let pwd = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
         make_skill(pwd.path(), "local-skill", "# Local Skill");
@@ -168,8 +170,8 @@ mod tests {
         assert!(skills.contains_key("local-skill"), "should find pwd skill");
     }
 
-    #[test]
-    fn discover_skills_finds_skills_from_both_locations() {
+    #[tokio::test]
+    async fn discover_skills_finds_skills_from_both_locations() {
         let pwd = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
         make_skill(home.path(), "home-skill", "# Home Skill");
@@ -181,8 +183,8 @@ mod tests {
         assert!(skills.contains_key("pwd-skill"));
     }
 
-    #[test]
-    fn discover_skills_ignores_dirs_without_skill_md() {
+    #[tokio::test]
+    async fn discover_skills_ignores_dirs_without_skill_md() {
         let pwd = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
         let empty_dir = home.path().join(".claude/skills/empty-skill");
@@ -196,8 +198,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn discover_skills_returns_empty_when_no_skill_dirs_exist() {
+    #[tokio::test]
+    async fn discover_skills_returns_empty_when_no_skill_dirs_exist() {
         let pwd = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
 
@@ -206,8 +208,8 @@ mod tests {
         assert!(skills.is_empty());
     }
 
-    #[test]
-    fn pwd_skill_overrides_home_skill_with_same_name() {
+    #[tokio::test]
+    async fn pwd_skill_overrides_home_skill_with_same_name() {
         let pwd = TempDir::new().unwrap();
         let home = TempDir::new().unwrap();
         make_skill(home.path(), "shared-skill", "# Home version");
@@ -248,8 +250,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn skill_tool_execute_returns_file_content() {
+    #[tokio::test]
+    async fn skill_tool_execute_returns_file_content() {
         let dir = TempDir::new().unwrap();
         let skill_file = dir.path().join("my-skill.md");
         fs::write(&skill_file, "# Skill Content\nThis is the skill prompt").unwrap();
@@ -260,6 +262,7 @@ mod tests {
 
         let result = tool
             .execute(serde_json::json!({"name": "my-skill"}))
+            .await
             .expect("should succeed");
 
         assert!(!result.is_error);
@@ -271,11 +274,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn skill_tool_execute_unknown_name_returns_error() {
+    #[tokio::test]
+    async fn skill_tool_execute_unknown_name_returns_error() {
         let tool = SkillTool::new(&HashMap::new());
 
-        let result = tool.execute(serde_json::json!({"name": "nonexistent"}));
+        let result = tool
+            .execute(serde_json::json!({"name": "nonexistent"}))
+            .await;
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -289,23 +294,23 @@ mod tests {
         }
     }
 
-    #[test]
-    fn skill_tool_execute_missing_name_field_returns_invalid_input() {
+    #[tokio::test]
+    async fn skill_tool_execute_missing_name_field_returns_invalid_input() {
         let tool = SkillTool::new(&HashMap::new());
 
-        let result = tool.execute(serde_json::json!({}));
+        let result = tool.execute(serde_json::json!({})).await;
 
         assert!(matches!(result, Err(ToolError::InvalidInput { .. })));
     }
 
-    #[test]
-    fn skill_tool_is_not_a_write_tool() {
+    #[tokio::test]
+    async fn skill_tool_is_not_a_write_tool() {
         let tool = SkillTool::new(&HashMap::new());
         assert!(!tool.is_write_tool());
     }
 
-    #[test]
-    fn skill_description_extracts_description_from_frontmatter() {
+    #[tokio::test]
+    async fn skill_description_extracts_description_from_frontmatter() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("skill.md");
         fs::write(
@@ -317,8 +322,8 @@ mod tests {
         assert_eq!(skill_description(&path).unwrap(), "does the thing");
     }
 
-    #[test]
-    fn skill_description_returns_none_when_no_frontmatter() {
+    #[tokio::test]
+    async fn skill_description_returns_none_when_no_frontmatter() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("skill.md");
         fs::write(&path, "# My Skill\nNo frontmatter here").unwrap();
@@ -326,8 +331,8 @@ mod tests {
         assert!(skill_description(&path).is_none());
     }
 
-    #[test]
-    fn skill_description_returns_none_when_description_field_missing() {
+    #[tokio::test]
+    async fn skill_description_returns_none_when_description_field_missing() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("skill.md");
         fs::write(&path, "---\nname: my-skill\n---\n\n# Body").unwrap();
@@ -335,8 +340,8 @@ mod tests {
         assert!(skill_description(&path).is_none());
     }
 
-    #[test]
-    fn skill_description_returns_none_for_missing_file() {
+    #[tokio::test]
+    async fn skill_description_returns_none_for_missing_file() {
         assert!(skill_description(Path::new("/nonexistent/path.md")).is_none());
     }
 }

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use async_trait::async_trait;
 use serde_json::Value;
 
 use super::{Tool, ToolError, ToolResult};
@@ -33,6 +34,7 @@ impl WriteFileTool {
     }
 }
 
+#[async_trait]
 impl Tool for WriteFileTool {
     fn name(&self) -> &str {
         "write_file"
@@ -70,7 +72,7 @@ impl Tool for WriteFileTool {
     fn is_write_tool(&self) -> bool {
         true
     }
-    fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
         let path_str = input["path"]
             .as_str()
             .ok_or_else(|| ToolError::InvalidInput {
@@ -133,8 +135,8 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    #[test]
-    fn write_file_creates_new_file_with_correct_content() {
+    #[tokio::test]
+    async fn write_file_creates_new_file_with_correct_content() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = WriteFileTool::new(sandbox);
@@ -145,15 +147,15 @@ mod tests {
             "content": "Hello, world!"
         });
 
-        let result = tool.execute(input).expect("Write should succeed");
+        let result = tool.execute(input).await.expect("Write should succeed");
         assert!(!result.is_error);
 
         let written = fs::read_to_string(&file_path).expect("File should exist");
         assert_eq!(written, "Hello, world!");
     }
 
-    #[test]
-    fn write_file_overwrites_existing_file() {
+    #[tokio::test]
+    async fn write_file_overwrites_existing_file() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let file_path = temp_dir.path().join("existing.txt");
         fs::write(&file_path, "old content").expect("Failed to create file");
@@ -166,14 +168,14 @@ mod tests {
             "content": "new content"
         });
 
-        tool.execute(input).expect("Write should succeed");
+        tool.execute(input).await.expect("Write should succeed");
 
         let written = fs::read_to_string(&file_path).expect("File should exist");
         assert_eq!(written, "new content");
     }
 
-    #[test]
-    fn write_file_creates_parent_directories() {
+    #[tokio::test]
+    async fn write_file_creates_parent_directories() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = WriteFileTool::new(sandbox);
@@ -189,15 +191,15 @@ mod tests {
             "content": "nested content"
         });
 
-        let result = tool.execute(input).expect("Write should succeed");
+        let result = tool.execute(input).await.expect("Write should succeed");
         assert!(!result.is_error);
 
         let written = fs::read_to_string(&file_path).expect("File should exist");
         assert_eq!(written, "nested content");
     }
 
-    #[test]
-    fn write_file_outside_sandbox_is_rejected() {
+    #[tokio::test]
+    async fn write_file_outside_sandbox_is_rejected() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = WriteFileTool::new(sandbox);
@@ -212,7 +214,7 @@ mod tests {
             "content": "should not be written"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         match result {
             Err(ToolError::Execution { .. }) => {}
             Ok(_) => panic!("Write outside sandbox should fail"),
@@ -220,8 +222,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn write_file_with_symlink_escaping_sandbox_is_rejected() {
+    #[tokio::test]
+    async fn write_file_with_symlink_escaping_sandbox_is_rejected() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let outside_dir = TempDir::new().expect("Failed to create outside dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
@@ -246,7 +248,7 @@ mod tests {
             "content": "should not be written"
         });
 
-        let result = tool.execute(input);
+        let result = tool.execute(input).await;
         match result {
             Err(ToolError::Execution { .. }) => {}
             Ok(_) => panic!("Symlink escaping sandbox should be rejected"),
@@ -254,8 +256,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn write_file_result_reports_bytes_written() {
+    #[tokio::test]
+    async fn write_file_result_reports_bytes_written() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = WriteFileTool::new(sandbox);
@@ -267,7 +269,7 @@ mod tests {
             "content": content
         });
 
-        let result = tool.execute(input).expect("Write should succeed");
+        let result = tool.execute(input).await.expect("Write should succeed");
         assert!(!result.is_error);
         assert_eq!(result.content.len(), 1);
         match &result.content[0] {
@@ -278,8 +280,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn markdown_input_formats_path_and_content() {
+    #[tokio::test]
+    async fn markdown_input_formats_path_and_content() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = WriteFileTool::new(sandbox);
@@ -294,8 +296,8 @@ mod tests {
         assert!(md.contains("fn main()"), "should include content");
     }
 
-    #[test]
-    fn markdown_output_returns_result_text() {
+    #[tokio::test]
+    async fn markdown_output_returns_result_text() {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let sandbox = SandboxPolicy::new(temp_dir.path());
         let tool = WriteFileTool::new(sandbox);
@@ -305,7 +307,7 @@ mod tests {
             "path": file_path.to_str().expect("path"),
             "content": "data"
         });
-        let result = tool.execute(input).expect("Write should succeed");
+        let result = tool.execute(input).await.expect("Write should succeed");
         let md = tool.markdown_output(&result);
         assert!(md.contains("Wrote"), "should contain wrote message");
     }


### PR DESCRIPTION
Closes #137

Refactor the `Tool` trait so that `execute` is an async method, enabling tools to perform async I/O (database queries, network calls) directly without workarounds. Prerequisite for task management tools (issue 136).

Implementation plan posted as a comment below.