### PR TITLE
feat: task management tools

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -413,13 +413,16 @@ async fn execute_tool_calls(
     let mut tool_result_blocks: Vec<ContentBlock> = vec![];
 
     for call in tool_calls {
-        let (input, parse_error) = match serde_json::from_str::<serde_json::Value>(&call.input_json)
-        {
-            Ok(v) => (v, None),
-            Err(e) => (
-                serde_json::Value::Null,
-                Some(format!("Invalid tool input JSON: {e}")),
-            ),
+        let (input, parse_error) = if call.input_json.trim().is_empty() {
+            (serde_json::Value::Object(serde_json::Map::new()), None)
+        } else {
+            match serde_json::from_str::<serde_json::Value>(&call.input_json) {
+                Ok(v) => (v, None),
+                Err(e) => (
+                    serde_json::Value::Null,
+                    Some(format!("Invalid tool input JSON: {e}")),
+                ),
+            }
         };
 
         assistant_content.push(ContentBlock::ToolUse {
@@ -1042,6 +1045,44 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, AgentEvent::ResponseComplete(_))),
             "loop should continue and complete after malformed input"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_tool_input_json_is_treated_as_empty_object() {
+        // Regression: LLM sends no input for a no-arg tool (e.g. list_tasks).
+        // The SSE stream delivers no ToolUseDelta events, leaving input_json = "".
+        // This must not produce an error — it should be treated as {}.
+        let empty_input_response: Vec<Result<StreamEvent>> = vec![
+            Ok(StreamEvent::ToolUseStart {
+                id: "t1".to_string(),
+                name: "bash".to_string(),
+            }),
+            // No ToolUseDelta — input_json stays empty
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::Done),
+        ];
+        let backend = SequencedBackend::new(vec![empty_input_response, text_response("ok")]);
+        let agent = agent_with_mode(
+            backend,
+            Some(Box::new(EchoTool::new("bash", "echo output"))),
+            ConfirmationMode::Never,
+        )
+        .await;
+
+        let stream = agent
+            .send("list".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AgentEvent::ToolResult { content, is_error, .. }
+                    if content == "echo output" && !is_error
+            )),
+            "empty input_json should execute successfully with empty object input"
         );
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -147,7 +147,12 @@ impl Agent {
     }
 
     pub async fn session_history(&self) -> Result<Vec<Message>, anyhow::Error> {
-        self.session.lock().await.conversation().load_history().await
+        self.session
+            .lock()
+            .await
+            .conversation()
+            .load_history()
+            .await
     }
 
     /// If the current session has no messages, delete its DB file from disk.
@@ -163,7 +168,11 @@ impl Agent {
     /// Non-persisted context messages (context files, skill definitions) are preserved
     /// at the front of history; only the persisted portion is replaced.
     pub async fn load_session(&self, session: Session) {
-        let new_history = session.conversation().load_history().await.unwrap_or_default();
+        let new_history = session
+            .conversation()
+            .load_history()
+            .await
+            .unwrap_or_default();
         {
             let prefix_len = *self
                 .context_prefix_len
@@ -222,7 +231,12 @@ impl Agent {
         let confirmation_mode = self.confirmation_mode.clone();
         let session = Arc::clone(&self.session);
 
-        self.session.lock().await.conversation().insert_message(&user_msg).await?;
+        self.session
+            .lock()
+            .await
+            .conversation()
+            .insert_message(&user_msg)
+            .await?;
 
         tokio::spawn(async move {
             let mut iterations = 0u32;
@@ -292,7 +306,12 @@ impl Agent {
                                     content: vec![ContentBlock::Text(text_accumulated.clone())],
                                 };
                                 lock(&history_arc).push(partial_msg.clone());
-                                let _ = session.lock().await.conversation().insert_message(&partial_msg).await;
+                                let _ = session
+                                    .lock()
+                                    .await
+                                    .conversation()
+                                    .insert_message(&partial_msg)
+                                    .await;
                             }
                             record_error(&e.to_string(), &history_arc, &session, &event_tx).await;
                             break 'outer;
@@ -310,7 +329,12 @@ impl Agent {
                         content,
                     };
                     lock(&history_arc).push(assistant_msg.clone());
-                    let _ = session.lock().await.conversation().insert_message(&assistant_msg).await;
+                    let _ = session
+                        .lock()
+                        .await
+                        .conversation()
+                        .insert_message(&assistant_msg)
+                        .await;
                     let _ = event_tx.unbounded_send(AgentEvent::ResponseComplete(text_accumulated));
                     break;
                 }
@@ -330,14 +354,24 @@ impl Agent {
                     content: assistant_content,
                 };
                 lock(&history_arc).push(assistant_msg.clone());
-                let _ = session.lock().await.conversation().insert_message(&assistant_msg).await;
+                let _ = session
+                    .lock()
+                    .await
+                    .conversation()
+                    .insert_message(&assistant_msg)
+                    .await;
 
                 let tool_result_msg = Message {
                     role: Role::User,
                     content: tool_result_blocks,
                 };
                 lock(&history_arc).push(tool_result_msg.clone());
-                let _ = session.lock().await.conversation().insert_message(&tool_result_msg).await;
+                let _ = session
+                    .lock()
+                    .await
+                    .conversation()
+                    .insert_message(&tool_result_msg)
+                    .await;
             }
         });
 
@@ -353,7 +387,12 @@ async fn record_error(
 ) {
     let error_user_msg = Message::text(Role::User, format!("[ERROR] {error_msg}"));
     lock(history).push(error_user_msg.clone());
-    let _ = session.lock().await.conversation().insert_message(&error_user_msg).await;
+    let _ = session
+        .lock()
+        .await
+        .conversation()
+        .insert_message(&error_user_msg)
+        .await;
     let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg.to_string()));
 }
 
@@ -1371,7 +1410,8 @@ mod tests {
             .await
             .expect("session a");
         session_a
-            .conversation().insert_message(&Message::text(Role::User, "session a message".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "session a message".to_string()))
             .await
             .expect("insert");
 
@@ -1379,7 +1419,8 @@ mod tests {
             .await
             .expect("session b");
         session_b
-            .conversation().insert_message(&Message::text(Role::User, "session b message".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "session b message".to_string()))
             .await
             .expect("insert");
 
@@ -1417,7 +1458,8 @@ mod tests {
             .await
             .expect("session a");
         session_a
-            .conversation().insert_message(&Message::text(Role::User, "session a message".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "session a message".to_string()))
             .await
             .expect("insert");
 
@@ -1425,7 +1467,8 @@ mod tests {
             .await
             .expect("session b");
         session_b
-            .conversation().insert_message(&Message::text(Role::User, "session b message".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "session b message".to_string()))
             .await
             .expect("insert");
 
@@ -1531,7 +1574,8 @@ mod tests {
 
         let session = Session::new(None, dir_path.clone()).await.expect("session");
         session
-            .conversation().insert_message(&Message::text(Role::User, "hello".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "hello".to_string()))
             .await
             .expect("insert");
         let db_path = dir_path.join(format!("{}.db", session.id));

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -44,9 +44,14 @@ impl Agent {
     pub async fn new(
         backend: Box<dyn LlmBackend>,
         config: RequestConfig,
-        session: Session,
+        session: Arc<TokioMutex<Session>>,
     ) -> Self {
-        let history: Vec<Message> = session.load_history().await.unwrap_or_default();
+        let history: Vec<Message> = session
+            .lock()
+            .await
+            .load_history()
+            .await
+            .unwrap_or_default();
 
         Self {
             backend: Arc::from(backend),
@@ -56,7 +61,7 @@ impl Agent {
             tools: Arc::new(ToolRegistry::new()),
             max_tool_iterations: 25,
             confirmation_mode: ConfirmationMode::WriteOnly,
-            session: Arc::new(TokioMutex::new(session)),
+            session,
         }
     }
 
@@ -478,7 +483,7 @@ pub async fn spawn_agent(
     factory: &BackendFactory,
     role: &str,
     tool_config: &ToolsConfig,
-    session: Session,
+    session: Arc<TokioMutex<Session>>,
     tools: ToolRegistry,
 ) -> anyhow::Result<Agent> {
     let selection = factory.for_role(role).await?;
@@ -491,7 +496,7 @@ pub async fn spawn_agent(
 pub async fn spawn_agent_with_selection(
     selection: crate::backend::BackendSelection,
     tool_config: &ToolsConfig,
-    session: Session,
+    session: Arc<TokioMutex<Session>>,
     tools: ToolRegistry,
 ) -> anyhow::Result<Agent> {
     let request_config = RequestConfig {
@@ -517,6 +522,10 @@ mod tests {
     async fn test_session() -> Session {
         let dir = tempfile::TempDir::new().expect("temp dir");
         Session::new(None, dir.keep()).await.expect("test session")
+    }
+
+    async fn test_session_arc() -> Arc<TokioMutex<Session>> {
+        Arc::new(TokioMutex::new(test_session().await))
     }
 
     struct SequencedBackend {
@@ -632,7 +641,7 @@ mod tests {
             confirmation: mode,
             ..Default::default()
         };
-        Agent::new(Box::new(backend), config, test_session().await)
+        Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config)
@@ -743,7 +752,7 @@ mod tests {
             .unbounded_send(ConfirmationResponse::Approved)
             .expect("send approval");
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -787,7 +796,7 @@ mod tests {
             .unbounded_send(ConfirmationResponse::Approved)
             .expect("send approval");
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -832,7 +841,7 @@ mod tests {
             .unbounded_send(ConfirmationResponse::Rejected)
             .expect("send rejection");
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -878,7 +887,7 @@ mod tests {
             ..Default::default()
         };
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -933,7 +942,7 @@ mod tests {
             ..Default::default()
         };
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -1197,7 +1206,7 @@ mod tests {
             ..Default::default()
         };
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -1271,7 +1280,7 @@ mod tests {
             .unbounded_send(ConfirmationResponse::Approved)
             .expect("send approval");
 
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_tools(registry)
             .with_tool_config(&tool_config);
@@ -1315,7 +1324,7 @@ mod tests {
             "another-skill".to_string(),
             std::path::PathBuf::from("/fake/path2"),
         );
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_skills(&skills);
 
@@ -1342,7 +1351,7 @@ mod tests {
             max_tokens: 100,
             tools: vec![],
         };
-        let agent = Agent::new(Box::new(backend), config, test_session().await)
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
             .with_skills(&std::collections::HashMap::new());
 
@@ -1378,7 +1387,12 @@ mod tests {
             max_tokens: 100,
             tools: vec![],
         };
-        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session_a).await;
+        let agent = Agent::new(
+            Box::new(SequencedBackend::new(vec![])),
+            config,
+            Arc::new(TokioMutex::new(session_a)),
+        )
+        .await;
 
         assert_eq!(agent.history().len(), 1);
         assert!(
@@ -1426,9 +1440,13 @@ mod tests {
         std::fs::write(&skill_path, "---\ndescription: A test skill\n---\nContent").expect("write");
         skills.insert("test-skill".to_string(), skill_path);
 
-        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session_a)
-            .await
-            .with_skills(&skills);
+        let agent = Agent::new(
+            Box::new(SequencedBackend::new(vec![])),
+            config,
+            Arc::new(TokioMutex::new(session_a)),
+        )
+        .await
+        .with_skills(&skills);
 
         // history should be: [skill_prefix, session_a_message]
         assert_eq!(agent.history().len(), 2);
@@ -1468,7 +1486,12 @@ mod tests {
             max_tokens: 100,
             tools: vec![],
         };
-        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session_a).await;
+        let agent = Agent::new(
+            Box::new(SequencedBackend::new(vec![])),
+            config,
+            Arc::new(TokioMutex::new(session_a)),
+        )
+        .await;
 
         assert_eq!(agent.session_id().await, id_a);
         agent.load_session(session_b).await;
@@ -1489,7 +1512,12 @@ mod tests {
             max_tokens: 100,
             tools: vec![],
         };
-        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session).await;
+        let agent = Agent::new(
+            Box::new(SequencedBackend::new(vec![])),
+            config,
+            Arc::new(TokioMutex::new(session)),
+        )
+        .await;
 
         agent.cleanup_empty_session().await.expect("cleanup");
         assert!(!db_path.exists());
@@ -1512,7 +1540,12 @@ mod tests {
             max_tokens: 100,
             tools: vec![],
         };
-        let agent = Agent::new(Box::new(SequencedBackend::new(vec![])), config, session).await;
+        let agent = Agent::new(
+            Box::new(SequencedBackend::new(vec![])),
+            config,
+            Arc::new(TokioMutex::new(session)),
+        )
+        .await;
 
         agent.cleanup_empty_session().await.expect("cleanup");
         assert!(db_path.exists());
@@ -1525,9 +1558,11 @@ mod tests {
         use crate::tools::ToolRegistry;
 
         let dir = tempfile::TempDir::new().expect("temp dir");
-        let session = Session::new(None, dir.path().to_path_buf())
-            .await
-            .expect("session");
+        let session = Arc::new(TokioMutex::new(
+            Session::new(None, dir.path().to_path_buf())
+                .await
+                .expect("session"),
+        ));
 
         let selection = BackendSelection {
             backend: Box::new(SequencedBackend::new(vec![])),

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -49,6 +49,7 @@ impl Agent {
         let history: Vec<Message> = session
             .lock()
             .await
+            .conversation()
             .load_history()
             .await
             .unwrap_or_default();
@@ -146,13 +147,13 @@ impl Agent {
     }
 
     pub async fn session_history(&self) -> Result<Vec<Message>, anyhow::Error> {
-        self.session.lock().await.load_history().await
+        self.session.lock().await.conversation().load_history().await
     }
 
     /// If the current session has no messages, delete its DB file from disk.
     pub async fn cleanup_empty_session(&self) -> Result<()> {
         let session = self.session.lock().await;
-        if session.is_empty().await? {
+        if session.conversation().is_empty().await? {
             session.delete_db()?;
         }
         Ok(())
@@ -162,7 +163,7 @@ impl Agent {
     /// Non-persisted context messages (context files, skill definitions) are preserved
     /// at the front of history; only the persisted portion is replaced.
     pub async fn load_session(&self, session: Session) {
-        let new_history = session.load_history().await.unwrap_or_default();
+        let new_history = session.conversation().load_history().await.unwrap_or_default();
         {
             let prefix_len = *self
                 .context_prefix_len
@@ -221,7 +222,7 @@ impl Agent {
         let confirmation_mode = self.confirmation_mode.clone();
         let session = Arc::clone(&self.session);
 
-        self.session.lock().await.insert_message(&user_msg).await?;
+        self.session.lock().await.conversation().insert_message(&user_msg).await?;
 
         tokio::spawn(async move {
             let mut iterations = 0u32;
@@ -291,7 +292,7 @@ impl Agent {
                                     content: vec![ContentBlock::Text(text_accumulated.clone())],
                                 };
                                 lock(&history_arc).push(partial_msg.clone());
-                                let _ = session.lock().await.insert_message(&partial_msg).await;
+                                let _ = session.lock().await.conversation().insert_message(&partial_msg).await;
                             }
                             record_error(&e.to_string(), &history_arc, &session, &event_tx).await;
                             break 'outer;
@@ -309,7 +310,7 @@ impl Agent {
                         content,
                     };
                     lock(&history_arc).push(assistant_msg.clone());
-                    let _ = session.lock().await.insert_message(&assistant_msg).await;
+                    let _ = session.lock().await.conversation().insert_message(&assistant_msg).await;
                     let _ = event_tx.unbounded_send(AgentEvent::ResponseComplete(text_accumulated));
                     break;
                 }
@@ -329,14 +330,14 @@ impl Agent {
                     content: assistant_content,
                 };
                 lock(&history_arc).push(assistant_msg.clone());
-                let _ = session.lock().await.insert_message(&assistant_msg).await;
+                let _ = session.lock().await.conversation().insert_message(&assistant_msg).await;
 
                 let tool_result_msg = Message {
                     role: Role::User,
                     content: tool_result_blocks,
                 };
                 lock(&history_arc).push(tool_result_msg.clone());
-                let _ = session.lock().await.insert_message(&tool_result_msg).await;
+                let _ = session.lock().await.conversation().insert_message(&tool_result_msg).await;
             }
         });
 
@@ -352,7 +353,7 @@ async fn record_error(
 ) {
     let error_user_msg = Message::text(Role::User, format!("[ERROR] {error_msg}"));
     lock(history).push(error_user_msg.clone());
-    let _ = session.lock().await.insert_message(&error_user_msg).await;
+    let _ = session.lock().await.conversation().insert_message(&error_user_msg).await;
     let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg.to_string()));
 }
 
@@ -1370,7 +1371,7 @@ mod tests {
             .await
             .expect("session a");
         session_a
-            .insert_message(&Message::text(Role::User, "session a message".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "session a message".to_string()))
             .await
             .expect("insert");
 
@@ -1378,7 +1379,7 @@ mod tests {
             .await
             .expect("session b");
         session_b
-            .insert_message(&Message::text(Role::User, "session b message".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "session b message".to_string()))
             .await
             .expect("insert");
 
@@ -1416,7 +1417,7 @@ mod tests {
             .await
             .expect("session a");
         session_a
-            .insert_message(&Message::text(Role::User, "session a message".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "session a message".to_string()))
             .await
             .expect("insert");
 
@@ -1424,7 +1425,7 @@ mod tests {
             .await
             .expect("session b");
         session_b
-            .insert_message(&Message::text(Role::User, "session b message".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "session b message".to_string()))
             .await
             .expect("insert");
 
@@ -1530,7 +1531,7 @@ mod tests {
 
         let session = Session::new(None, dir_path.clone()).await.expect("session");
         session
-            .insert_message(&Message::text(Role::User, "hello".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "hello".to_string()))
             .await
             .expect("insert");
         let db_path = dir_path.join(format!("{}.db", session.id));

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -744,7 +744,9 @@ mod tests {
             responses: Arc::new(tokio::sync::Mutex::new(responses)),
         };
         let dir = tempfile::TempDir::new().expect("temp dir");
-        let session = Session::new(None, dir.keep()).await.expect("test session");
+        let session = std::sync::Arc::new(tokio::sync::Mutex::new(
+            Session::new(None, dir.keep()).await.expect("test session"),
+        ));
         let config = crate::types::RequestConfig {
             model: "test".to_string(),
             max_tokens: 1024,

--- a/src/frontend/tui/commands.rs
+++ b/src/frontend/tui/commands.rs
@@ -223,9 +223,10 @@ mod tests {
 
         rt.block_on(async {
             let dir = tempfile::TempDir::new().expect("temp dir");
-            let session = crate::session::Session::new(None, dir.path().to_path_buf())
+            let session_inner = crate::session::Session::new(None, dir.path().to_path_buf())
                 .await
                 .expect("session");
+            let session = std::sync::Arc::new(tokio::sync::Mutex::new(session_inner));
             let agent = Arc::new(
                 crate::agent::Agent::new(
                     Box::new(FakeBackend),
@@ -261,9 +262,10 @@ mod tests {
 
         rt.block_on(async {
             let dir = tempfile::TempDir::new().expect("temp dir");
-            let session = crate::session::Session::new(None, dir.path().to_path_buf())
+            let session_inner = crate::session::Session::new(None, dir.path().to_path_buf())
                 .await
                 .expect("session");
+            let session = std::sync::Arc::new(tokio::sync::Mutex::new(session_inner));
             let agent = Arc::new(
                 crate::agent::Agent::new(
                     Box::new(FakeBackend),
@@ -298,9 +300,10 @@ mod tests {
 
         rt.block_on(async {
             let dir = tempfile::TempDir::new().expect("temp dir");
-            let session = crate::session::Session::new(None, dir.path().to_path_buf())
+            let session_inner = crate::session::Session::new(None, dir.path().to_path_buf())
                 .await
                 .expect("session");
+            let session = std::sync::Arc::new(tokio::sync::Mutex::new(session_inner));
             let agent = Arc::new(
                 crate::agent::Agent::new(
                     Box::new(FakeBackend),
@@ -335,9 +338,10 @@ mod tests {
 
         rt.block_on(async {
             let dir = tempfile::TempDir::new().expect("temp dir");
-            let session = crate::session::Session::new(None, dir.path().to_path_buf())
+            let session_inner = crate::session::Session::new(None, dir.path().to_path_buf())
                 .await
                 .expect("session");
+            let session = std::sync::Arc::new(tokio::sync::Mutex::new(session_inner));
             let agent = Arc::new(
                 crate::agent::Agent::new(
                     Box::new(FakeBackend),
@@ -372,9 +376,10 @@ mod tests {
 
         rt.block_on(async {
             let dir = tempfile::TempDir::new().expect("temp dir");
-            let session = crate::session::Session::new(None, dir.path().to_path_buf())
+            let session_inner = crate::session::Session::new(None, dir.path().to_path_buf())
                 .await
                 .expect("session");
+            let session = std::sync::Arc::new(tokio::sync::Mutex::new(session_inner));
             let agent = Arc::new(
                 crate::agent::Agent::new(
                     Box::new(FakeBackend),

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -1333,7 +1333,11 @@ mod tests {
         app.scroll_offset = 10;
 
         // simulate selecting the session
-        let history = session.conversation().load_history().await.expect("load history");
+        let history = session
+            .conversation()
+            .load_history()
+            .await
+            .expect("load history");
         app.conversation.clear();
         app.current_response.clear();
         app.scroll_offset = 0;

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -757,9 +757,11 @@ mod tests {
         }
 
         let dir = tempfile::TempDir::new().expect("temp dir");
-        let session = crate::session::Session::new(None, dir.keep())
-            .await
-            .expect("test session");
+        let session = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::session::Session::new(None, dir.keep())
+                .await
+                .expect("test session"),
+        ));
         let agent = Arc::new(
             Agent::new(
                 Box::new(StubBackend),
@@ -1303,6 +1305,11 @@ mod tests {
             .await
             .expect("insert");
 
+        let initial_session = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::session::Session::new(None, dir_path.clone())
+                .await
+                .expect("initial session"),
+        ));
         let agent = Arc::new(
             Agent::new(
                 Box::new(StubBackend),
@@ -1311,9 +1318,7 @@ mod tests {
                     max_tokens: 1024,
                     tools: vec![],
                 },
-                crate::session::Session::new(None, dir_path.clone())
-                    .await
-                    .expect("initial session"),
+                initial_session,
             )
             .await,
         );
@@ -1568,9 +1573,11 @@ mod tests {
         }
 
         let dir = tempfile::TempDir::new().expect("temp dir");
-        let session = crate::session::Session::new(None, dir.keep())
-            .await
-            .expect("test session");
+        let session = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::session::Session::new(None, dir.keep())
+                .await
+                .expect("test session"),
+        ));
         let agent = Arc::new(
             Agent::new(
                 Box::new(StubBackend),
@@ -1610,9 +1617,11 @@ mod tests {
         }
 
         let dir = tempfile::TempDir::new().expect("temp dir");
-        let session = crate::session::Session::new(None, dir.keep())
-            .await
-            .expect("test session");
+        let session = std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::session::Session::new(None, dir.keep())
+                .await
+                .expect("test session"),
+        ));
         let agent = Arc::new(
             Agent::new(
                 Box::new(StubBackend),

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -531,7 +531,7 @@ async fn run_app(
                                         .await
                                         {
                                             Ok(session) => {
-                                                match session.load_history().await {
+                                                match session.conversation().load_history().await {
                                                     Ok(history) => {
                                                         app.conversation.clear();
                                                         app.current_response.clear();
@@ -1301,6 +1301,7 @@ mod tests {
             .await
             .expect("session");
         session
+            .conversation()
             .insert_message(&Message::text(Role::User, "loaded message".to_string()))
             .await
             .expect("insert");
@@ -1332,7 +1333,7 @@ mod tests {
         app.scroll_offset = 10;
 
         // simulate selecting the session
-        let history = session.load_history().await.expect("load history");
+        let history = session.conversation().load_history().await.expect("load history");
         app.conversation.clear();
         app.current_response.clear();
         app.scroll_offset = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use tools::edit_file::EditFile;
 use tools::sandbox::SandboxPolicy;
 use tools::search::SearchTool;
 use tools::skill::{SkillTool, discover_skills_from_env};
+use tools::task::{CreateTaskTool, DeleteTaskTool, ListTasksTool, UpdateTaskTool};
 use tools::write_file::WriteFileTool;
 
 const DEFAULT_MAX_SCHEMA_RETRIES: u32 = 3;
@@ -160,14 +161,26 @@ async fn main() -> Result<()> {
     registry.register(Box::new(SkillTool::new(&skills)))?;
 
     let session = Session::new(cli.session_id.clone(), app_config.sessions_dir.clone()).await?;
+    let session_arc = Arc::new(tokio::sync::Mutex::new(session));
+
+    registry.register(Box::new(CreateTaskTool::new(Arc::clone(&session_arc))))?;
+    registry.register(Box::new(ListTasksTool::new(Arc::clone(&session_arc))))?;
+    registry.register(Box::new(UpdateTaskTool::new(Arc::clone(&session_arc))))?;
+    registry.register(Box::new(DeleteTaskTool::new(Arc::clone(&session_arc))))?;
 
     let agent = Arc::new(
-        spawn_agent(&factory, "default", &app_config.tools, session, registry)
-            .await?
-            // This ordering is because both `with_skills` and `with_context_files` PREPEND to history.
-            // because initial history is set from the input session
-            .with_skills(&skills)
-            .with_context_files()?,
+        spawn_agent(
+            &factory,
+            "default",
+            &app_config.tools,
+            session_arc,
+            registry,
+        )
+        .await?
+        // This ordering is because both `with_skills` and `with_context_files` PREPEND to history.
+        // because initial history is set from the input session
+        .with_skills(&skills)
+        .with_context_files()?,
     );
 
     let mut logger = if cli.debug {

--- a/src/session.rs
+++ b/src/session.rs
@@ -104,6 +104,14 @@ CREATE TABLE IF NOT EXISTS conversation (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     role TEXT NOT NULL,
     content TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS task (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
 );";
 
 pub struct Session {
@@ -123,22 +131,14 @@ impl Session {
         };
 
         let db_path = session_dir.join(format!("{}.db", &sess_id));
-        let needs_migration = !db_path.exists();
         let db = Builder::new_local(db_path.to_string_lossy().as_ref())
             .build()
             .await
             .with_context(|| format!("Failed to open session DB at {}", db_path.display()))?;
         let conn = db.connect()?;
-        if !needs_migration {
-            return Ok(Self {
-                id: sess_id,
-                conn,
-                db_path,
-            });
-        }
-        conn.execute(SCHEMA, ())
+        conn.execute_batch(SCHEMA)
             .await
-            .context("Failed to create conversation table")?;
+            .context("Failed to run schema DDL")?;
 
         Ok(Self {
             id: sess_id,
@@ -644,5 +644,59 @@ mod tests {
             .expect("create");
         // No WAL/SHM files — should still succeed
         session.delete_db().expect("delete_db");
+    }
+
+    #[tokio::test]
+    async fn task_table_is_created_on_new_session() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create session");
+
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time")
+            .as_secs() as i64;
+
+        session
+            .conn
+            .execute(
+                "INSERT INTO task (title, status, created_at, updated_at) VALUES ('t', 'pending', ?1, ?2)",
+                [turso::Value::Integer(now), turso::Value::Integer(now)],
+            )
+            .await
+            .expect("task insert should succeed");
+    }
+
+    #[tokio::test]
+    async fn task_table_is_added_on_reopen_of_existing_db() {
+        let dir = TempDir::new().expect("temp dir");
+        let id = uuid::Uuid::now_v7().to_string();
+
+        {
+            let session = Session::new(Some(id.clone()), dir.path().to_path_buf())
+                .await
+                .expect("create");
+            let msg = Message::text(Role::User, "hello".to_string());
+            session.insert_message(&msg).await.expect("insert");
+        }
+
+        let session = Session::new(Some(id), dir.path().to_path_buf())
+            .await
+            .expect("reopen");
+
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("time")
+            .as_secs() as i64;
+
+        session
+            .conn
+            .execute(
+                "INSERT INTO task (title, status, created_at, updated_at) VALUES ('t', 'pending', ?1, ?2)",
+                [turso::Value::Integer(now), turso::Value::Integer(now)],
+            )
+            .await
+            .expect("task insert on reopened session should succeed");
     }
 }

--- a/src/session/conversation.rs
+++ b/src/session/conversation.rs
@@ -1,0 +1,102 @@
+use anyhow::{Context, Result, bail};
+use turso::Value;
+
+use crate::types::{ContentBlock, Message, Role};
+
+use super::Session;
+
+pub async fn insert_message(session: &Session, message: &Message) -> Result<()> {
+    let content_json =
+        serde_json::to_string(&message.content).context("Failed to serialize message content")?;
+    let role_str = match message.role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+    };
+    session
+        .conn
+        .execute(
+            "INSERT INTO conversation (role, content) VALUES (?1, ?2)",
+            [Value::Text(role_str.to_string()), Value::Text(content_json)],
+        )
+        .await
+        .context("Failed to insert message into session")?;
+    Ok(())
+}
+
+pub async fn is_empty(session: &Session) -> Result<bool> {
+    let mut rows = session
+        .conn
+        .query("SELECT COUNT(*) FROM conversation", ())
+        .await
+        .context("Failed to count conversation messages")?;
+
+    if let Some(row) = rows.next().await? {
+        let count = match row.get_value(0)? {
+            Value::Integer(n) => n,
+            _ => return Ok(true),
+        };
+        return Ok(count == 0);
+    }
+
+    Ok(true)
+}
+
+pub async fn load_history(session: &Session) -> Result<Vec<Message>> {
+    let mut rows = session
+        .conn
+        .query("SELECT role, content FROM conversation ORDER BY id ASC", ())
+        .await
+        .context("Failed to query conversation history")?;
+
+    let mut messages = Vec::new();
+    while let Some(row) = rows.next().await? {
+        let role_str = match row.get_value(0)? {
+            Value::Text(s) => s,
+            other => bail!("Unexpected role type in DB: {:?}", other),
+        };
+        let content_str = match row.get_value(1)? {
+            Value::Text(s) => s,
+            other => bail!("Unexpected content type in DB: {:?}", other),
+        };
+
+        let role = match role_str.as_str() {
+            "user" => Role::User,
+            "assistant" => Role::Assistant,
+            other => bail!("Unknown role in DB: {}", other),
+        };
+
+        let content: Vec<ContentBlock> =
+            serde_json::from_str(&content_str).context("Failed to deserialize content")?;
+
+        messages.push(Message { role, content });
+    }
+
+    Ok(messages)
+}
+
+pub async fn read_first_user_message(session: &Session) -> Result<String> {
+    let mut rows = session
+        .conn
+        .query(
+            "SELECT content FROM conversation WHERE role = 'user' ORDER BY id ASC LIMIT 1",
+            (),
+        )
+        .await
+        .context("Failed to query first user message")?;
+
+    if let Some(row) = rows.next().await? {
+        let content_str = match row.get_value(0)? {
+            Value::Text(s) => s,
+            _ => return Ok(String::new()),
+        };
+        let blocks: Vec<ContentBlock> =
+            serde_json::from_str(&content_str).context("Failed to deserialize content blocks")?;
+        for block in blocks {
+            if let ContentBlock::Text(text) = block {
+                return Ok(text);
+            }
+        }
+    }
+
+    Ok(String::new())
+}

--- a/src/session/conversation.rs
+++ b/src/session/conversation.rs
@@ -1,102 +1,117 @@
 use anyhow::{Context, Result, bail};
-use turso::Value;
 
 use crate::types::{ContentBlock, Message, Role};
 
 use super::Session;
 
-pub async fn insert_message(session: &Session, message: &Message) -> Result<()> {
-    let content_json =
-        serde_json::to_string(&message.content).context("Failed to serialize message content")?;
-    let role_str = match message.role {
-        Role::User => "user",
-        Role::Assistant => "assistant",
-    };
-    session
-        .conn
-        .execute(
-            "INSERT INTO conversation (role, content) VALUES (?1, ?2)",
-            [Value::Text(role_str.to_string()), Value::Text(content_json)],
-        )
-        .await
-        .context("Failed to insert message into session")?;
-    Ok(())
+pub struct ConversationRepo<'a> {
+    session: &'a Session,
 }
 
-pub async fn is_empty(session: &Session) -> Result<bool> {
-    let mut rows = session
-        .conn
-        .query("SELECT COUNT(*) FROM conversation", ())
-        .await
-        .context("Failed to count conversation messages")?;
-
-    if let Some(row) = rows.next().await? {
-        let count = match row.get_value(0)? {
-            Value::Integer(n) => n,
-            _ => return Ok(true),
-        };
-        return Ok(count == 0);
+impl<'a> ConversationRepo<'a> {
+    pub(super) fn new(session: &'a Session) -> Self {
+        Self { session }
     }
 
-    Ok(true)
-}
-
-pub async fn load_history(session: &Session) -> Result<Vec<Message>> {
-    let mut rows = session
-        .conn
-        .query("SELECT role, content FROM conversation ORDER BY id ASC", ())
-        .await
-        .context("Failed to query conversation history")?;
-
-    let mut messages = Vec::new();
-    while let Some(row) = rows.next().await? {
-        let role_str = match row.get_value(0)? {
-            Value::Text(s) => s,
-            other => bail!("Unexpected role type in DB: {:?}", other),
+    pub async fn insert_message(&self, message: &Message) -> Result<()> {
+        let content_json = serde_json::to_string(&message.content)
+            .context("Failed to serialize message content")?;
+        let role_str = match message.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
         };
-        let content_str = match row.get_value(1)? {
-            Value::Text(s) => s,
-            other => bail!("Unexpected content type in DB: {:?}", other),
-        };
-
-        let role = match role_str.as_str() {
-            "user" => Role::User,
-            "assistant" => Role::Assistant,
-            other => bail!("Unknown role in DB: {}", other),
-        };
-
-        let content: Vec<ContentBlock> =
-            serde_json::from_str(&content_str).context("Failed to deserialize content")?;
-
-        messages.push(Message { role, content });
+        self.session
+            .conn
+            .execute(
+                "INSERT INTO conversation (role, content) VALUES (?1, ?2)",
+                [
+                    turso::Value::Text(role_str.to_string()),
+                    turso::Value::Text(content_json),
+                ],
+            )
+            .await
+            .context("Failed to insert message into session")?;
+        Ok(())
     }
 
-    Ok(messages)
-}
+    pub async fn is_empty(&self) -> Result<bool> {
+        let mut rows = self
+            .session
+            .conn
+            .query("SELECT COUNT(*) FROM conversation", ())
+            .await
+            .context("Failed to count conversation messages")?;
 
-pub async fn read_first_user_message(session: &Session) -> Result<String> {
-    let mut rows = session
-        .conn
-        .query(
-            "SELECT content FROM conversation WHERE role = 'user' ORDER BY id ASC LIMIT 1",
-            (),
-        )
-        .await
-        .context("Failed to query first user message")?;
+        if let Some(row) = rows.next().await? {
+            let count = match row.get_value(0)? {
+                turso::Value::Integer(n) => n,
+                _ => return Ok(true),
+            };
+            return Ok(count == 0);
+        }
 
-    if let Some(row) = rows.next().await? {
-        let content_str = match row.get_value(0)? {
-            Value::Text(s) => s,
-            _ => return Ok(String::new()),
-        };
-        let blocks: Vec<ContentBlock> =
-            serde_json::from_str(&content_str).context("Failed to deserialize content blocks")?;
-        for block in blocks {
-            if let ContentBlock::Text(text) = block {
-                return Ok(text);
+        Ok(true)
+    }
+
+    pub async fn load_history(&self) -> Result<Vec<Message>> {
+        let mut rows = self
+            .session
+            .conn
+            .query("SELECT role, content FROM conversation ORDER BY id ASC", ())
+            .await
+            .context("Failed to query conversation history")?;
+
+        let mut messages = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let role_str = match row.get_value(0)? {
+                turso::Value::Text(s) => s,
+                other => bail!("Unexpected role type in DB: {:?}", other),
+            };
+            let content_str = match row.get_value(1)? {
+                turso::Value::Text(s) => s,
+                other => bail!("Unexpected content type in DB: {:?}", other),
+            };
+
+            let role = match role_str.as_str() {
+                "user" => Role::User,
+                "assistant" => Role::Assistant,
+                other => bail!("Unknown role in DB: {}", other),
+            };
+
+            let content: Vec<ContentBlock> =
+                serde_json::from_str(&content_str).context("Failed to deserialize content")?;
+
+            messages.push(Message { role, content });
+        }
+
+        Ok(messages)
+    }
+
+    pub async fn read_first_user_message(&self) -> Result<String> {
+        let mut rows = self
+            .session
+            .conn
+            .query(
+                "SELECT content FROM conversation WHERE role = 'user' ORDER BY id ASC LIMIT 1",
+                (),
+            )
+            .await
+            .context("Failed to query first user message")?;
+
+        if let Some(row) = rows.next().await? {
+            let content_str = match row.get_value(0)? {
+                turso::Value::Text(s) => s,
+                _ => return Ok(String::new()),
+            };
+            let blocks: Vec<ContentBlock> = serde_json::from_str(&content_str)
+                .context("Failed to deserialize content blocks")?;
+            for block in blocks {
+                if let ContentBlock::Text(text) = block {
+                    return Ok(text);
+                }
             }
         }
-    }
 
-    Ok(String::new())
+        Ok(String::new())
+    }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,9 +1,15 @@
-use anyhow::{Context, Result, bail};
+pub mod task;
+
+mod conversation;
+
+use anyhow::{Context, Result};
 use std::path::PathBuf;
 use std::time::SystemTime;
-use turso::{Builder, Connection, Value};
+use turso::{Builder, Connection};
 
-use crate::types::{ContentBlock, Message, Role};
+pub use task::{TaskRecord, TaskRepo, TaskStatus};
+
+use crate::types::Message;
 
 /// Summary of a session, used for the session picker.
 #[derive(Debug, Clone)]
@@ -14,7 +20,6 @@ pub struct SessionSummary {
 }
 
 /// List all sessions in the given directory, ordered by most recently modified first.
-/// Each summary includes the session ID and the first user message text.
 pub async fn list_sessions(session_dir: &std::path::Path) -> Result<Vec<SessionSummary>> {
     let mut summaries = Vec::new();
 
@@ -53,7 +58,9 @@ pub async fn list_sessions(session_dir: &std::path::Path) -> Result<Vec<SessionS
             .and_then(|m| m.modified())
             .unwrap_or(SystemTime::UNIX_EPOCH);
 
-        let first_user_message = read_first_user_message(&path).await.unwrap_or_default();
+        let first_user_message = read_first_user_message_from_path(&path)
+            .await
+            .unwrap_or_default();
 
         summaries.push(SessionSummary {
             id: file_stem,
@@ -67,36 +74,18 @@ pub async fn list_sessions(session_dir: &std::path::Path) -> Result<Vec<SessionS
     Ok(summaries)
 }
 
-async fn read_first_user_message(db_path: &std::path::Path) -> Result<String> {
+async fn read_first_user_message_from_path(db_path: &std::path::Path) -> Result<String> {
     let db = Builder::new_local(db_path.to_string_lossy().as_ref())
         .build()
         .await
         .with_context(|| format!("Failed to open session DB at {}", db_path.display()))?;
     let conn = db.connect()?;
-
-    let mut rows = conn
-        .query(
-            "SELECT content FROM conversation WHERE role = 'user' ORDER BY id ASC LIMIT 1",
-            (),
-        )
-        .await
-        .context("Failed to query first user message")?;
-
-    if let Some(row) = rows.next().await? {
-        let content_str = match row.get_value(0)? {
-            Value::Text(s) => s,
-            _ => return Ok(String::new()),
-        };
-        let blocks: Vec<ContentBlock> =
-            serde_json::from_str(&content_str).context("Failed to deserialize content blocks")?;
-        for block in blocks {
-            if let ContentBlock::Text(text) = block {
-                return Ok(text);
-            }
-        }
-    }
-
-    Ok(String::new())
+    let session = Session {
+        id: String::new(),
+        conn,
+        db_path: db_path.to_path_buf(),
+    };
+    conversation::read_first_user_message(&session).await
 }
 
 const SCHEMA: &str = "\
@@ -147,39 +136,20 @@ impl Session {
         })
     }
 
+    pub fn tasks(&self) -> TaskRepo<'_> {
+        TaskRepo::new(self)
+    }
+
     pub async fn insert_message(&self, message: &Message) -> Result<()> {
-        let content_json = serde_json::to_string(&message.content)
-            .context("Failed to serialize message content")?;
-        let role_str = match message.role {
-            Role::User => "user",
-            Role::Assistant => "assistant",
-        };
-        self.conn
-            .execute(
-                "INSERT INTO conversation (role, content) VALUES (?1, ?2)",
-                [Value::Text(role_str.to_string()), Value::Text(content_json)],
-            )
-            .await
-            .context("Failed to insert message into session")?;
-        Ok(())
+        conversation::insert_message(self, message).await
     }
 
     pub async fn is_empty(&self) -> Result<bool> {
-        let mut rows = self
-            .conn
-            .query("SELECT COUNT(*) FROM conversation", ())
-            .await
-            .context("Failed to count conversation messages")?;
+        conversation::is_empty(self).await
+    }
 
-        if let Some(row) = rows.next().await? {
-            let count = match row.get_value(0)? {
-                Value::Integer(n) => n,
-                _ => return Ok(true),
-            };
-            return Ok(count == 0);
-        }
-
-        Ok(true)
+    pub async fn load_history(&self) -> Result<Vec<Message>> {
+        conversation::load_history(self).await
     }
 
     pub fn delete_db(&self) -> Result<()> {
@@ -196,39 +166,6 @@ impl Session {
         }
         Ok(())
     }
-
-    pub async fn load_history(&self) -> Result<Vec<Message>> {
-        let mut rows = self
-            .conn
-            .query("SELECT role, content FROM conversation ORDER BY id ASC", ())
-            .await
-            .context("Failed to query conversation history")?;
-
-        let mut messages = Vec::new();
-        while let Some(row) = rows.next().await? {
-            let role_str = match row.get_value(0)? {
-                Value::Text(s) => s,
-                other => bail!("Unexpected role type in DB: {:?}", other),
-            };
-            let content_str = match row.get_value(1)? {
-                Value::Text(s) => s,
-                other => bail!("Unexpected content type in DB: {:?}", other),
-            };
-
-            let role = match role_str.as_str() {
-                "user" => Role::User,
-                "assistant" => Role::Assistant,
-                other => bail!("Unknown role in DB: {}", other),
-            };
-
-            let content: Vec<ContentBlock> =
-                serde_json::from_str(&content_str).context("Failed to deserialize content")?;
-
-            messages.push(Message { role, content });
-        }
-
-        Ok(messages)
-    }
 }
 
 fn generate_uuidv7() -> String {
@@ -240,7 +177,7 @@ fn validate_uuidv7(id: &str) -> Result<()> {
     let version = parsed.get_version();
     match version {
         Some(uuid::Version::SortRand) | Some(uuid::Version::SortMac) => Ok(()),
-        _ => bail!(
+        _ => anyhow::bail!(
             "Session ID must be a valid UUIDv7, got version {:?}",
             version
         ),
@@ -250,6 +187,7 @@ fn validate_uuidv7(id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{ContentBlock, Role};
     use tempfile::TempDir;
 
     #[test]
@@ -642,7 +580,6 @@ mod tests {
         let session = Session::new(None, dir.path().to_path_buf())
             .await
             .expect("create");
-        // No WAL/SHM files — should still succeed
         session.delete_db().expect("delete_db");
     }
 
@@ -653,19 +590,8 @@ mod tests {
             .await
             .expect("create session");
 
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("time")
-            .as_secs() as i64;
-
-        session
-            .conn
-            .execute(
-                "INSERT INTO task (title, status, created_at, updated_at) VALUES ('t', 'pending', ?1, ?2)",
-                [turso::Value::Integer(now), turso::Value::Integer(now)],
-            )
-            .await
-            .expect("task insert should succeed");
+        let id = session.tasks().create("t", None).await.expect("create");
+        assert_eq!(id, 1);
     }
 
     #[tokio::test]
@@ -677,26 +603,16 @@ mod tests {
             let session = Session::new(Some(id.clone()), dir.path().to_path_buf())
                 .await
                 .expect("create");
-            let msg = Message::text(Role::User, "hello".to_string());
-            session.insert_message(&msg).await.expect("insert");
+            session
+                .insert_message(&Message::text(Role::User, "hello".to_string()))
+                .await
+                .expect("insert");
         }
 
         let session = Session::new(Some(id), dir.path().to_path_buf())
             .await
             .expect("reopen");
-
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("time")
-            .as_secs() as i64;
-
-        session
-            .conn
-            .execute(
-                "INSERT INTO task (title, status, created_at, updated_at) VALUES ('t', 'pending', ?1, ?2)",
-                [turso::Value::Integer(now), turso::Value::Integer(now)],
-            )
-            .await
-            .expect("task insert on reopened session should succeed");
+        let task_id = session.tasks().create("t", None).await.expect("create");
+        assert_eq!(task_id, 1);
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -6,9 +6,8 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 use turso::{Builder, Connection};
 
-pub use task::{TaskRecord, TaskRepo, TaskStatus};
 pub use conversation::ConversationRepo;
-
+pub use task::{TaskRecord, TaskRepo, TaskStatus};
 
 /// Summary of a session, used for the session picker.
 #[derive(Debug, Clone)]
@@ -217,7 +216,11 @@ mod tests {
         assert!(db_path.exists(), "DB file should be created");
 
         let msg = Message::text(Role::User, "hello".to_string());
-        session.conversation().insert_message(&msg).await.expect("insert");
+        session
+            .conversation()
+            .insert_message(&msg)
+            .await
+            .expect("insert");
         let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].role, Role::User);
@@ -255,13 +258,21 @@ mod tests {
                 .await
                 .expect("create");
             let msg = Message::text(Role::User, "saved message".to_string());
-            session.conversation().insert_message(&msg).await.expect("insert");
+            session
+                .conversation()
+                .insert_message(&msg)
+                .await
+                .expect("insert");
         }
 
         let session = Session::new(Some(id), dir.path().to_path_buf())
             .await
             .expect("reopen");
-        let history = session.conversation().load_history().await.expect("load history");
+        let history = session
+            .conversation()
+            .load_history()
+            .await
+            .expect("load history");
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].role, Role::User);
         match &history[0].content[0] {
@@ -279,15 +290,18 @@ mod tests {
             .expect("create");
 
         session
-            .conversation().insert_message(&Message::text(Role::User, "first".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "first".to_string()))
             .await
             .expect("insert 1");
         session
-            .conversation().insert_message(&Message::text(Role::Assistant, "second".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::Assistant, "second".to_string()))
             .await
             .expect("insert 2");
         session
-            .conversation().insert_message(&Message::text(Role::User, "third".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "third".to_string()))
             .await
             .expect("insert 3");
 
@@ -317,7 +331,11 @@ mod tests {
                 },
             ],
         };
-        session.conversation().insert_message(&msg).await.expect("insert");
+        session
+            .conversation()
+            .insert_message(&msg)
+            .await
+            .expect("insert");
 
         let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 1);
@@ -348,7 +366,11 @@ mod tests {
                 is_error: false,
             }],
         };
-        session.conversation().insert_message(&msg).await.expect("insert");
+        session
+            .conversation()
+            .insert_message(&msg)
+            .await
+            .expect("insert");
 
         let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 1);
@@ -402,7 +424,8 @@ mod tests {
             .await
             .expect("create");
         session
-            .conversation().insert_message(&Message::text(Role::User, "hello world".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "hello world".to_string()))
             .await
             .expect("insert");
 
@@ -453,7 +476,8 @@ mod tests {
             .await
             .expect("create a");
         session_a
-            .conversation().insert_message(&Message::text(Role::User, "first session".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "first session".to_string()))
             .await
             .expect("insert a");
 
@@ -463,7 +487,8 @@ mod tests {
             .await
             .expect("create b");
         session_b
-            .conversation().insert_message(&Message::text(Role::User, "second session".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "second session".to_string()))
             .await
             .expect("insert b");
 
@@ -497,15 +522,18 @@ mod tests {
             .await
             .expect("create");
         session
-            .conversation().insert_message(&Message::text(Role::User, "first message".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "first message".to_string()))
             .await
             .expect("insert 1");
         session
-            .conversation().insert_message(&Message::text(Role::Assistant, "response".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::Assistant, "response".to_string()))
             .await
             .expect("insert 2");
         session
-            .conversation().insert_message(&Message::text(Role::User, "second message".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "second message".to_string()))
             .await
             .expect("insert 3");
 
@@ -529,7 +557,8 @@ mod tests {
             .await
             .expect("create");
         session
-            .conversation().insert_message(&Message::text(Role::User, "hello".to_string()))
+            .conversation()
+            .insert_message(&Message::text(Role::User, "hello".to_string()))
             .await
             .expect("insert");
         assert!(!session.conversation().is_empty().await.expect("is_empty"));
@@ -595,7 +624,8 @@ mod tests {
                 .await
                 .expect("create");
             session
-                .conversation().insert_message(&Message::text(Role::User, "hello".to_string()))
+                .conversation()
+                .insert_message(&Message::text(Role::User, "hello".to_string()))
                 .await
                 .expect("insert");
         }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,6 +1,5 @@
+pub mod conversation;
 pub mod task;
-
-mod conversation;
 
 use anyhow::{Context, Result};
 use std::path::PathBuf;
@@ -8,8 +7,8 @@ use std::time::SystemTime;
 use turso::{Builder, Connection};
 
 pub use task::{TaskRecord, TaskRepo, TaskStatus};
+pub use conversation::ConversationRepo;
 
-use crate::types::Message;
 
 /// Summary of a session, used for the session picker.
 #[derive(Debug, Clone)]
@@ -85,7 +84,7 @@ async fn read_first_user_message_from_path(db_path: &std::path::Path) -> Result<
         conn,
         db_path: db_path.to_path_buf(),
     };
-    conversation::read_first_user_message(&session).await
+    session.conversation().read_first_user_message().await
 }
 
 const SCHEMA: &str = "\
@@ -136,20 +135,12 @@ impl Session {
         })
     }
 
+    pub fn conversation(&self) -> ConversationRepo<'_> {
+        ConversationRepo::new(self)
+    }
+
     pub fn tasks(&self) -> TaskRepo<'_> {
         TaskRepo::new(self)
-    }
-
-    pub async fn insert_message(&self, message: &Message) -> Result<()> {
-        conversation::insert_message(self, message).await
-    }
-
-    pub async fn is_empty(&self) -> Result<bool> {
-        conversation::is_empty(self).await
-    }
-
-    pub async fn load_history(&self) -> Result<Vec<Message>> {
-        conversation::load_history(self).await
     }
 
     pub fn delete_db(&self) -> Result<()> {
@@ -187,7 +178,7 @@ fn validate_uuidv7(id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ContentBlock, Role};
+    use crate::types::{ContentBlock, Message, Role};
     use tempfile::TempDir;
 
     #[test]
@@ -226,8 +217,8 @@ mod tests {
         assert!(db_path.exists(), "DB file should be created");
 
         let msg = Message::text(Role::User, "hello".to_string());
-        session.insert_message(&msg).await.expect("insert");
-        let history = session.load_history().await.expect("load");
+        session.conversation().insert_message(&msg).await.expect("insert");
+        let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].role, Role::User);
     }
@@ -264,13 +255,13 @@ mod tests {
                 .await
                 .expect("create");
             let msg = Message::text(Role::User, "saved message".to_string());
-            session.insert_message(&msg).await.expect("insert");
+            session.conversation().insert_message(&msg).await.expect("insert");
         }
 
         let session = Session::new(Some(id), dir.path().to_path_buf())
             .await
             .expect("reopen");
-        let history = session.load_history().await.expect("load history");
+        let history = session.conversation().load_history().await.expect("load history");
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].role, Role::User);
         match &history[0].content[0] {
@@ -288,19 +279,19 @@ mod tests {
             .expect("create");
 
         session
-            .insert_message(&Message::text(Role::User, "first".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "first".to_string()))
             .await
             .expect("insert 1");
         session
-            .insert_message(&Message::text(Role::Assistant, "second".to_string()))
+            .conversation().insert_message(&Message::text(Role::Assistant, "second".to_string()))
             .await
             .expect("insert 2");
         session
-            .insert_message(&Message::text(Role::User, "third".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "third".to_string()))
             .await
             .expect("insert 3");
 
-        let history = session.load_history().await.expect("load");
+        let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 3);
         assert_eq!(history[0].role, Role::User);
         assert_eq!(history[1].role, Role::Assistant);
@@ -326,9 +317,9 @@ mod tests {
                 },
             ],
         };
-        session.insert_message(&msg).await.expect("insert");
+        session.conversation().insert_message(&msg).await.expect("insert");
 
-        let history = session.load_history().await.expect("load");
+        let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].content.len(), 2);
         match &history[0].content[0] {
@@ -357,9 +348,9 @@ mod tests {
                 is_error: false,
             }],
         };
-        session.insert_message(&msg).await.expect("insert");
+        session.conversation().insert_message(&msg).await.expect("insert");
 
-        let history = session.load_history().await.expect("load");
+        let history = session.conversation().load_history().await.expect("load");
         assert_eq!(history.len(), 1);
         match &history[0].content[0] {
             ContentBlock::ToolResult {
@@ -411,7 +402,7 @@ mod tests {
             .await
             .expect("create");
         session
-            .insert_message(&Message::text(Role::User, "hello world".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "hello world".to_string()))
             .await
             .expect("insert");
 
@@ -462,7 +453,7 @@ mod tests {
             .await
             .expect("create a");
         session_a
-            .insert_message(&Message::text(Role::User, "first session".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "first session".to_string()))
             .await
             .expect("insert a");
 
@@ -472,7 +463,7 @@ mod tests {
             .await
             .expect("create b");
         session_b
-            .insert_message(&Message::text(Role::User, "second session".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "second session".to_string()))
             .await
             .expect("insert b");
 
@@ -506,15 +497,15 @@ mod tests {
             .await
             .expect("create");
         session
-            .insert_message(&Message::text(Role::User, "first message".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "first message".to_string()))
             .await
             .expect("insert 1");
         session
-            .insert_message(&Message::text(Role::Assistant, "response".to_string()))
+            .conversation().insert_message(&Message::text(Role::Assistant, "response".to_string()))
             .await
             .expect("insert 2");
         session
-            .insert_message(&Message::text(Role::User, "second message".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "second message".to_string()))
             .await
             .expect("insert 3");
 
@@ -528,7 +519,7 @@ mod tests {
         let session = Session::new(None, dir.path().to_path_buf())
             .await
             .expect("create");
-        assert!(session.is_empty().await.expect("is_empty"));
+        assert!(session.conversation().is_empty().await.expect("is_empty"));
     }
 
     #[tokio::test]
@@ -538,10 +529,10 @@ mod tests {
             .await
             .expect("create");
         session
-            .insert_message(&Message::text(Role::User, "hello".to_string()))
+            .conversation().insert_message(&Message::text(Role::User, "hello".to_string()))
             .await
             .expect("insert");
-        assert!(!session.is_empty().await.expect("is_empty"));
+        assert!(!session.conversation().is_empty().await.expect("is_empty"));
     }
 
     #[tokio::test]
@@ -604,7 +595,7 @@ mod tests {
                 .await
                 .expect("create");
             session
-                .insert_message(&Message::text(Role::User, "hello".to_string()))
+                .conversation().insert_message(&Message::text(Role::User, "hello".to_string()))
                 .await
                 .expect("insert");
         }

--- a/src/session/task.rs
+++ b/src/session/task.rs
@@ -1,0 +1,373 @@
+use std::str::FromStr;
+use std::time::SystemTime;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use turso::Value as DbValue;
+
+use super::Session;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+}
+
+impl TaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+impl FromStr for TaskStatus {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            other => bail!(
+                "Invalid status '{}'. Must be one of: pending, in_progress, completed",
+                other
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskRecord {
+    pub id: i64,
+    pub title: String,
+    pub description: Option<String>,
+    pub status: TaskStatus,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+fn now_epoch_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time is before UNIX epoch")
+        .as_secs() as i64
+}
+
+pub struct TaskRepo<'a> {
+    session: &'a Session,
+}
+
+impl<'a> TaskRepo<'a> {
+    pub(super) fn new(session: &'a Session) -> Self {
+        Self { session }
+    }
+
+    pub async fn create(&self, title: &str, description: Option<&str>) -> Result<i64> {
+        let now = now_epoch_secs();
+        let mut rows = self
+            .session
+            .conn
+            .query(
+                "INSERT INTO task (title, description, status, created_at, updated_at) \
+                 VALUES (?1, ?2, 'pending', ?3, ?4) RETURNING id",
+                [
+                    DbValue::Text(title.to_string()),
+                    description
+                        .map(|s| DbValue::Text(s.to_string()))
+                        .unwrap_or(DbValue::Null),
+                    DbValue::Integer(now),
+                    DbValue::Integer(now),
+                ],
+            )
+            .await
+            .context("Failed to insert task")?;
+
+        let row = rows
+            .next()
+            .await?
+            .context("INSERT RETURNING returned no rows")?;
+
+        match row.get_value(0)? {
+            DbValue::Integer(id) => Ok(id),
+            other => bail!("Unexpected id type from INSERT RETURNING: {:?}", other),
+        }
+    }
+
+    pub async fn list(&self, status_filter: Option<TaskStatus>) -> Result<Vec<TaskRecord>> {
+        let mut rows = if let Some(status) = status_filter {
+            self.session
+                .conn
+                .query(
+                    "SELECT id, title, description, status, created_at, updated_at \
+                     FROM task WHERE status = ?1 ORDER BY id ASC",
+                    [DbValue::Text(status.as_str().to_string())],
+                )
+                .await
+                .context("Failed to list tasks by status")?
+        } else {
+            self.session
+                .conn
+                .query(
+                    "SELECT id, title, description, status, created_at, updated_at \
+                     FROM task ORDER BY id ASC",
+                    (),
+                )
+                .await
+                .context("Failed to list tasks")?
+        };
+
+        let mut tasks = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let id = match row.get_value(0)? {
+                DbValue::Integer(n) => n,
+                other => bail!("Unexpected id type: {:?}", other),
+            };
+            let title = match row.get_value(1)? {
+                DbValue::Text(s) => s,
+                other => bail!("Unexpected title type: {:?}", other),
+            };
+            let description = match row.get_value(2)? {
+                DbValue::Text(s) => Some(s),
+                DbValue::Null => None,
+                other => bail!("Unexpected description type: {:?}", other),
+            };
+            let status_str = match row.get_value(3)? {
+                DbValue::Text(s) => s,
+                other => bail!("Unexpected status type: {:?}", other),
+            };
+            let status = TaskStatus::from_str(&status_str)?;
+            let created_at = match row.get_value(4)? {
+                DbValue::Integer(n) => n,
+                other => bail!("Unexpected created_at type: {:?}", other),
+            };
+            let updated_at = match row.get_value(5)? {
+                DbValue::Integer(n) => n,
+                other => bail!("Unexpected updated_at type: {:?}", other),
+            };
+            tasks.push(TaskRecord {
+                id,
+                title,
+                description,
+                status,
+                created_at,
+                updated_at,
+            });
+        }
+
+        Ok(tasks)
+    }
+
+    pub async fn update(
+        &self,
+        id: i64,
+        title: Option<&str>,
+        description: Option<&str>,
+        status: Option<TaskStatus>,
+    ) -> Result<bool> {
+        let now = now_epoch_secs();
+        let mut set_parts: Vec<String> = Vec::new();
+        let mut params: Vec<DbValue> = Vec::new();
+        let mut idx = 1usize;
+
+        if let Some(t) = title {
+            set_parts.push(format!("title = ?{}", idx));
+            params.push(DbValue::Text(t.to_string()));
+            idx += 1;
+        }
+        if let Some(d) = description {
+            set_parts.push(format!("description = ?{}", idx));
+            params.push(DbValue::Text(d.to_string()));
+            idx += 1;
+        }
+        if let Some(s) = status {
+            set_parts.push(format!("status = ?{}", idx));
+            params.push(DbValue::Text(s.as_str().to_string()));
+            idx += 1;
+        }
+        set_parts.push(format!("updated_at = ?{}", idx));
+        params.push(DbValue::Integer(now));
+        idx += 1;
+
+        params.push(DbValue::Integer(id));
+        let sql = format!(
+            "UPDATE task SET {} WHERE id = ?{}",
+            set_parts.join(", "),
+            idx
+        );
+
+        let rows_affected = self
+            .session
+            .conn
+            .execute(&sql, params)
+            .await
+            .context("Failed to update task")?;
+
+        Ok(rows_affected > 0)
+    }
+
+    pub async fn delete(&self, id: i64) -> Result<bool> {
+        let rows_affected = self
+            .session
+            .conn
+            .execute("DELETE FROM task WHERE id = ?1", [DbValue::Integer(id)])
+            .await
+            .context("Failed to delete task")?;
+
+        Ok(rows_affected > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::Session;
+    use tempfile::TempDir;
+
+    async fn new_session() -> Session {
+        let dir = TempDir::new().expect("temp dir");
+        Session::new(None, dir.keep()).await.expect("session")
+    }
+
+    #[test]
+    fn task_status_round_trips_through_string() {
+        for (variant, s) in [
+            (TaskStatus::Pending, "pending"),
+            (TaskStatus::InProgress, "in_progress"),
+            (TaskStatus::Completed, "completed"),
+        ] {
+            assert_eq!(variant.as_str(), s);
+            assert_eq!(TaskStatus::from_str(s).expect("parse"), variant);
+        }
+    }
+
+    #[test]
+    fn task_status_rejects_invalid_string() {
+        assert!(TaskStatus::from_str("done").is_err());
+    }
+
+    #[test]
+    fn task_status_default_is_pending() {
+        assert_eq!(TaskStatus::default(), TaskStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn create_returns_id() {
+        let session = new_session().await;
+        let id = session
+            .tasks()
+            .create("my task", None)
+            .await
+            .expect("create");
+        assert_eq!(id, 1);
+    }
+
+    #[tokio::test]
+    async fn create_with_description_persists() {
+        let session = new_session().await;
+        session
+            .tasks()
+            .create("t", Some("desc"))
+            .await
+            .expect("create");
+        let tasks = session.tasks().list(None).await.expect("list");
+        assert_eq!(tasks[0].description.as_deref(), Some("desc"));
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_none() {
+        let session = new_session().await;
+        let tasks = session.tasks().list(None).await.expect("list");
+        assert!(tasks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_in_id_order() {
+        let session = new_session().await;
+        let repo = session.tasks();
+        repo.create("a", None).await.expect("c1");
+        repo.create("b", None).await.expect("c2");
+        repo.create("c", None).await.expect("c3");
+
+        let tasks = repo.list(None).await.expect("list");
+        assert_eq!(tasks.len(), 3);
+        assert_eq!(tasks[0].title, "a");
+        assert_eq!(tasks[1].title, "b");
+        assert_eq!(tasks[2].title, "c");
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_status() {
+        let session = new_session().await;
+        let repo = session.tasks();
+        repo.create("pending", None).await.expect("c1");
+        repo.create("active", None).await.expect("c2");
+        repo.update(2, None, None, Some(TaskStatus::InProgress))
+            .await
+            .expect("update");
+
+        let tasks = repo.list(Some(TaskStatus::InProgress)).await.expect("list");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "active");
+    }
+
+    #[tokio::test]
+    async fn update_returns_true_on_success() {
+        let session = new_session().await;
+        let repo = session.tasks();
+        repo.create("task", None).await.expect("create");
+        let updated = repo
+            .update(1, Some("new title"), None, None)
+            .await
+            .expect("update");
+        assert!(updated);
+        let tasks = repo.list(None).await.expect("list");
+        assert_eq!(tasks[0].title, "new title");
+    }
+
+    #[tokio::test]
+    async fn update_returns_false_for_missing_id() {
+        let session = new_session().await;
+        let updated = session
+            .tasks()
+            .update(999, Some("x"), None, None)
+            .await
+            .expect("update");
+        assert!(!updated);
+    }
+
+    #[tokio::test]
+    async fn update_advances_updated_at() {
+        let session = new_session().await;
+        let repo = session.tasks();
+        repo.create("task", None).await.expect("create");
+        let before = repo.list(None).await.expect("list")[0].updated_at;
+        repo.update(1, Some("new"), None, None)
+            .await
+            .expect("update");
+        let after = repo.list(None).await.expect("list")[0].updated_at;
+        assert!(after >= before);
+    }
+
+    #[tokio::test]
+    async fn delete_returns_true_on_success() {
+        let session = new_session().await;
+        let repo = session.tasks();
+        repo.create("task", None).await.expect("create");
+        let deleted = repo.delete(1).await.expect("delete");
+        assert!(deleted);
+        assert!(repo.list(None).await.expect("list").is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_returns_false_for_missing_id() {
+        let session = new_session().await;
+        let deleted = session.tasks().delete(999).await.expect("delete");
+        assert!(!deleted);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -5,6 +5,7 @@ pub mod edit_file;
 pub mod sandbox;
 pub mod search;
 pub mod skill;
+pub mod task;
 pub mod write_file;
 
 use crate::types::ContentBlock;

--- a/src/tools/task/create.rs
+++ b/src/tools/task/create.rs
@@ -1,0 +1,187 @@
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use turso::Value as DbValue;
+
+use crate::session::Session;
+use crate::tools::{Tool, ToolError, ToolResult};
+use crate::types::ContentBlock;
+
+fn now_epoch_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time is before UNIX epoch")
+        .as_secs() as i64
+}
+
+pub struct CreateTaskTool {
+    session: Arc<TokioMutex<Session>>,
+    schema: Value,
+}
+
+impl CreateTaskTool {
+    pub fn new(session: Arc<TokioMutex<Session>>) -> Self {
+        Self {
+            session,
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string", "description": "Task title"},
+                    "description": {"type": "string", "description": "Optional task description"}
+                },
+                "required": ["title"]
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for CreateTaskTool {
+    fn name(&self) -> &str {
+        "create_task"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new task in the current session. Returns the new task ID."
+    }
+
+    fn input_schema(&self) -> &Value {
+        &self.schema
+    }
+
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let title = input
+            .get("title")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| ToolError::InvalidInput {
+                message: "title is required".to_string(),
+            })?
+            .to_string();
+
+        let description = input
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let now = now_epoch_secs();
+        let session = self.session.lock().await;
+
+        let mut rows = session
+            .conn
+            .query(
+                "INSERT INTO task (title, description, status, created_at, updated_at) VALUES (?1, ?2, 'pending', ?3, ?4) RETURNING id",
+                [
+                    DbValue::Text(title),
+                    description.map(DbValue::Text).unwrap_or(DbValue::Null),
+                    DbValue::Integer(now),
+                    DbValue::Integer(now),
+                ],
+            )
+            .await
+            .map_err(|e| ToolError::Execution {
+                tool_name: "create_task".to_string(),
+                message: e.to_string(),
+            })?;
+
+        let id = if let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
+            tool_name: "create_task".to_string(),
+            message: e.to_string(),
+        })? {
+            match row.get_value(0).map_err(|e| ToolError::Execution {
+                tool_name: "create_task".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Integer(id) => id,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "create_task".to_string(),
+                        message: format!("Unexpected id type: {:?}", other),
+                    });
+                }
+            }
+        } else {
+            return Err(ToolError::Execution {
+                tool_name: "create_task".to_string(),
+                message: "INSERT returned no rows".to_string(),
+            });
+        };
+
+        Ok(ToolResult {
+            content: vec![ContentBlock::Text(format!("Created task with id {}", id))],
+            is_error: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn test_session_arc() -> Arc<TokioMutex<Session>> {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.keep()).await.expect("session");
+        Arc::new(TokioMutex::new(session))
+    }
+
+    #[tokio::test]
+    async fn create_task_inserts_row_and_returns_id() {
+        let session = test_session_arc().await;
+        let tool = CreateTaskTool::new(Arc::clone(&session));
+        let result = tool
+            .execute(serde_json::json!({"title": "My task"}))
+            .await
+            .expect("create");
+        assert!(!result.is_error);
+        let text = match &result.content[0] {
+            ContentBlock::Text(t) => t.clone(),
+            _ => panic!("expected text"),
+        };
+        assert!(text.contains('1'), "first task id should be 1");
+    }
+
+    #[tokio::test]
+    async fn create_task_with_description() {
+        let session = test_session_arc().await;
+        let tool = CreateTaskTool::new(Arc::clone(&session));
+        let result = tool
+            .execute(serde_json::json!({"title": "t", "description": "desc"}))
+            .await
+            .expect("create");
+        assert!(!result.is_error);
+
+        let sess = session.lock().await;
+        let mut rows = sess
+            .conn
+            .query("SELECT description FROM task WHERE id = 1", ())
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("next").expect("row");
+        match row.get_value(0).expect("val") {
+            DbValue::Text(d) => assert_eq!(d, "desc"),
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_task_without_title_errors() {
+        let session = test_session_arc().await;
+        let tool = CreateTaskTool::new(session);
+        let err = tool
+            .execute(serde_json::json!({}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[tokio::test]
+    async fn is_write_tool_returns_false() {
+        let session = test_session_arc().await;
+        let tool = CreateTaskTool::new(session);
+        assert!(!tool.is_write_tool());
+    }
+}

--- a/src/tools/task/create.rs
+++ b/src/tools/task/create.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -10,12 +9,7 @@ use crate::session::Session;
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
 
-fn now_epoch_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("system time is before UNIX epoch")
-        .as_secs() as i64
-}
+use super::now_epoch_secs;
 
 pub struct CreateTaskTool {
     session: Arc<TokioMutex<Session>>,
@@ -176,12 +170,5 @@ mod tests {
             .await
             .expect_err("should fail");
         assert!(matches!(err, ToolError::InvalidInput { .. }));
-    }
-
-    #[tokio::test]
-    async fn is_write_tool_returns_false() {
-        let session = test_session_arc().await;
-        let tool = CreateTaskTool::new(session);
-        assert!(!tool.is_write_tool());
     }
 }

--- a/src/tools/task/create.rs
+++ b/src/tools/task/create.rs
@@ -3,13 +3,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::Mutex as TokioMutex;
-use turso::Value as DbValue;
 
 use crate::session::Session;
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
-
-use super::now_epoch_secs;
 
 pub struct CreateTaskTool {
     session: Arc<TokioMutex<Session>>,
@@ -52,57 +49,20 @@ impl Tool for CreateTaskTool {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .ok_or_else(|| ToolError::InvalidInput {
-                message: "title is required".to_string(),
-            })?
-            .to_string();
+                message: "title is required and must not be empty".to_string(),
+            })?;
 
-        let description = input
-            .get("description")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        let description = input.get("description").and_then(|v| v.as_str());
 
-        let now = now_epoch_secs();
         let session = self.session.lock().await;
-
-        let mut rows = session
-            .conn
-            .query(
-                "INSERT INTO task (title, description, status, created_at, updated_at) VALUES (?1, ?2, 'pending', ?3, ?4) RETURNING id",
-                [
-                    DbValue::Text(title),
-                    description.map(DbValue::Text).unwrap_or(DbValue::Null),
-                    DbValue::Integer(now),
-                    DbValue::Integer(now),
-                ],
-            )
+        let id = session
+            .tasks()
+            .create(title, description)
             .await
             .map_err(|e| ToolError::Execution {
                 tool_name: "create_task".to_string(),
                 message: e.to_string(),
             })?;
-
-        let id = if let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
-            tool_name: "create_task".to_string(),
-            message: e.to_string(),
-        })? {
-            match row.get_value(0).map_err(|e| ToolError::Execution {
-                tool_name: "create_task".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Integer(id) => id,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "create_task".to_string(),
-                        message: format!("Unexpected id type: {:?}", other),
-                    });
-                }
-            }
-        } else {
-            return Err(ToolError::Execution {
-                tool_name: "create_task".to_string(),
-                message: "INSERT returned no rows".to_string(),
-            });
-        };
 
         Ok(ToolResult {
             content: vec![ContentBlock::Text(format!("Created task with id {}", id))],
@@ -142,23 +102,12 @@ mod tests {
     async fn create_task_with_description() {
         let session = test_session_arc().await;
         let tool = CreateTaskTool::new(Arc::clone(&session));
-        let result = tool
-            .execute(serde_json::json!({"title": "t", "description": "desc"}))
+        tool.execute(serde_json::json!({"title": "t", "description": "desc"}))
             .await
             .expect("create");
-        assert!(!result.is_error);
 
-        let sess = session.lock().await;
-        let mut rows = sess
-            .conn
-            .query("SELECT description FROM task WHERE id = 1", ())
-            .await
-            .expect("query");
-        let row = rows.next().await.expect("next").expect("row");
-        match row.get_value(0).expect("val") {
-            DbValue::Text(d) => assert_eq!(d, "desc"),
-            other => panic!("unexpected: {:?}", other),
-        }
+        let tasks = session.lock().await.tasks().list(None).await.expect("list");
+        assert_eq!(tasks[0].description.as_deref(), Some("desc"));
     }
 
     #[tokio::test]

--- a/src/tools/task/delete.rs
+++ b/src/tools/task/delete.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::Mutex as TokioMutex;
-use turso::Value as DbValue;
 
 use crate::session::Session;
 use crate::tools::{Tool, ToolError, ToolResult};
@@ -53,17 +52,16 @@ impl Tool for DeleteTaskTool {
                 })?;
 
         let session = self.session.lock().await;
-
-        let rows_affected = session
-            .conn
-            .execute("DELETE FROM task WHERE id = ?1", [DbValue::Integer(id)])
+        let deleted = session
+            .tasks()
+            .delete(id)
             .await
             .map_err(|e| ToolError::Execution {
                 tool_name: "delete_task".to_string(),
                 message: e.to_string(),
             })?;
 
-        if rows_affected == 0 {
+        if !deleted {
             return Err(ToolError::Execution {
                 tool_name: "delete_task".to_string(),
                 message: format!("Task with id {} does not exist", id),
@@ -92,37 +90,24 @@ mod tests {
     #[tokio::test]
     async fn delete_task_removes_row() {
         let session = test_session_arc().await;
-        let create = CreateTaskTool::new(Arc::clone(&session));
-        create
+        CreateTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"title": "to delete"}))
             .await
             .expect("create");
 
-        let delete = DeleteTaskTool::new(Arc::clone(&session));
-        delete
+        DeleteTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"id": 1}))
             .await
             .expect("delete");
 
-        let sess = session.lock().await;
-        let mut rows = sess
-            .conn
-            .query("SELECT COUNT(*) FROM task", ())
-            .await
-            .expect("q");
-        let row = rows.next().await.expect("n").expect("r");
-        let count = match row.get_value(0).expect("v") {
-            DbValue::Integer(n) => n,
-            other => panic!("unexpected count type: {:?}", other),
-        };
-        assert_eq!(count, 0);
+        let tasks = session.lock().await.tasks().list(None).await.expect("list");
+        assert!(tasks.is_empty());
     }
 
     #[tokio::test]
     async fn delete_task_missing_id_errors() {
         let session = test_session_arc().await;
-        let tool = DeleteTaskTool::new(session);
-        let err = tool
+        let err = DeleteTaskTool::new(session)
             .execute(serde_json::json!({"id": 999}))
             .await
             .expect_err("should fail");

--- a/src/tools/task/delete.rs
+++ b/src/tools/task/delete.rs
@@ -54,42 +54,7 @@ impl Tool for DeleteTaskTool {
 
         let session = self.session.lock().await;
 
-        // Check existence first
-        let mut rows = session
-            .conn
-            .query(
-                "SELECT COUNT(*) FROM task WHERE id = ?1",
-                [DbValue::Integer(id)],
-            )
-            .await
-            .map_err(|e| ToolError::Execution {
-                tool_name: "delete_task".to_string(),
-                message: e.to_string(),
-            })?;
-
-        let count = if let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
-            tool_name: "delete_task".to_string(),
-            message: e.to_string(),
-        })? {
-            match row.get_value(0).map_err(|e| ToolError::Execution {
-                tool_name: "delete_task".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Integer(n) => n,
-                _ => 0,
-            }
-        } else {
-            0
-        };
-
-        if count == 0 {
-            return Err(ToolError::Execution {
-                tool_name: "delete_task".to_string(),
-                message: format!("Task with id {} does not exist", id),
-            });
-        }
-
-        session
+        let rows_affected = session
             .conn
             .execute("DELETE FROM task WHERE id = ?1", [DbValue::Integer(id)])
             .await
@@ -97,6 +62,13 @@ impl Tool for DeleteTaskTool {
                 tool_name: "delete_task".to_string(),
                 message: e.to_string(),
             })?;
+
+        if rows_affected == 0 {
+            return Err(ToolError::Execution {
+                tool_name: "delete_task".to_string(),
+                message: format!("Task with id {} does not exist", id),
+            });
+        }
 
         Ok(ToolResult {
             content: vec![ContentBlock::Text(format!("Deleted task {}", id))],
@@ -141,7 +113,7 @@ mod tests {
         let row = rows.next().await.expect("n").expect("r");
         let count = match row.get_value(0).expect("v") {
             DbValue::Integer(n) => n,
-            _ => panic!(),
+            other => panic!("unexpected count type: {:?}", other),
         };
         assert_eq!(count, 0);
     }
@@ -155,12 +127,5 @@ mod tests {
             .await
             .expect_err("should fail");
         assert!(matches!(err, ToolError::Execution { .. }));
-    }
-
-    #[tokio::test]
-    async fn is_write_tool_returns_false() {
-        let session = test_session_arc().await;
-        let tool = DeleteTaskTool::new(session);
-        assert!(!tool.is_write_tool());
     }
 }

--- a/src/tools/task/delete.rs
+++ b/src/tools/task/delete.rs
@@ -1,0 +1,166 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use turso::Value as DbValue;
+
+use crate::session::Session;
+use crate::tools::{Tool, ToolError, ToolResult};
+use crate::types::ContentBlock;
+
+pub struct DeleteTaskTool {
+    session: Arc<TokioMutex<Session>>,
+    schema: Value,
+}
+
+impl DeleteTaskTool {
+    pub fn new(session: Arc<TokioMutex<Session>>) -> Self {
+        Self {
+            session,
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer", "description": "Task ID to delete"}
+                },
+                "required": ["id"]
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for DeleteTaskTool {
+    fn name(&self) -> &str {
+        "delete_task"
+    }
+
+    fn description(&self) -> &str {
+        "Delete a task by ID from the current session."
+    }
+
+    fn input_schema(&self) -> &Value {
+        &self.schema
+    }
+
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let id =
+            input
+                .get("id")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| ToolError::InvalidInput {
+                    message: "id is required and must be an integer".to_string(),
+                })?;
+
+        let session = self.session.lock().await;
+
+        // Check existence first
+        let mut rows = session
+            .conn
+            .query(
+                "SELECT COUNT(*) FROM task WHERE id = ?1",
+                [DbValue::Integer(id)],
+            )
+            .await
+            .map_err(|e| ToolError::Execution {
+                tool_name: "delete_task".to_string(),
+                message: e.to_string(),
+            })?;
+
+        let count = if let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
+            tool_name: "delete_task".to_string(),
+            message: e.to_string(),
+        })? {
+            match row.get_value(0).map_err(|e| ToolError::Execution {
+                tool_name: "delete_task".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Integer(n) => n,
+                _ => 0,
+            }
+        } else {
+            0
+        };
+
+        if count == 0 {
+            return Err(ToolError::Execution {
+                tool_name: "delete_task".to_string(),
+                message: format!("Task with id {} does not exist", id),
+            });
+        }
+
+        session
+            .conn
+            .execute("DELETE FROM task WHERE id = ?1", [DbValue::Integer(id)])
+            .await
+            .map_err(|e| ToolError::Execution {
+                tool_name: "delete_task".to_string(),
+                message: e.to_string(),
+            })?;
+
+        Ok(ToolResult {
+            content: vec![ContentBlock::Text(format!("Deleted task {}", id))],
+            is_error: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::task::create::CreateTaskTool;
+    use tempfile::TempDir;
+
+    async fn test_session_arc() -> Arc<TokioMutex<Session>> {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.keep()).await.expect("session");
+        Arc::new(TokioMutex::new(session))
+    }
+
+    #[tokio::test]
+    async fn delete_task_removes_row() {
+        let session = test_session_arc().await;
+        let create = CreateTaskTool::new(Arc::clone(&session));
+        create
+            .execute(serde_json::json!({"title": "to delete"}))
+            .await
+            .expect("create");
+
+        let delete = DeleteTaskTool::new(Arc::clone(&session));
+        delete
+            .execute(serde_json::json!({"id": 1}))
+            .await
+            .expect("delete");
+
+        let sess = session.lock().await;
+        let mut rows = sess
+            .conn
+            .query("SELECT COUNT(*) FROM task", ())
+            .await
+            .expect("q");
+        let row = rows.next().await.expect("n").expect("r");
+        let count = match row.get_value(0).expect("v") {
+            DbValue::Integer(n) => n,
+            _ => panic!(),
+        };
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn delete_task_missing_id_errors() {
+        let session = test_session_arc().await;
+        let tool = DeleteTaskTool::new(session);
+        let err = tool
+            .execute(serde_json::json!({"id": 999}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::Execution { .. }));
+    }
+
+    #[tokio::test]
+    async fn is_write_tool_returns_false() {
+        let session = test_session_arc().await;
+        let tool = DeleteTaskTool::new(session);
+        assert!(!tool.is_write_tool());
+    }
+}

--- a/src/tools/task/list.rs
+++ b/src/tools/task/list.rs
@@ -26,7 +26,8 @@ impl ListTasksTool {
                 "properties": {
                     "status": {
                         "type": "string",
-                        "description": "Optional status filter: pending, in_progress, or completed"
+                        "enum": ["pending", "in_progress", "completed"],
+                        "description": "Optional status filter"
                     }
                 }
             }),
@@ -284,12 +285,5 @@ mod tests {
             .await
             .expect_err("should fail");
         assert!(matches!(err, ToolError::InvalidInput { .. }));
-    }
-
-    #[tokio::test]
-    async fn is_write_tool_returns_false() {
-        let session = test_session_arc().await;
-        let tool = ListTasksTool::new(session);
-        assert!(!tool.is_write_tool());
     }
 }

--- a/src/tools/task/list.rs
+++ b/src/tools/task/list.rs
@@ -4,13 +4,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::Mutex as TokioMutex;
-use turso::Value as DbValue;
 
-use crate::session::Session;
+use crate::session::{Session, TaskStatus};
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
-
-use super::status::TaskStatus;
 
 pub struct ListTasksTool {
     session: Arc<TokioMutex<Session>>,
@@ -50,128 +47,26 @@ impl Tool for ListTasksTool {
     }
 
     async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
-        let status_filter = if let Some(s) = input.get("status").and_then(|v| v.as_str()) {
-            Some(TaskStatus::from_str(s)?)
-        } else {
-            None
-        };
+        let status_filter = input
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(|s| {
+                TaskStatus::from_str(s).map_err(|e| ToolError::InvalidInput {
+                    message: e.to_string(),
+                })
+            })
+            .transpose()?;
 
         let session = self.session.lock().await;
-
-        let mut rows = if let Some(status) = status_filter {
+        let tasks =
             session
-                .conn
-                .query(
-                    "SELECT id, title, description, status, created_at, updated_at FROM task WHERE status = ?1 ORDER BY id ASC",
-                    [DbValue::Text(status.as_str().to_string())],
-                )
+                .tasks()
+                .list(status_filter)
                 .await
                 .map_err(|e| ToolError::Execution {
                     tool_name: "list_tasks".to_string(),
                     message: e.to_string(),
-                })?
-        } else {
-            session
-                .conn
-                .query(
-                    "SELECT id, title, description, status, created_at, updated_at FROM task ORDER BY id ASC",
-                    (),
-                )
-                .await
-                .map_err(|e| ToolError::Execution {
-                    tool_name: "list_tasks".to_string(),
-                    message: e.to_string(),
-                })?
-        };
-
-        let mut tasks: Vec<serde_json::Value> = Vec::new();
-        while let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
-            tool_name: "list_tasks".to_string(),
-            message: e.to_string(),
-        })? {
-            let id = match row.get_value(0).map_err(|e| ToolError::Execution {
-                tool_name: "list_tasks".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Integer(n) => n,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "list_tasks".to_string(),
-                        message: format!("unexpected id type: {:?}", other),
-                    });
-                }
-            };
-            let title = match row.get_value(1).map_err(|e| ToolError::Execution {
-                tool_name: "list_tasks".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Text(s) => s,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "list_tasks".to_string(),
-                        message: format!("unexpected title type: {:?}", other),
-                    });
-                }
-            };
-            let description = match row.get_value(2).map_err(|e| ToolError::Execution {
-                tool_name: "list_tasks".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Text(s) => Some(s),
-                DbValue::Null => None,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "list_tasks".to_string(),
-                        message: format!("unexpected description type: {:?}", other),
-                    });
-                }
-            };
-            let status = match row.get_value(3).map_err(|e| ToolError::Execution {
-                tool_name: "list_tasks".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Text(s) => s,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "list_tasks".to_string(),
-                        message: format!("unexpected status type: {:?}", other),
-                    });
-                }
-            };
-            let created_at = match row.get_value(4).map_err(|e| ToolError::Execution {
-                tool_name: "list_tasks".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Integer(n) => n,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "list_tasks".to_string(),
-                        message: format!("unexpected created_at type: {:?}", other),
-                    });
-                }
-            };
-            let updated_at = match row.get_value(5).map_err(|e| ToolError::Execution {
-                tool_name: "list_tasks".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Integer(n) => n,
-                other => {
-                    return Err(ToolError::Execution {
-                        tool_name: "list_tasks".to_string(),
-                        message: format!("unexpected updated_at type: {:?}", other),
-                    });
-                }
-            };
-
-            tasks.push(serde_json::json!({
-                "id": id,
-                "title": title,
-                "description": description,
-                "status": status,
-                "created_at": created_at,
-                "updated_at": updated_at,
-            }));
-        }
+                })?;
 
         let output = serde_json::to_string_pretty(&tasks).map_err(|e| ToolError::Execution {
             tool_name: "list_tasks".to_string(),
@@ -197,90 +92,75 @@ mod tests {
         Arc::new(TokioMutex::new(session))
     }
 
-    #[tokio::test]
-    async fn list_tasks_returns_empty_when_none() {
-        let session = test_session_arc().await;
-        let tool = ListTasksTool::new(session);
-        let result = tool.execute(serde_json::json!({})).await.expect("list");
+    fn titles_from_result(result: &ToolResult) -> Vec<String> {
         let text = match &result.content[0] {
             ContentBlock::Text(t) => t.clone(),
             _ => panic!("expected text"),
         };
-        let parsed: serde_json::Value = serde_json::from_str(&text).expect("json");
-        assert_eq!(parsed.as_array().expect("array").len(), 0);
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).expect("json");
+        parsed
+            .iter()
+            .map(|t| t["title"].as_str().expect("title").to_string())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn list_tasks_returns_empty_when_none() {
+        let session = test_session_arc().await;
+        let result = ListTasksTool::new(session)
+            .execute(serde_json::json!({}))
+            .await
+            .expect("list");
+        assert!(titles_from_result(&result).is_empty());
     }
 
     #[tokio::test]
     async fn list_tasks_returns_all_in_id_order() {
         let session = test_session_arc().await;
-        let create = CreateTaskTool::new(Arc::clone(&session));
-        create
-            .execute(serde_json::json!({"title": "a"}))
+        for title in ["a", "b", "c"] {
+            CreateTaskTool::new(Arc::clone(&session))
+                .execute(serde_json::json!({"title": title}))
+                .await
+                .expect("create");
+        }
+        let result = ListTasksTool::new(Arc::clone(&session))
+            .execute(serde_json::json!({}))
             .await
-            .expect("c1");
-        create
-            .execute(serde_json::json!({"title": "b"}))
-            .await
-            .expect("c2");
-        create
-            .execute(serde_json::json!({"title": "c"}))
-            .await
-            .expect("c3");
-
-        let list = ListTasksTool::new(Arc::clone(&session));
-        let result = list.execute(serde_json::json!({})).await.expect("list");
-        let text = match &result.content[0] {
-            ContentBlock::Text(t) => t.clone(),
-            _ => panic!("expected text"),
-        };
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).expect("json");
-        assert_eq!(parsed.len(), 3);
-        assert_eq!(parsed[0]["title"], "a");
-        assert_eq!(parsed[1]["title"], "b");
-        assert_eq!(parsed[2]["title"], "c");
+            .expect("list");
+        assert_eq!(titles_from_result(&result), vec!["a", "b", "c"]);
     }
 
     #[tokio::test]
     async fn list_tasks_filters_by_status() {
         let session = test_session_arc().await;
-        let create = CreateTaskTool::new(Arc::clone(&session));
-        create
+        CreateTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"title": "pending-task"}))
             .await
             .expect("c1");
-        create
-            .execute(serde_json::json!({"title": "another"}))
+        CreateTaskTool::new(Arc::clone(&session))
+            .execute(serde_json::json!({"title": "active"}))
             .await
             .expect("c2");
 
-        // Manually update one to in_progress
-        {
-            let sess = session.lock().await;
-            sess.conn
-                .execute("UPDATE task SET status = 'in_progress' WHERE id = 2", ())
-                .await
-                .expect("update");
-        }
+        session
+            .lock()
+            .await
+            .tasks()
+            .update(2, None, None, Some(TaskStatus::InProgress))
+            .await
+            .expect("update");
 
-        let list = ListTasksTool::new(Arc::clone(&session));
-        let result = list
+        let result = ListTasksTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"status": "in_progress"}))
             .await
             .expect("list");
-        let text = match &result.content[0] {
-            ContentBlock::Text(t) => t.clone(),
-            _ => panic!("expected text"),
-        };
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).expect("json");
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0]["title"], "another");
+        assert_eq!(titles_from_result(&result), vec!["active"]);
     }
 
     #[tokio::test]
     async fn list_tasks_invalid_status_filter_errors() {
         let session = test_session_arc().await;
-        let tool = ListTasksTool::new(session);
-        let err = tool
+        let err = ListTasksTool::new(session)
             .execute(serde_json::json!({"status": "bogus"}))
             .await
             .expect_err("should fail");

--- a/src/tools/task/list.rs
+++ b/src/tools/task/list.rs
@@ -1,0 +1,295 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use turso::Value as DbValue;
+
+use crate::session::Session;
+use crate::tools::{Tool, ToolError, ToolResult};
+use crate::types::ContentBlock;
+
+use super::status::TaskStatus;
+
+pub struct ListTasksTool {
+    session: Arc<TokioMutex<Session>>,
+    schema: Value,
+}
+
+impl ListTasksTool {
+    pub fn new(session: Arc<TokioMutex<Session>>) -> Self {
+        Self {
+            session,
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Optional status filter: pending, in_progress, or completed"
+                    }
+                }
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ListTasksTool {
+    fn name(&self) -> &str {
+        "list_tasks"
+    }
+
+    fn description(&self) -> &str {
+        "List tasks in the current session, ordered by id. Optionally filter by status."
+    }
+
+    fn input_schema(&self) -> &Value {
+        &self.schema
+    }
+
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let status_filter = if let Some(s) = input.get("status").and_then(|v| v.as_str()) {
+            Some(TaskStatus::from_str(s)?)
+        } else {
+            None
+        };
+
+        let session = self.session.lock().await;
+
+        let mut rows = if let Some(status) = status_filter {
+            session
+                .conn
+                .query(
+                    "SELECT id, title, description, status, created_at, updated_at FROM task WHERE status = ?1 ORDER BY id ASC",
+                    [DbValue::Text(status.as_str().to_string())],
+                )
+                .await
+                .map_err(|e| ToolError::Execution {
+                    tool_name: "list_tasks".to_string(),
+                    message: e.to_string(),
+                })?
+        } else {
+            session
+                .conn
+                .query(
+                    "SELECT id, title, description, status, created_at, updated_at FROM task ORDER BY id ASC",
+                    (),
+                )
+                .await
+                .map_err(|e| ToolError::Execution {
+                    tool_name: "list_tasks".to_string(),
+                    message: e.to_string(),
+                })?
+        };
+
+        let mut tasks: Vec<serde_json::Value> = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
+            tool_name: "list_tasks".to_string(),
+            message: e.to_string(),
+        })? {
+            let id = match row.get_value(0).map_err(|e| ToolError::Execution {
+                tool_name: "list_tasks".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Integer(n) => n,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "list_tasks".to_string(),
+                        message: format!("unexpected id type: {:?}", other),
+                    });
+                }
+            };
+            let title = match row.get_value(1).map_err(|e| ToolError::Execution {
+                tool_name: "list_tasks".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Text(s) => s,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "list_tasks".to_string(),
+                        message: format!("unexpected title type: {:?}", other),
+                    });
+                }
+            };
+            let description = match row.get_value(2).map_err(|e| ToolError::Execution {
+                tool_name: "list_tasks".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Text(s) => Some(s),
+                DbValue::Null => None,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "list_tasks".to_string(),
+                        message: format!("unexpected description type: {:?}", other),
+                    });
+                }
+            };
+            let status = match row.get_value(3).map_err(|e| ToolError::Execution {
+                tool_name: "list_tasks".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Text(s) => s,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "list_tasks".to_string(),
+                        message: format!("unexpected status type: {:?}", other),
+                    });
+                }
+            };
+            let created_at = match row.get_value(4).map_err(|e| ToolError::Execution {
+                tool_name: "list_tasks".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Integer(n) => n,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "list_tasks".to_string(),
+                        message: format!("unexpected created_at type: {:?}", other),
+                    });
+                }
+            };
+            let updated_at = match row.get_value(5).map_err(|e| ToolError::Execution {
+                tool_name: "list_tasks".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Integer(n) => n,
+                other => {
+                    return Err(ToolError::Execution {
+                        tool_name: "list_tasks".to_string(),
+                        message: format!("unexpected updated_at type: {:?}", other),
+                    });
+                }
+            };
+
+            tasks.push(serde_json::json!({
+                "id": id,
+                "title": title,
+                "description": description,
+                "status": status,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }));
+        }
+
+        let output = serde_json::to_string_pretty(&tasks).map_err(|e| ToolError::Execution {
+            tool_name: "list_tasks".to_string(),
+            message: e.to_string(),
+        })?;
+
+        Ok(ToolResult {
+            content: vec![ContentBlock::Text(output)],
+            is_error: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::task::create::CreateTaskTool;
+    use tempfile::TempDir;
+
+    async fn test_session_arc() -> Arc<TokioMutex<Session>> {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.keep()).await.expect("session");
+        Arc::new(TokioMutex::new(session))
+    }
+
+    #[tokio::test]
+    async fn list_tasks_returns_empty_when_none() {
+        let session = test_session_arc().await;
+        let tool = ListTasksTool::new(session);
+        let result = tool.execute(serde_json::json!({})).await.expect("list");
+        let text = match &result.content[0] {
+            ContentBlock::Text(t) => t.clone(),
+            _ => panic!("expected text"),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&text).expect("json");
+        assert_eq!(parsed.as_array().expect("array").len(), 0);
+    }
+
+    #[tokio::test]
+    async fn list_tasks_returns_all_in_id_order() {
+        let session = test_session_arc().await;
+        let create = CreateTaskTool::new(Arc::clone(&session));
+        create
+            .execute(serde_json::json!({"title": "a"}))
+            .await
+            .expect("c1");
+        create
+            .execute(serde_json::json!({"title": "b"}))
+            .await
+            .expect("c2");
+        create
+            .execute(serde_json::json!({"title": "c"}))
+            .await
+            .expect("c3");
+
+        let list = ListTasksTool::new(Arc::clone(&session));
+        let result = list.execute(serde_json::json!({})).await.expect("list");
+        let text = match &result.content[0] {
+            ContentBlock::Text(t) => t.clone(),
+            _ => panic!("expected text"),
+        };
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).expect("json");
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[0]["title"], "a");
+        assert_eq!(parsed[1]["title"], "b");
+        assert_eq!(parsed[2]["title"], "c");
+    }
+
+    #[tokio::test]
+    async fn list_tasks_filters_by_status() {
+        let session = test_session_arc().await;
+        let create = CreateTaskTool::new(Arc::clone(&session));
+        create
+            .execute(serde_json::json!({"title": "pending-task"}))
+            .await
+            .expect("c1");
+        create
+            .execute(serde_json::json!({"title": "another"}))
+            .await
+            .expect("c2");
+
+        // Manually update one to in_progress
+        {
+            let sess = session.lock().await;
+            sess.conn
+                .execute("UPDATE task SET status = 'in_progress' WHERE id = 2", ())
+                .await
+                .expect("update");
+        }
+
+        let list = ListTasksTool::new(Arc::clone(&session));
+        let result = list
+            .execute(serde_json::json!({"status": "in_progress"}))
+            .await
+            .expect("list");
+        let text = match &result.content[0] {
+            ContentBlock::Text(t) => t.clone(),
+            _ => panic!("expected text"),
+        };
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).expect("json");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0]["title"], "another");
+    }
+
+    #[tokio::test]
+    async fn list_tasks_invalid_status_filter_errors() {
+        let session = test_session_arc().await;
+        let tool = ListTasksTool::new(session);
+        let err = tool
+            .execute(serde_json::json!({"status": "bogus"}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[tokio::test]
+    async fn is_write_tool_returns_false() {
+        let session = test_session_arc().await;
+        let tool = ListTasksTool::new(session);
+        assert!(!tool.is_write_tool());
+    }
+}

--- a/src/tools/task/mod.rs
+++ b/src/tools/task/mod.rs
@@ -1,0 +1,134 @@
+pub mod create;
+pub mod delete;
+pub mod list;
+pub mod status;
+pub mod update;
+
+pub use create::CreateTaskTool;
+pub use delete::DeleteTaskTool;
+pub use list::ListTasksTool;
+pub use update::UpdateTaskTool;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::Mutex as TokioMutex;
+
+    use crate::session::Session;
+    use crate::tools::{Tool, ToolError};
+    use crate::types::ContentBlock;
+
+    use super::*;
+
+    async fn test_session_arc_in(dir: &std::path::Path) -> Arc<TokioMutex<Session>> {
+        let session = Session::new(None, dir.to_path_buf())
+            .await
+            .expect("session");
+        Arc::new(TokioMutex::new(session))
+    }
+
+    async fn test_session_arc() -> Arc<TokioMutex<Session>> {
+        let dir = TempDir::new().expect("temp dir");
+        test_session_arc_in(&dir.keep()).await
+    }
+
+    async fn create_task(session: &Arc<TokioMutex<Session>>, title: &str) {
+        CreateTaskTool::new(Arc::clone(session))
+            .execute(serde_json::json!({"title": title}))
+            .await
+            .expect("create");
+    }
+
+    fn task_titles(result: &crate::tools::ToolResult) -> Vec<String> {
+        let text = match &result.content[0] {
+            ContentBlock::Text(t) => t.clone(),
+            _ => panic!("expected text"),
+        };
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&text).expect("json");
+        parsed
+            .iter()
+            .map(|t| t["title"].as_str().expect("title").to_string())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn tasks_persist_across_session_reopen() {
+        let dir = TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let id = {
+            let session = Session::new(None, dir_path.clone()).await.expect("create");
+            let id = session.id.clone();
+            let arc = Arc::new(TokioMutex::new(session));
+            create_task(&arc, "persisted task").await;
+            id
+        };
+
+        let session2 = Session::new(Some(id), dir_path).await.expect("reopen");
+        let arc2 = Arc::new(TokioMutex::new(session2));
+        let result = ListTasksTool::new(arc2)
+            .execute(serde_json::json!({}))
+            .await
+            .expect("list");
+        let titles = task_titles(&result);
+        assert_eq!(titles, vec!["persisted task"]);
+    }
+
+    #[tokio::test]
+    async fn tasks_are_scoped_per_session() {
+        let dir = TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session_a = test_session_arc_in(&dir_path).await;
+        create_task(&session_a, "session a task").await;
+
+        let session_b = test_session_arc_in(&dir_path).await;
+
+        let result = ListTasksTool::new(session_b)
+            .execute(serde_json::json!({}))
+            .await
+            .expect("list");
+        let titles = task_titles(&result);
+        assert!(titles.is_empty(), "session B should have no tasks");
+    }
+
+    #[tokio::test]
+    async fn session_swap_routes_subsequent_calls_to_new_session_db() {
+        let dir = TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session_a = Session::new(None, dir_path.clone()).await.expect("a");
+        let session_b = Session::new(None, dir_path.clone()).await.expect("b");
+
+        let arc = Arc::new(TokioMutex::new(session_a));
+        create_task(&arc, "task in A").await;
+
+        // Swap inner session to B
+        *arc.lock().await = session_b;
+
+        let result = ListTasksTool::new(Arc::clone(&arc))
+            .execute(serde_json::json!({}))
+            .await
+            .expect("list");
+        let titles = task_titles(&result);
+        assert!(titles.is_empty(), "after swap to B, list should be empty");
+
+        create_task(&arc, "task in B").await;
+        let result2 = ListTasksTool::new(Arc::clone(&arc))
+            .execute(serde_json::json!({}))
+            .await
+            .expect("list after create in B");
+        let titles2 = task_titles(&result2);
+        assert_eq!(titles2, vec!["task in B"]);
+    }
+
+    #[tokio::test]
+    async fn is_write_tool_returns_false_for_all_four() {
+        let session = test_session_arc().await;
+        assert!(!CreateTaskTool::new(Arc::clone(&session)).is_write_tool());
+        assert!(!ListTasksTool::new(Arc::clone(&session)).is_write_tool());
+        assert!(!UpdateTaskTool::new(Arc::clone(&session)).is_write_tool());
+        assert!(!DeleteTaskTool::new(Arc::clone(&session)).is_write_tool());
+    }
+}

--- a/src/tools/task/mod.rs
+++ b/src/tools/task/mod.rs
@@ -1,22 +1,12 @@
 pub mod create;
 pub mod delete;
 pub mod list;
-pub mod status;
 pub mod update;
 
 pub use create::CreateTaskTool;
 pub use delete::DeleteTaskTool;
 pub use list::ListTasksTool;
 pub use update::UpdateTaskTool;
-
-use std::time::SystemTime;
-
-pub(super) fn now_epoch_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("system time is before UNIX epoch")
-        .as_secs() as i64
-}
 
 #[cfg(test)]
 mod tests {
@@ -25,16 +15,17 @@ mod tests {
     use tokio::sync::Mutex as TokioMutex;
 
     use crate::session::Session;
-    use crate::tools::{Tool, ToolError};
+    use crate::tools::Tool;
     use crate::types::ContentBlock;
 
     use super::*;
 
     async fn test_session_arc_in(dir: &std::path::Path) -> Arc<TokioMutex<Session>> {
-        let session = Session::new(None, dir.to_path_buf())
-            .await
-            .expect("session");
-        Arc::new(TokioMutex::new(session))
+        Arc::new(TokioMutex::new(
+            Session::new(None, dir.to_path_buf())
+                .await
+                .expect("session"),
+        ))
     }
 
     async fn test_session_arc() -> Arc<TokioMutex<Session>> {
@@ -49,7 +40,7 @@ mod tests {
             .expect("create");
     }
 
-    fn task_titles(result: &crate::tools::ToolResult) -> Vec<String> {
+    fn task_titles_from_result(result: &crate::tools::ToolResult) -> Vec<String> {
         let text = match &result.content[0] {
             ContentBlock::Text(t) => t.clone(),
             _ => panic!("expected text"),
@@ -66,22 +57,23 @@ mod tests {
         let dir = TempDir::new().expect("temp dir");
         let dir_path = dir.keep();
 
-        let id = {
+        let session_id = {
             let session = Session::new(None, dir_path.clone()).await.expect("create");
             let id = session.id.clone();
-            let arc = Arc::new(TokioMutex::new(session));
-            create_task(&arc, "persisted task").await;
+            session
+                .tasks()
+                .create("persisted task", None)
+                .await
+                .expect("create");
             id
         };
 
-        let session2 = Session::new(Some(id), dir_path).await.expect("reopen");
-        let arc2 = Arc::new(TokioMutex::new(session2));
-        let result = ListTasksTool::new(arc2)
-            .execute(serde_json::json!({}))
+        let session2 = Session::new(Some(session_id), dir_path)
             .await
-            .expect("list");
-        let titles = task_titles(&result);
-        assert_eq!(titles, vec!["persisted task"]);
+            .expect("reopen");
+        let tasks = session2.tasks().list(None).await.expect("list");
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].title, "persisted task");
     }
 
     #[tokio::test]
@@ -93,13 +85,14 @@ mod tests {
         create_task(&session_a, "session a task").await;
 
         let session_b = test_session_arc_in(&dir_path).await;
-
-        let result = ListTasksTool::new(session_b)
-            .execute(serde_json::json!({}))
+        let tasks = session_b
+            .lock()
+            .await
+            .tasks()
+            .list(None)
             .await
             .expect("list");
-        let titles = task_titles(&result);
-        assert!(titles.is_empty(), "session B should have no tasks");
+        assert!(tasks.is_empty(), "session B should have no tasks");
     }
 
     #[tokio::test]
@@ -113,23 +106,23 @@ mod tests {
         let arc = Arc::new(TokioMutex::new(session_a));
         create_task(&arc, "task in A").await;
 
-        // Swap inner session to B
         *arc.lock().await = session_b;
 
         let result = ListTasksTool::new(Arc::clone(&arc))
             .execute(serde_json::json!({}))
             .await
-            .expect("list");
-        let titles = task_titles(&result);
-        assert!(titles.is_empty(), "after swap to B, list should be empty");
+            .expect("list after swap");
+        assert!(
+            task_titles_from_result(&result).is_empty(),
+            "after swap to B, list should be empty"
+        );
 
         create_task(&arc, "task in B").await;
         let result2 = ListTasksTool::new(Arc::clone(&arc))
             .execute(serde_json::json!({}))
             .await
             .expect("list after create in B");
-        let titles2 = task_titles(&result2);
-        assert_eq!(titles2, vec!["task in B"]);
+        assert_eq!(task_titles_from_result(&result2), vec!["task in B"]);
     }
 
     #[tokio::test]

--- a/src/tools/task/mod.rs
+++ b/src/tools/task/mod.rs
@@ -9,6 +9,15 @@ pub use delete::DeleteTaskTool;
 pub use list::ListTasksTool;
 pub use update::UpdateTaskTool;
 
+use std::time::SystemTime;
+
+pub(super) fn now_epoch_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time is before UNIX epoch")
+        .as_secs() as i64
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/src/tools/task/status.rs
+++ b/src/tools/task/status.rs
@@ -1,0 +1,70 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::tools::ToolError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+}
+
+impl TaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+        }
+    }
+}
+
+impl FromStr for TaskStatus {
+    type Err = ToolError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "in_progress" => Ok(Self::InProgress),
+            "completed" => Ok(Self::Completed),
+            other => Err(ToolError::InvalidInput {
+                message: format!(
+                    "Invalid status '{}'. Must be one of: pending, in_progress, completed",
+                    other
+                ),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_status_round_trips_through_string() {
+        for (variant, s) in [
+            (TaskStatus::Pending, "pending"),
+            (TaskStatus::InProgress, "in_progress"),
+            (TaskStatus::Completed, "completed"),
+        ] {
+            assert_eq!(variant.as_str(), s);
+            assert_eq!(TaskStatus::from_str(s).expect("parse"), variant);
+        }
+    }
+
+    #[test]
+    fn task_status_rejects_invalid_string() {
+        let err = TaskStatus::from_str("done").expect_err("should fail");
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[test]
+    fn task_status_default_is_pending() {
+        assert_eq!(TaskStatus::default(), TaskStatus::Pending);
+    }
+}

--- a/src/tools/task/update.rs
+++ b/src/tools/task/update.rs
@@ -1,6 +1,5 @@
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::SystemTime;
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -11,14 +10,8 @@ use crate::session::Session;
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
 
+use super::now_epoch_secs;
 use super::status::TaskStatus;
-
-fn now_epoch_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("system time is before UNIX epoch")
-        .as_secs() as i64
-}
 
 pub struct UpdateTaskTool {
     session: Arc<TokioMutex<Session>>,
@@ -35,7 +28,11 @@ impl UpdateTaskTool {
                     "id": {"type": "integer", "description": "Task ID to update"},
                     "title": {"type": "string", "description": "New title"},
                     "description": {"type": "string", "description": "New description"},
-                    "status": {"type": "string", "description": "New status: pending, in_progress, or completed"}
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "in_progress", "completed"],
+                        "description": "New status"
+                    }
                 },
                 "required": ["id"]
             }),
@@ -87,6 +84,14 @@ impl Tool for UpdateTaskTool {
             });
         }
 
+        if let Some(ref t) = new_title
+            && t.is_empty()
+        {
+            return Err(ToolError::InvalidInput {
+                message: "title must not be empty".to_string(),
+            });
+        }
+
         let now = now_epoch_secs();
         let session = self.session.lock().await;
 
@@ -121,44 +126,17 @@ impl Tool for UpdateTaskTool {
             idx
         );
 
-        session
-            .conn
-            .execute(&sql, params)
-            .await
-            .map_err(|e| ToolError::Execution {
-                tool_name: "update_task".to_string(),
-                message: e.to_string(),
-            })?;
+        let rows_affected =
+            session
+                .conn
+                .execute(&sql, params)
+                .await
+                .map_err(|e| ToolError::Execution {
+                    tool_name: "update_task".to_string(),
+                    message: e.to_string(),
+                })?;
 
-        // Verify the row existed
-        let mut rows = session
-            .conn
-            .query(
-                "SELECT COUNT(*) FROM task WHERE id = ?1",
-                [DbValue::Integer(id)],
-            )
-            .await
-            .map_err(|e| ToolError::Execution {
-                tool_name: "update_task".to_string(),
-                message: e.to_string(),
-            })?;
-
-        let count = if let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
-            tool_name: "update_task".to_string(),
-            message: e.to_string(),
-        })? {
-            match row.get_value(0).map_err(|e| ToolError::Execution {
-                tool_name: "update_task".to_string(),
-                message: e.to_string(),
-            })? {
-                DbValue::Integer(n) => n,
-                _ => 0,
-            }
-        } else {
-            0
-        };
-
-        if count == 0 {
+        if rows_affected == 0 {
             return Err(ToolError::Execution {
                 tool_name: "update_task".to_string(),
                 message: format!("Task with id {} does not exist", id),
@@ -210,8 +188,6 @@ mod tests {
             }
         };
 
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
         let tool = UpdateTaskTool::new(Arc::clone(&session));
         tool.execute(serde_json::json!({"id": 1, "title": "updated"}))
             .await
@@ -241,7 +217,7 @@ mod tests {
         };
         assert_eq!(title, "updated");
         assert_eq!(status, "pending");
-        assert!(updated_at > before, "updated_at should advance");
+        assert!(updated_at >= before, "updated_at should not regress");
     }
 
     #[tokio::test]
@@ -296,6 +272,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_task_empty_title_errors() {
+        let session = test_session_arc().await;
+        create_task(&session, "task").await;
+        let tool = UpdateTaskTool::new(Arc::clone(&session));
+        let err = tool
+            .execute(serde_json::json!({"id": 1, "title": ""}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[tokio::test]
     async fn update_task_missing_id_errors() {
         let session = test_session_arc().await;
         let tool = UpdateTaskTool::new(Arc::clone(&session));
@@ -304,12 +292,5 @@ mod tests {
             .await
             .expect_err("should fail");
         assert!(matches!(err, ToolError::Execution { .. }));
-    }
-
-    #[tokio::test]
-    async fn is_write_tool_returns_false() {
-        let session = test_session_arc().await;
-        let tool = UpdateTaskTool::new(session);
-        assert!(!tool.is_write_tool());
     }
 }

--- a/src/tools/task/update.rs
+++ b/src/tools/task/update.rs
@@ -1,0 +1,315 @@
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::Mutex as TokioMutex;
+use turso::Value as DbValue;
+
+use crate::session::Session;
+use crate::tools::{Tool, ToolError, ToolResult};
+use crate::types::ContentBlock;
+
+use super::status::TaskStatus;
+
+fn now_epoch_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time is before UNIX epoch")
+        .as_secs() as i64
+}
+
+pub struct UpdateTaskTool {
+    session: Arc<TokioMutex<Session>>,
+    schema: Value,
+}
+
+impl UpdateTaskTool {
+    pub fn new(session: Arc<TokioMutex<Session>>) -> Self {
+        Self {
+            session,
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer", "description": "Task ID to update"},
+                    "title": {"type": "string", "description": "New title"},
+                    "description": {"type": "string", "description": "New description"},
+                    "status": {"type": "string", "description": "New status: pending, in_progress, or completed"}
+                },
+                "required": ["id"]
+            }),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for UpdateTaskTool {
+    fn name(&self) -> &str {
+        "update_task"
+    }
+
+    fn description(&self) -> &str {
+        "Update a task's title, description, or status. At least one of title, description, or status must be provided."
+    }
+
+    fn input_schema(&self) -> &Value {
+        &self.schema
+    }
+
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let id =
+            input
+                .get("id")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| ToolError::InvalidInput {
+                    message: "id is required and must be an integer".to_string(),
+                })?;
+
+        let new_title = input
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let new_description = input
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let new_status = if let Some(s) = input.get("status").and_then(|v| v.as_str()) {
+            Some(TaskStatus::from_str(s)?)
+        } else {
+            None
+        };
+
+        if new_title.is_none() && new_description.is_none() && new_status.is_none() {
+            return Err(ToolError::InvalidInput {
+                message: "At least one of title, description, or status must be provided"
+                    .to_string(),
+            });
+        }
+
+        let now = now_epoch_secs();
+        let session = self.session.lock().await;
+
+        // Build SET clauses dynamically
+        let mut set_parts: Vec<String> = Vec::new();
+        let mut params: Vec<DbValue> = Vec::new();
+        let mut idx = 1usize;
+
+        if let Some(ref t) = new_title {
+            set_parts.push(format!("title = ?{}", idx));
+            params.push(DbValue::Text(t.clone()));
+            idx += 1;
+        }
+        if let Some(ref d) = new_description {
+            set_parts.push(format!("description = ?{}", idx));
+            params.push(DbValue::Text(d.clone()));
+            idx += 1;
+        }
+        if let Some(s) = new_status {
+            set_parts.push(format!("status = ?{}", idx));
+            params.push(DbValue::Text(s.as_str().to_string()));
+            idx += 1;
+        }
+        set_parts.push(format!("updated_at = ?{}", idx));
+        params.push(DbValue::Integer(now));
+        idx += 1;
+
+        params.push(DbValue::Integer(id));
+        let sql = format!(
+            "UPDATE task SET {} WHERE id = ?{}",
+            set_parts.join(", "),
+            idx
+        );
+
+        session
+            .conn
+            .execute(&sql, params)
+            .await
+            .map_err(|e| ToolError::Execution {
+                tool_name: "update_task".to_string(),
+                message: e.to_string(),
+            })?;
+
+        // Verify the row existed
+        let mut rows = session
+            .conn
+            .query(
+                "SELECT COUNT(*) FROM task WHERE id = ?1",
+                [DbValue::Integer(id)],
+            )
+            .await
+            .map_err(|e| ToolError::Execution {
+                tool_name: "update_task".to_string(),
+                message: e.to_string(),
+            })?;
+
+        let count = if let Some(row) = rows.next().await.map_err(|e| ToolError::Execution {
+            tool_name: "update_task".to_string(),
+            message: e.to_string(),
+        })? {
+            match row.get_value(0).map_err(|e| ToolError::Execution {
+                tool_name: "update_task".to_string(),
+                message: e.to_string(),
+            })? {
+                DbValue::Integer(n) => n,
+                _ => 0,
+            }
+        } else {
+            0
+        };
+
+        if count == 0 {
+            return Err(ToolError::Execution {
+                tool_name: "update_task".to_string(),
+                message: format!("Task with id {} does not exist", id),
+            });
+        }
+
+        Ok(ToolResult {
+            content: vec![ContentBlock::Text(format!("Updated task {}", id))],
+            is_error: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::task::create::CreateTaskTool;
+    use tempfile::TempDir;
+
+    async fn test_session_arc() -> Arc<TokioMutex<Session>> {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.keep()).await.expect("session");
+        Arc::new(TokioMutex::new(session))
+    }
+
+    async fn create_task(session: &Arc<TokioMutex<Session>>, title: &str) {
+        let tool = CreateTaskTool::new(Arc::clone(session));
+        tool.execute(serde_json::json!({"title": title}))
+            .await
+            .expect("create");
+    }
+
+    #[tokio::test]
+    async fn update_task_partial_title_only() {
+        let session = test_session_arc().await;
+        create_task(&session, "original").await;
+
+        let before = {
+            let sess = session.lock().await;
+            let mut rows = sess
+                .conn
+                .query("SELECT updated_at FROM task WHERE id = 1", ())
+                .await
+                .expect("q");
+            let row = rows.next().await.expect("n").expect("r");
+            match row.get_value(0).expect("v") {
+                DbValue::Integer(n) => n,
+                _ => panic!(),
+            }
+        };
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        let tool = UpdateTaskTool::new(Arc::clone(&session));
+        tool.execute(serde_json::json!({"id": 1, "title": "updated"}))
+            .await
+            .expect("update");
+
+        let sess = session.lock().await;
+        let mut rows = sess
+            .conn
+            .query(
+                "SELECT title, status, updated_at FROM task WHERE id = 1",
+                (),
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("next").expect("row");
+        let title = match row.get_value(0).expect("v") {
+            DbValue::Text(s) => s,
+            _ => panic!(),
+        };
+        let status = match row.get_value(1).expect("v") {
+            DbValue::Text(s) => s,
+            _ => panic!(),
+        };
+        let updated_at = match row.get_value(2).expect("v") {
+            DbValue::Integer(n) => n,
+            _ => panic!(),
+        };
+        assert_eq!(title, "updated");
+        assert_eq!(status, "pending");
+        assert!(updated_at > before, "updated_at should advance");
+    }
+
+    #[tokio::test]
+    async fn update_task_status_transition() {
+        let session = test_session_arc().await;
+        create_task(&session, "task").await;
+
+        let tool = UpdateTaskTool::new(Arc::clone(&session));
+        tool.execute(serde_json::json!({"id": 1, "status": "in_progress"}))
+            .await
+            .expect("u1");
+        tool.execute(serde_json::json!({"id": 1, "status": "completed"}))
+            .await
+            .expect("u2");
+
+        let sess = session.lock().await;
+        let mut rows = sess
+            .conn
+            .query("SELECT status FROM task WHERE id = 1", ())
+            .await
+            .expect("q");
+        let row = rows.next().await.expect("n").expect("r");
+        let status = match row.get_value(0).expect("v") {
+            DbValue::Text(s) => s,
+            _ => panic!(),
+        };
+        assert_eq!(status, "completed");
+    }
+
+    #[tokio::test]
+    async fn update_task_invalid_status_errors() {
+        let session = test_session_arc().await;
+        create_task(&session, "task").await;
+        let tool = UpdateTaskTool::new(Arc::clone(&session));
+        let err = tool
+            .execute(serde_json::json!({"id": 1, "status": "bogus"}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[tokio::test]
+    async fn update_task_with_no_mutable_fields_errors() {
+        let session = test_session_arc().await;
+        create_task(&session, "task").await;
+        let tool = UpdateTaskTool::new(Arc::clone(&session));
+        let err = tool
+            .execute(serde_json::json!({"id": 1}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[tokio::test]
+    async fn update_task_missing_id_errors() {
+        let session = test_session_arc().await;
+        let tool = UpdateTaskTool::new(Arc::clone(&session));
+        let err = tool
+            .execute(serde_json::json!({"id": 999, "title": "x"}))
+            .await
+            .expect_err("should fail");
+        assert!(matches!(err, ToolError::Execution { .. }));
+    }
+
+    #[tokio::test]
+    async fn is_write_tool_returns_false() {
+        let session = test_session_arc().await;
+        let tool = UpdateTaskTool::new(session);
+        assert!(!tool.is_write_tool());
+    }
+}

--- a/src/tools/task/update.rs
+++ b/src/tools/task/update.rs
@@ -4,14 +4,10 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::Mutex as TokioMutex;
-use turso::Value as DbValue;
 
-use crate::session::Session;
+use crate::session::{Session, TaskStatus};
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
-
-use super::now_epoch_secs;
-use super::status::TaskStatus;
 
 pub struct UpdateTaskTool {
     session: Arc<TokioMutex<Session>>,
@@ -63,19 +59,17 @@ impl Tool for UpdateTaskTool {
                     message: "id is required and must be an integer".to_string(),
                 })?;
 
-        let new_title = input
-            .get("title")
+        let new_title = input.get("title").and_then(|v| v.as_str());
+        let new_description = input.get("description").and_then(|v| v.as_str());
+        let new_status = input
+            .get("status")
             .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        let new_description = input
-            .get("description")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-        let new_status = if let Some(s) = input.get("status").and_then(|v| v.as_str()) {
-            Some(TaskStatus::from_str(s)?)
-        } else {
-            None
-        };
+            .map(|s| {
+                TaskStatus::from_str(s).map_err(|e| ToolError::InvalidInput {
+                    message: e.to_string(),
+                })
+            })
+            .transpose()?;
 
         if new_title.is_none() && new_description.is_none() && new_status.is_none() {
             return Err(ToolError::InvalidInput {
@@ -84,7 +78,7 @@ impl Tool for UpdateTaskTool {
             });
         }
 
-        if let Some(ref t) = new_title
+        if let Some(t) = new_title
             && t.is_empty()
         {
             return Err(ToolError::InvalidInput {
@@ -92,51 +86,17 @@ impl Tool for UpdateTaskTool {
             });
         }
 
-        let now = now_epoch_secs();
         let session = self.session.lock().await;
+        let updated = session
+            .tasks()
+            .update(id, new_title, new_description, new_status)
+            .await
+            .map_err(|e| ToolError::Execution {
+                tool_name: "update_task".to_string(),
+                message: e.to_string(),
+            })?;
 
-        // Build SET clauses dynamically
-        let mut set_parts: Vec<String> = Vec::new();
-        let mut params: Vec<DbValue> = Vec::new();
-        let mut idx = 1usize;
-
-        if let Some(ref t) = new_title {
-            set_parts.push(format!("title = ?{}", idx));
-            params.push(DbValue::Text(t.clone()));
-            idx += 1;
-        }
-        if let Some(ref d) = new_description {
-            set_parts.push(format!("description = ?{}", idx));
-            params.push(DbValue::Text(d.clone()));
-            idx += 1;
-        }
-        if let Some(s) = new_status {
-            set_parts.push(format!("status = ?{}", idx));
-            params.push(DbValue::Text(s.as_str().to_string()));
-            idx += 1;
-        }
-        set_parts.push(format!("updated_at = ?{}", idx));
-        params.push(DbValue::Integer(now));
-        idx += 1;
-
-        params.push(DbValue::Integer(id));
-        let sql = format!(
-            "UPDATE task SET {} WHERE id = ?{}",
-            set_parts.join(", "),
-            idx
-        );
-
-        let rows_affected =
-            session
-                .conn
-                .execute(&sql, params)
-                .await
-                .map_err(|e| ToolError::Execution {
-                    tool_name: "update_task".to_string(),
-                    message: e.to_string(),
-                })?;
-
-        if rows_affected == 0 {
+        if !updated {
             return Err(ToolError::Execution {
                 tool_name: "update_task".to_string(),
                 message: format!("Task with id {} does not exist", id),
@@ -163,8 +123,8 @@ mod tests {
     }
 
     async fn create_task(session: &Arc<TokioMutex<Session>>, title: &str) {
-        let tool = CreateTaskTool::new(Arc::clone(session));
-        tool.execute(serde_json::json!({"title": title}))
+        CreateTaskTool::new(Arc::clone(session))
+            .execute(serde_json::json!({"title": title}))
             .await
             .expect("create");
     }
@@ -174,50 +134,20 @@ mod tests {
         let session = test_session_arc().await;
         create_task(&session, "original").await;
 
-        let before = {
-            let sess = session.lock().await;
-            let mut rows = sess
-                .conn
-                .query("SELECT updated_at FROM task WHERE id = 1", ())
-                .await
-                .expect("q");
-            let row = rows.next().await.expect("n").expect("r");
-            match row.get_value(0).expect("v") {
-                DbValue::Integer(n) => n,
-                _ => panic!(),
-            }
-        };
+        let before = session.lock().await.tasks().list(None).await.expect("list")[0].updated_at;
 
-        let tool = UpdateTaskTool::new(Arc::clone(&session));
-        tool.execute(serde_json::json!({"id": 1, "title": "updated"}))
+        UpdateTaskTool::new(Arc::clone(&session))
+            .execute(serde_json::json!({"id": 1, "title": "updated"}))
             .await
             .expect("update");
 
-        let sess = session.lock().await;
-        let mut rows = sess
-            .conn
-            .query(
-                "SELECT title, status, updated_at FROM task WHERE id = 1",
-                (),
-            )
-            .await
-            .expect("query");
-        let row = rows.next().await.expect("next").expect("row");
-        let title = match row.get_value(0).expect("v") {
-            DbValue::Text(s) => s,
-            _ => panic!(),
-        };
-        let status = match row.get_value(1).expect("v") {
-            DbValue::Text(s) => s,
-            _ => panic!(),
-        };
-        let updated_at = match row.get_value(2).expect("v") {
-            DbValue::Integer(n) => n,
-            _ => panic!(),
-        };
-        assert_eq!(title, "updated");
-        assert_eq!(status, "pending");
-        assert!(updated_at >= before, "updated_at should not regress");
+        let tasks = session.lock().await.tasks().list(None).await.expect("list");
+        assert_eq!(tasks[0].title, "updated");
+        assert_eq!(tasks[0].status, TaskStatus::Pending);
+        assert!(
+            tasks[0].updated_at >= before,
+            "updated_at should not regress"
+        );
     }
 
     #[tokio::test]
@@ -233,26 +163,15 @@ mod tests {
             .await
             .expect("u2");
 
-        let sess = session.lock().await;
-        let mut rows = sess
-            .conn
-            .query("SELECT status FROM task WHERE id = 1", ())
-            .await
-            .expect("q");
-        let row = rows.next().await.expect("n").expect("r");
-        let status = match row.get_value(0).expect("v") {
-            DbValue::Text(s) => s,
-            _ => panic!(),
-        };
-        assert_eq!(status, "completed");
+        let tasks = session.lock().await.tasks().list(None).await.expect("list");
+        assert_eq!(tasks[0].status, TaskStatus::Completed);
     }
 
     #[tokio::test]
     async fn update_task_invalid_status_errors() {
         let session = test_session_arc().await;
         create_task(&session, "task").await;
-        let tool = UpdateTaskTool::new(Arc::clone(&session));
-        let err = tool
+        let err = UpdateTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"id": 1, "status": "bogus"}))
             .await
             .expect_err("should fail");
@@ -263,8 +182,7 @@ mod tests {
     async fn update_task_with_no_mutable_fields_errors() {
         let session = test_session_arc().await;
         create_task(&session, "task").await;
-        let tool = UpdateTaskTool::new(Arc::clone(&session));
-        let err = tool
+        let err = UpdateTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"id": 1}))
             .await
             .expect_err("should fail");
@@ -275,8 +193,7 @@ mod tests {
     async fn update_task_empty_title_errors() {
         let session = test_session_arc().await;
         create_task(&session, "task").await;
-        let tool = UpdateTaskTool::new(Arc::clone(&session));
-        let err = tool
+        let err = UpdateTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"id": 1, "title": ""}))
             .await
             .expect_err("should fail");
@@ -286,8 +203,7 @@ mod tests {
     #[tokio::test]
     async fn update_task_missing_id_errors() {
         let session = test_session_arc().await;
-        let tool = UpdateTaskTool::new(Arc::clone(&session));
-        let err = tool
+        let err = UpdateTaskTool::new(Arc::clone(&session))
             .execute(serde_json::json!({"id": 999, "title": "x"}))
             .await
             .expect_err("should fail");

--- a/tests/agent_context_test.rs
+++ b/tests/agent_context_test.rs
@@ -2,6 +2,8 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
 
 use illustrious_manager::agent::Agent;
 use illustrious_manager::backend::LlmBackend;
@@ -9,9 +11,11 @@ use illustrious_manager::context_files::ContextFile;
 use illustrious_manager::session::Session;
 use illustrious_manager::types::*;
 
-async fn test_session() -> Session {
+async fn test_session_arc() -> Arc<TokioMutex<Session>> {
     let dir = tempfile::TempDir::new().expect("temp dir");
-    Session::new(None, dir.keep()).await.expect("test session")
+    Arc::new(TokioMutex::new(
+        Session::new(None, dir.keep()).await.expect("test session"),
+    ))
 }
 
 struct NullBackend;
@@ -42,7 +46,7 @@ async fn load_context_files_adds_messages_to_history() {
         max_tokens: 100,
         tools: vec![],
     };
-    let agent = Agent::new(backend, config, test_session().await).await;
+    let agent = Agent::new(backend, config, test_session_arc().await).await;
 
     let context_files = vec![
         ContextFile {
@@ -94,7 +98,7 @@ async fn load_context_files_with_empty_vec_does_not_modify_history() {
         max_tokens: 100,
         tools: vec![],
     };
-    let agent = Agent::new(backend, config, test_session().await).await;
+    let agent = Agent::new(backend, config, test_session_arc().await).await;
 
     agent.load_context_files(vec![]);
 

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -1,15 +1,19 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;
+use std::sync::Arc;
+use tokio::sync::Mutex as TokioMutex;
 
 use illustrious_manager::agent::Agent;
 use illustrious_manager::backend::LlmBackend;
 use illustrious_manager::session::Session;
 use illustrious_manager::types::*;
 
-async fn test_session() -> Session {
+async fn test_session_arc() -> Arc<TokioMutex<Session>> {
     let dir = tempfile::TempDir::new().expect("temp dir");
-    Session::new(None, dir.keep()).await.expect("test session")
+    Arc::new(TokioMutex::new(
+        Session::new(None, dir.keep()).await.expect("test session"),
+    ))
 }
 
 /// A mock backend that returns a fixed sequence of StreamEvents.
@@ -56,7 +60,7 @@ async fn test_agent_single_message() {
         max_tokens: 1024,
         tools: vec![],
     };
-    let agent = Agent::new(Box::new(backend), config, test_session().await).await;
+    let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
 
     let mut stream = agent.send("Hi".to_string(), None).await.unwrap();
 
@@ -99,7 +103,7 @@ async fn test_agent_history_accumulates() {
         max_tokens: 1024,
         tools: vec![],
     };
-    let agent = Agent::new(Box::new(backend), config, test_session().await).await;
+    let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
 
     // First message
     let stream = agent.send("Hello".to_string(), None).await.unwrap();
@@ -138,7 +142,7 @@ async fn test_agent_backend_error_emits_error_event() {
         max_tokens: 1024,
         tools: vec![],
     };
-    let agent = Agent::new(Box::new(ErrorBackend), config, test_session().await).await;
+    let agent = Agent::new(Box::new(ErrorBackend), config, test_session_arc().await).await;
 
     let mut stream = agent.send("Hi".to_string(), None).await.unwrap();
 

--- a/tests/context_integration_test.rs
+++ b/tests/context_integration_test.rs
@@ -4,7 +4,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::fs::File;
 use std::io::Write;
+use std::sync::Arc;
 use tempfile::TempDir;
+use tokio::sync::Mutex as TokioMutex;
 
 use illustrious_manager::agent::Agent;
 use illustrious_manager::backend::LlmBackend;
@@ -12,9 +14,11 @@ use illustrious_manager::context_files;
 use illustrious_manager::session::Session;
 use illustrious_manager::types::*;
 
-async fn test_session() -> Session {
+async fn test_session_arc() -> Arc<TokioMutex<Session>> {
     let dir = tempfile::TempDir::new().expect("temp dir");
-    Session::new(None, dir.keep()).await.expect("test session")
+    Arc::new(TokioMutex::new(
+        Session::new(None, dir.keep()).await.expect("test session"),
+    ))
 }
 
 struct NullBackend;
@@ -61,7 +65,7 @@ async fn context_files_from_pwd_are_loaded_into_agent() {
         max_tokens: 100,
         tools: vec![],
     };
-    let agent = Agent::new(backend, config, test_session().await).await;
+    let agent = Agent::new(backend, config, test_session_arc().await).await;
     agent.load_context_files(files);
 
     let history = agent.history();
@@ -94,7 +98,7 @@ async fn context_files_from_home_are_loaded_into_agent() {
         max_tokens: 100,
         tools: vec![],
     };
-    let agent = Agent::new(backend, config, test_session().await).await;
+    let agent = Agent::new(backend, config, test_session_arc().await).await;
     agent.load_context_files(files);
 
     let history = agent.history();
@@ -136,7 +140,7 @@ async fn multiple_context_files_from_both_locations_are_all_loaded() {
         max_tokens: 100,
         tools: vec![],
     };
-    let agent = Agent::new(backend, config, test_session().await).await;
+    let agent = Agent::new(backend, config, test_session_arc().await).await;
     agent.load_context_files(files);
 
     let history = agent.history();

--- a/tests/tui_test.rs
+++ b/tests/tui_test.rs
@@ -192,7 +192,9 @@ async fn user_message_appears_immediately() {
         call_count: call_count.clone(),
     });
     let dir = tempfile::TempDir::new().expect("temp dir");
-    let session = Session::new(None, dir.keep()).await.expect("test session");
+    let session = Arc::new(tokio::sync::Mutex::new(
+        Session::new(None, dir.keep()).await.expect("test session"),
+    ));
     let agent = Arc::new(Agent::new(backend, config, session).await);
 
     let mut app = App::new(std::sync::Arc::new(


### PR DESCRIPTION
Closes #136

Adds four async tools (`create_task`, `list_tasks`, `update_task`, `delete_task`) backed by a new `task` table on the per-session turso SQLite DB. Tools share an `Arc<TokioMutex<Session>>` with the agent so session swaps route transparently.

Implementation plan posted as a comment below.