### PR TITLE
Parallel tool calls within a single LLM response

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -399,7 +399,7 @@ async fn record_error(
 async fn execute_tool_calls(
     tool_calls: Vec<PendingToolCall>,
     text_prefix: String,
-    tools: &ToolRegistry,
+    tools: &Arc<ToolRegistry>,
     confirmation_mode: &ConfirmationMode,
     confirmation_rx: &mut Option<mpsc::UnboundedReceiver<ConfirmationResponse>>,
     event_tx: &mpsc::UnboundedSender<AgentEvent>,
@@ -409,47 +409,59 @@ async fn execute_tool_calls(
         assistant_content.push(ContentBlock::Text(text_prefix));
     }
 
-    // TODO: tool calls within a single response are independent and could be executed concurrently.
-    let mut tool_result_blocks: Vec<ContentBlock> = vec![];
+    // Parse inputs and pre-build the assistant ToolUse blocks. Emit all
+    // ToolUseReceived events synchronously in input order before any execution.
+    struct ParsedCall {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+        parse_error: Option<String>,
+    }
 
-    for call in tool_calls {
-        let (input, parse_error) = if call.input_json.trim().is_empty() {
-            (serde_json::Value::Object(serde_json::Map::new()), None)
-        } else {
-            match serde_json::from_str::<serde_json::Value>(&call.input_json) {
-                Ok(v) => (v, None),
-                Err(e) => (
-                    serde_json::Value::Null,
-                    Some(format!("Invalid tool input JSON: {e}")),
-                ),
+    let parsed: Vec<ParsedCall> = tool_calls
+        .into_iter()
+        .map(|call| {
+            let (input, parse_error) = if call.input_json.trim().is_empty() {
+                (serde_json::Value::Object(serde_json::Map::new()), None)
+            } else {
+                match serde_json::from_str::<serde_json::Value>(&call.input_json) {
+                    Ok(v) => (v, None),
+                    Err(e) => (
+                        serde_json::Value::Null,
+                        Some(format!("Invalid tool input JSON: {e}")),
+                    ),
+                }
+            };
+            ParsedCall {
+                id: call.id,
+                name: call.name,
+                input,
+                parse_error,
             }
-        };
+        })
+        .collect();
 
+    for call in &parsed {
         assistant_content.push(ContentBlock::ToolUse {
             id: call.id.clone(),
             name: call.name.clone(),
-            input: input.clone(),
+            input: call.input.clone(),
         });
         let _ = event_tx.unbounded_send(AgentEvent::ToolUseReceived {
             id: call.id.clone(),
             name: call.name.clone(),
-            input: input.clone(),
+            input: call.input.clone(),
         });
+    }
 
-        if let Some(err_msg) = parse_error {
-            let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
-                name: call.name.clone(),
-                content: err_msg.clone(),
-                is_error: true,
-            });
-            tool_result_blocks.push(ContentBlock::ToolResult {
-                tool_use_id: call.id,
-                content: err_msg,
-                is_error: true,
-            });
+    // Confirmation gate: walk in input order, request confirmation for each
+    // tool that needs it, collect approvals sequentially.
+    let mut approvals: Vec<bool> = Vec::with_capacity(parsed.len());
+    for call in &parsed {
+        if call.parse_error.is_some() {
+            approvals.push(false);
             continue;
         }
-
         let needs_confirmation = match confirmation_mode {
             ConfirmationMode::Always => true,
             ConfirmationMode::Never => false,
@@ -457,12 +469,11 @@ async fn execute_tool_calls(
                 tools.lookup(&call.name).is_ok_and(|t| t.is_write_tool())
             }
         };
-
         let approved = if needs_confirmation {
             let _ = event_tx.unbounded_send(AgentEvent::ToolConfirmationRequired {
                 id: call.id.clone(),
                 name: call.name.clone(),
-                input: input.clone(),
+                input: call.input.clone(),
             });
             if let Some(rx) = confirmation_rx.as_mut() {
                 matches!(rx.next().await, Some(ConfirmationResponse::Approved))
@@ -472,12 +483,38 @@ async fn execute_tool_calls(
         } else {
             true
         };
+        approvals.push(approved);
+    }
 
-        let (result_content, is_error) = if approved {
-            match tools.lookup(&call.name) {
+    // Dispatch all approved tools concurrently; slot-vector preserves input order.
+    let n = parsed.len();
+    let mut slot_futures = Vec::with_capacity(n);
+
+    for (i, call) in parsed.iter().enumerate() {
+        let tools_clone = Arc::clone(tools);
+        let id = call.id.clone();
+        let name = call.name.clone();
+        let input = call.input.clone();
+        let approved = approvals[i];
+        let parse_error = call.parse_error.clone();
+
+        slot_futures.push(tokio::spawn(async move {
+            if let Some(err_msg) = parse_error {
+                return (i, id, name, err_msg, true);
+            }
+            if !approved {
+                return (
+                    i,
+                    id,
+                    name,
+                    "User declined to execute this tool.".to_string(),
+                    true,
+                );
+            }
+            let (content, is_error) = match tools_clone.lookup(&name) {
                 Ok(tool) => match tool.execute(input).await {
                     Ok(result) => {
-                        let content = result
+                        let text = result
                             .content
                             .iter()
                             .filter_map(|b| {
@@ -489,25 +526,36 @@ async fn execute_tool_calls(
                             })
                             .collect::<Vec<_>>()
                             .join("\n");
-                        (content, result.is_error)
+                        (text, result.is_error)
                     }
                     Err(e) => (e.to_string(), true),
                 },
                 Err(e) => (e.to_string(), true),
-            }
-        } else {
-            ("User declined to execute this tool.".to_string(), true)
-        };
+            };
+            (i, id, name, content, is_error)
+        }));
+    }
 
+    // Collect results preserving input order via slot-vector.
+    let mut slots: Vec<Option<(String, String, String, bool)>> = (0..n).map(|_| None).collect();
+    for fut in slot_futures {
+        if let Ok((i, id, name, content, is_error)) = fut.await {
+            slots[i] = Some((id, name, content, is_error));
+        }
+    }
+
+    let mut tool_result_blocks: Vec<ContentBlock> = Vec::with_capacity(n);
+    for slot in slots.into_iter().flatten() {
+        let (id, name, content, is_error) = slot;
         let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
-            name: call.name.clone(),
-            content: result_content.clone(),
+            id: id.clone(),
+            name,
+            content: content.clone(),
             is_error,
         });
-
         tool_result_blocks.push(ContentBlock::ToolResult {
-            tool_use_id: call.id,
-            content: result_content,
+            tool_use_id: id,
+            content,
             is_error,
         });
     }
@@ -758,7 +806,7 @@ mod tests {
         assert!(
             events.iter().any(|e| matches!(
                 e,
-                AgentEvent::ToolResult { name, content, is_error }
+                AgentEvent::ToolResult { name, content, is_error, .. }
                     if name == "bash" && content == "ls output" && !is_error
             )),
             "expected ToolResult with ls output"
@@ -1680,5 +1728,397 @@ mod tests {
             &ConfirmationMode::Never,
             "agent confirmation_mode must reflect tool_config"
         );
+    }
+
+    // --- Parallel execution tests ---
+
+    struct SleepyTool {
+        name: String,
+        sleep_ms: u64,
+        log: Arc<tokio::sync::Mutex<Vec<(String, std::time::Instant, std::time::Instant)>>>,
+        schema: serde_json::Value,
+    }
+
+    impl SleepyTool {
+        fn new(
+            name: &str,
+            sleep_ms: u64,
+            log: Arc<tokio::sync::Mutex<Vec<(String, std::time::Instant, std::time::Instant)>>>,
+        ) -> Self {
+            Self {
+                name: name.to_string(),
+                sleep_ms,
+                log,
+                schema: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for SleepyTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "Sleepy tool"
+        }
+        fn input_schema(&self) -> &serde_json::Value {
+            &self.schema
+        }
+        fn is_write_tool(&self) -> bool {
+            false
+        }
+        async fn execute(&self, _input: serde_json::Value) -> Result<ToolExecResult, ToolError> {
+            let start = std::time::Instant::now();
+            tokio::time::sleep(tokio::time::Duration::from_millis(self.sleep_ms)).await;
+            let end = std::time::Instant::now();
+            self.log.lock().await.push((self.name.clone(), start, end));
+            Ok(ToolExecResult {
+                content: vec![ContentBlock::Text(format!("{}-output", self.name))],
+                is_error: false,
+            })
+        }
+    }
+
+    fn two_tool_response(
+        id1: &str,
+        name1: &str,
+        id2: &str,
+        name2: &str,
+    ) -> Vec<Result<StreamEvent>> {
+        vec![
+            Ok(StreamEvent::ToolUseStart {
+                id: id1.to_string(),
+                name: name1.to_string(),
+            }),
+            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::ToolUseStart {
+                id: id2.to_string(),
+                name: name2.to_string(),
+            }),
+            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::Done),
+        ]
+    }
+
+    fn three_tool_response(
+        id1: &str,
+        name1: &str,
+        id2: &str,
+        name2: &str,
+        id3: &str,
+        name3: &str,
+    ) -> Vec<Result<StreamEvent>> {
+        vec![
+            Ok(StreamEvent::ToolUseStart {
+                id: id1.to_string(),
+                name: name1.to_string(),
+            }),
+            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::ToolUseStart {
+                id: id2.to_string(),
+                name: name2.to_string(),
+            }),
+            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::ToolUseStart {
+                id: id3.to_string(),
+                name: name3.to_string(),
+            }),
+            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::Done),
+        ]
+    }
+
+    #[tokio::test]
+    async fn two_tool_calls_in_one_response_execute_concurrently() {
+        let log = Arc::new(tokio::sync::Mutex::new(vec![]));
+        let backend = SequencedBackend::new(vec![
+            two_tool_response("t1", "slow", "t2", "fast"),
+            text_response("done"),
+        ]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(SleepyTool::new("slow", 200, Arc::clone(&log))))
+            .expect("register slow");
+        registry
+            .register(Box::new(SleepyTool::new("fast", 50, Arc::clone(&log))))
+            .expect("register fast");
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Never,
+            ..Default::default()
+        };
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        let stream = agent
+            .send("run".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let entries = log.lock().await;
+        assert_eq!(entries.len(), 2, "both tools must have executed");
+
+        let wall_start = entries.iter().map(|(_, s, _)| *s).min().expect("min start");
+        let wall_end = entries.iter().map(|(_, _, e)| *e).max().expect("max end");
+        let wall_ms = (wall_end - wall_start).as_millis();
+        let sum_ms: u64 = 200 + 50;
+
+        // If sequential: wall ≈ 250 ms. If concurrent: wall ≈ 200 ms.
+        // Allow generous slack for CI; the key invariant is overlap.
+        assert!(
+            wall_ms < sum_ms as u128,
+            "tools must overlap: wall={wall_ms}ms sum={sum_ms}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_results_preserve_input_order_under_concurrent_completion() {
+        // Three tools with descending sleep durations — fastest finishes first.
+        // The tool_result blocks in the User message must still appear in input order.
+        let log = Arc::new(tokio::sync::Mutex::new(vec![]));
+        let backend = SequencedBackend::new(vec![
+            three_tool_response("t1", "slow", "t2", "medium", "t3", "fast"),
+            text_response("done"),
+        ]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(SleepyTool::new("slow", 150, Arc::clone(&log))))
+            .expect("register slow");
+        registry
+            .register(Box::new(SleepyTool::new("medium", 75, Arc::clone(&log))))
+            .expect("register medium");
+        registry
+            .register(Box::new(SleepyTool::new("fast", 10, Arc::clone(&log))))
+            .expect("register fast");
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Never,
+            ..Default::default()
+        };
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        let stream = agent
+            .send("run".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        // Inspect the User message that holds the tool_result blocks.
+        let history = agent.history();
+        let tool_result_msg = history
+            .iter()
+            .find(|m| {
+                m.role == Role::User
+                    && m.content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            })
+            .expect("must have a tool result message");
+
+        let ids: Vec<&str> = tool_result_msg
+            .content
+            .iter()
+            .filter_map(|b| {
+                if let ContentBlock::ToolResult { tool_use_id, .. } = b {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec!["t1", "t2", "t3"],
+            "tool_result blocks must appear in input order"
+        );
+    }
+
+    #[tokio::test]
+    async fn always_confirmation_with_multiple_calls_prompts_in_order() {
+        let backend = SequencedBackend::new(vec![
+            three_tool_response("t1", "bash", "t2", "bash", "t3", "bash"),
+            text_response("done"),
+        ]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(EchoTool::new("bash", "output")))
+            .expect("register");
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Always,
+            ..Default::default()
+        };
+        let (confirm_tx, confirm_rx) = mpsc::unbounded::<ConfirmationResponse>();
+        // Pre-load three approvals.
+        confirm_tx
+            .unbounded_send(ConfirmationResponse::Approved)
+            .expect("send");
+        confirm_tx
+            .unbounded_send(ConfirmationResponse::Approved)
+            .expect("send");
+        confirm_tx
+            .unbounded_send(ConfirmationResponse::Approved)
+            .expect("send");
+
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        let stream = agent
+            .send("run".to_string(), Some(confirm_rx))
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        let confirmations: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ToolConfirmationRequired { .. }))
+            .collect();
+        assert_eq!(
+            confirmations.len(),
+            3,
+            "three confirmations must be required"
+        );
+
+        // Verify they arrived in input order (t1, t2, t3).
+        let ids: Vec<&str> = confirmations
+            .iter()
+            .filter_map(|e| {
+                if let AgentEvent::ToolConfirmationRequired { id, .. } = e {
+                    Some(id.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["t1", "t2", "t3"],
+            "confirmations must arrive in input order"
+        );
+
+        // All three tools must have executed (three ToolResult events).
+        let results: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ToolResult { .. }))
+            .collect();
+        assert_eq!(
+            results.len(),
+            3,
+            "all three tools must execute after approval"
+        );
+    }
+
+    #[tokio::test]
+    async fn declined_tool_in_batch_does_not_block_others() {
+        let backend = SequencedBackend::new(vec![
+            three_tool_response("t1", "bash", "t2", "bash", "t3", "bash"),
+            text_response("done"),
+        ]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(EchoTool::new("bash", "real output")))
+            .expect("register");
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Always,
+            ..Default::default()
+        };
+        let (confirm_tx, confirm_rx) = mpsc::unbounded::<ConfirmationResponse>();
+        confirm_tx
+            .unbounded_send(ConfirmationResponse::Approved)
+            .expect("send");
+        confirm_tx
+            .unbounded_send(ConfirmationResponse::Rejected)
+            .expect("send");
+        confirm_tx
+            .unbounded_send(ConfirmationResponse::Approved)
+            .expect("send");
+
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        let stream = agent
+            .send("run".to_string(), Some(confirm_rx))
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        let results: Vec<&AgentEvent> = events
+            .iter()
+            .filter(|e| matches!(e, AgentEvent::ToolResult { .. }))
+            .collect();
+        assert_eq!(results.len(), 3, "three ToolResult events expected");
+
+        // Middle slot (t2, second approval = Rejected) must contain decline message.
+        let tool_result_ids: Vec<(&str, &str, bool)> = results
+            .iter()
+            .filter_map(|e| {
+                if let AgentEvent::ToolResult {
+                    id,
+                    content,
+                    is_error,
+                    ..
+                } = e
+                {
+                    Some((id.as_str(), content.as_str(), *is_error))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // Verify the declined tool has the canned message.
+        let (_, declined_content, declined_error) = tool_result_ids
+            .iter()
+            .find(|(id, _, _)| *id == "t2")
+            .expect("t2 result must exist");
+        assert!(declined_error, "declined tool must be an error");
+        assert!(
+            declined_content.contains("declined"),
+            "declined content must mention 'declined'"
+        );
+
+        // The other two must have the real tool output.
+        for id in ["t1", "t3"] {
+            let (_, content, is_error) = tool_result_ids
+                .iter()
+                .find(|(i, _, _)| *i == id)
+                .unwrap_or_else(|| panic!("{id} result must exist"));
+            assert!(!is_error, "{id} must not be an error");
+            assert_eq!(*content, "real output", "{id} must have real output");
+        }
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -486,72 +486,105 @@ async fn execute_tool_calls(
         approvals.push(approved);
     }
 
-    // Dispatch all approved tools concurrently; slot-vector preserves input order.
+    // Dispatch all approved tools concurrently via FuturesUnordered so each
+    // completion emits its ToolResult event immediately. Slot-vector preserves
+    // input order for the final tool_result_blocks.
     let n = parsed.len();
-    let mut slot_futures = Vec::with_capacity(n);
+    let mut slots: Vec<Option<(String, String, String, bool)>> = (0..n).map(|_| None).collect();
+
+    let mut futures = futures::stream::FuturesUnordered::new();
 
     for (i, call) in parsed.iter().enumerate() {
-        let tools_clone = Arc::clone(tools);
         let id = call.id.clone();
         let name = call.name.clone();
         let input = call.input.clone();
         let approved = approvals[i];
         let parse_error = call.parse_error.clone();
 
-        slot_futures.push(tokio::spawn(async move {
-            if let Some(err_msg) = parse_error {
-                return (i, id, name, err_msg, true);
-            }
-            if !approved {
-                return (
-                    i,
-                    id,
+        // Handle non-dispatchable cases: parse errors, declined tools, and
+        // unknown tools all produce synthetic error results without spawning.
+        if let Some(err_msg) = parse_error {
+            slots[i] = Some((id, name.clone(), err_msg, true));
+            let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
+                id: call.id.clone(),
+                name,
+                content: slots[i].as_ref().expect("just-set").2.clone(),
+                is_error: true,
+            });
+            continue;
+        }
+        if !approved {
+            let msg = "User declined to execute this tool.".to_string();
+            slots[i] = Some((id, name.clone(), msg.clone(), true));
+            let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
+                id: call.id.clone(),
+                name,
+                content: msg,
+                is_error: true,
+            });
+            continue;
+        }
+        let tool = match tools.lookup(&call.name) {
+            Ok(t) => t,
+            Err(e) => {
+                let msg = e.to_string();
+                slots[i] = Some((id, name.clone(), msg.clone(), true));
+                let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
+                    id: call.id.clone(),
                     name,
-                    "User declined to execute this tool.".to_string(),
-                    true,
-                );
+                    content: msg,
+                    is_error: true,
+                });
+                continue;
             }
-            let (content, is_error) = match tools_clone.lookup(&name) {
-                Ok(tool) => match tool.execute(input).await {
-                    Ok(result) => {
-                        let text = result
-                            .content
-                            .iter()
-                            .filter_map(|b| {
-                                if let ContentBlock::Text(s) = b {
-                                    Some(s.clone())
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        (text, result.is_error)
-                    }
-                    Err(e) => (e.to_string(), true),
-                },
+        };
+
+        // The tool reference borrows &ToolRegistry which outlives the futures.
+        futures.push(async move {
+            let (content, is_error) = match tool.execute(input).await {
+                Ok(result) => {
+                    let text = result
+                        .content
+                        .iter()
+                        .filter_map(|b| {
+                            if let ContentBlock::Text(s) = b {
+                                Some(s.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    (text, result.is_error)
+                }
                 Err(e) => (e.to_string(), true),
             };
             (i, id, name, content, is_error)
-        }));
+        });
     }
 
-    // Collect results preserving input order via slot-vector.
-    let mut slots: Vec<Option<(String, String, String, bool)>> = (0..n).map(|_| None).collect();
-    for fut in slot_futures {
-        if let Ok((i, id, name, content, is_error)) = fut.await {
-            slots[i] = Some((id, name, content, is_error));
-        }
-    }
-
-    let mut tool_result_blocks: Vec<ContentBlock> = Vec::with_capacity(n);
-    for slot in slots.into_iter().flatten() {
-        let (id, name, content, is_error) = slot;
+    // Collect results as they complete. Each result emits a ToolResult event
+    // immediately and fills its slot for ordered reassembly.
+    while let Some(result) = futures.next().await {
+        let (i, id, name, content, is_error) = result;
         let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
             id: id.clone(),
-            name,
+            name: name.clone(),
             content: content.clone(),
             is_error,
+        });
+        slots[i] = Some((id, name, content, is_error));
+    }
+
+    // Synthesize error results for any slot that was never filled to preserve
+    // the Anthropic tool_use/tool_result count invariant.
+    let mut tool_result_blocks: Vec<ContentBlock> = Vec::with_capacity(n);
+    for (i, slot) in slots.into_iter().enumerate() {
+        let (id, _name, content, is_error) = slot.unwrap_or_else(|| {
+            let id = parsed[i].id.clone();
+            let name = parsed[i].name.clone();
+            let content = "Tool execution failed: result was unexpectedly lost".to_string();
+            (id, name, content, true)
         });
         tool_result_blocks.push(ContentBlock::ToolResult {
             tool_use_id: id,
@@ -1871,16 +1904,22 @@ mod tests {
         let entries = log.lock().await;
         assert_eq!(entries.len(), 2, "both tools must have executed");
 
-        let wall_start = entries.iter().map(|(_, s, _)| *s).min().expect("min start");
-        let wall_end = entries.iter().map(|(_, _, e)| *e).max().expect("max end");
-        let wall_ms = (wall_end - wall_start).as_millis();
-        let sum_ms: u64 = 200 + 50;
-
-        // If sequential: wall ≈ 250 ms. If concurrent: wall ≈ 200 ms.
-        // Allow generous slack for CI; the key invariant is overlap.
+        // Assert true overlap: the fast tool must start before the slow tool ends.
+        // This is the actual definition of "ran concurrently" and is immune to
+        // wall-clock noise in CI environments.
+        let slow_entry = entries.iter().find(|(n, _, _)| n == "slow").expect("slow");
+        let fast_entry = entries.iter().find(|(n, _, _)| n == "fast").expect("fast");
         assert!(
-            wall_ms < sum_ms as u128,
-            "tools must overlap: wall={wall_ms}ms sum={sum_ms}ms"
+            fast_entry.1 < slow_entry.2,
+            "fast must start before slow ends: fast_start={:?} slow_end={:?}",
+            fast_entry.1,
+            slow_entry.2
+        );
+        assert!(
+            slow_entry.1 < fast_entry.2,
+            "slow must start before fast ends: slow_start={:?} fast_end={:?}",
+            slow_entry.1,
+            fast_entry.2
         );
     }
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -262,6 +262,9 @@ impl Agent {
                 let mut text_accumulated = String::new();
                 let mut tool_calls: Vec<PendingToolCall> = vec![];
                 let mut current_tool: Option<PendingToolCall> = None;
+                let mut pending_by_index: std::collections::HashMap<u64, PendingToolCall> =
+                    std::collections::HashMap::new();
+                let mut has_indexed_tools = false;
                 let mut stream = backend_stream;
 
                 while let Some(result) = stream.next().await {
@@ -270,21 +273,51 @@ impl Agent {
                             text_accumulated.push_str(&text);
                             let _ = event_tx.unbounded_send(AgentEvent::TokenReceived(text));
                         }
-                        Ok(StreamEvent::ToolUseStart { id, name }) => {
-                            current_tool = Some(PendingToolCall {
+                        Ok(StreamEvent::ToolUseStart { id, name, index }) => {
+                            let tool = PendingToolCall {
                                 id,
                                 name,
                                 input_json: String::new(),
-                            });
-                        }
-                        Ok(StreamEvent::ToolUseDelta(chunk)) => {
-                            if let Some(ref mut t) = current_tool {
-                                t.input_json.push_str(&chunk);
+                            };
+                            match index {
+                                Some(idx) => {
+                                    has_indexed_tools = true;
+                                    pending_by_index.insert(idx, tool);
+                                }
+                                None => {
+                                    current_tool = Some(tool);
+                                }
                             }
                         }
+                        Ok(StreamEvent::ToolUseDelta { chunk, index }) => match index {
+                            Some(idx) => {
+                                if let Some(t) = pending_by_index.get_mut(&idx) {
+                                    t.input_json.push_str(&chunk);
+                                }
+                            }
+                            None => {
+                                if let Some(ref mut t) = current_tool {
+                                    t.input_json.push_str(&chunk);
+                                }
+                            }
+                        },
                         Ok(StreamEvent::ToolUseDone) => {
                             if let Some(t) = current_tool.take() {
                                 tool_calls.push(t);
+                            }
+                            // For indexed tools (OpenAI-compatible), ToolUseDone
+                            // signals all tools are complete. Collect them in
+                            // index order.
+                            if has_indexed_tools && current_tool.is_none() {
+                                let max_index = pending_by_index.keys().max().copied();
+                                if let Some(max) = max_index {
+                                    for i in 0..=max {
+                                        if let Some(t) = pending_by_index.remove(&i) {
+                                            tool_calls.push(t);
+                                        }
+                                    }
+                                }
+                                has_indexed_tools = false;
                             }
                         }
                         Ok(StreamEvent::Usage {
@@ -693,8 +726,12 @@ mod tests {
             Ok(StreamEvent::ToolUseStart {
                 id: id.to_string(),
                 name: name.to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(input.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: input.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::Done),
         ]
@@ -1040,14 +1077,22 @@ mod tests {
             Ok(StreamEvent::ToolUseStart {
                 id: "tool-1".to_string(),
                 name: "bash".to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::ToolUseStart {
                 id: "tool-2".to_string(),
                 name: "bash".to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::Done),
         ];
@@ -1096,8 +1141,12 @@ mod tests {
             Ok(StreamEvent::ToolUseStart {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta("not valid json {{{".to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: "not valid json {{{".to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::Done),
         ];
@@ -1138,6 +1187,7 @@ mod tests {
             Ok(StreamEvent::ToolUseStart {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
+                index: None,
             }),
             // No ToolUseDelta — input_json stays empty
             Ok(StreamEvent::ToolUseDone),
@@ -1823,14 +1873,22 @@ mod tests {
             Ok(StreamEvent::ToolUseStart {
                 id: id1.to_string(),
                 name: name1.to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::ToolUseStart {
                 id: id2.to_string(),
                 name: name2.to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::Done),
         ]
@@ -1848,20 +1906,32 @@ mod tests {
             Ok(StreamEvent::ToolUseStart {
                 id: id1.to_string(),
                 name: name1.to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::ToolUseStart {
                 id: id2.to_string(),
                 name: name2.to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::ToolUseStart {
                 id: id3.to_string(),
                 name: name3.to_string(),
+                index: None,
             }),
-            Ok(StreamEvent::ToolUseDelta(r#"{}"#.to_string())),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: None,
+            }),
             Ok(StreamEvent::ToolUseDone),
             Ok(StreamEvent::Done),
         ]
@@ -2159,5 +2229,97 @@ mod tests {
             assert!(!is_error, "{id} must not be an error");
             assert_eq!(*content, "real output", "{id} must have real output");
         }
+    }
+
+    #[tokio::test]
+    async fn indexed_tool_calls_from_openai_backend_accumulate_correctly() {
+        // Regression: OpenAI-compatible backends (zai, ollama) emit tool calls
+        // with index fields and a single ToolUseDone at the end. The accumulation
+        // loop must track each tool by index, not overwrite with the last one.
+        let log = Arc::new(tokio::sync::Mutex::new(vec![]));
+        let indexed_response: Vec<Result<StreamEvent>> = vec![
+            Ok(StreamEvent::ToolUseStart {
+                id: "tool_0".to_string(),
+                name: "slow".to_string(),
+                index: Some(0),
+            }),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: Some(0),
+            }),
+            Ok(StreamEvent::ToolUseStart {
+                id: "tool_1".to_string(),
+                name: "fast".to_string(),
+                index: Some(1),
+            }),
+            Ok(StreamEvent::ToolUseDelta {
+                chunk: r#"{}"#.to_string(),
+                index: Some(1),
+            }),
+            // Single ToolUseDone for all indexed tools
+            Ok(StreamEvent::ToolUseDone),
+            Ok(StreamEvent::Done),
+        ];
+        let backend = SequencedBackend::new(vec![indexed_response, text_response("done")]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(SleepyTool::new("slow", 50, Arc::clone(&log))))
+            .expect("register slow");
+        registry
+            .register(Box::new(SleepyTool::new("fast", 10, Arc::clone(&log))))
+            .expect("register fast");
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Never,
+            ..Default::default()
+        };
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        let stream = agent
+            .send("run".to_string(), None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        // Both tools must have executed.
+        let entries = log.lock().await;
+        assert_eq!(entries.len(), 2, "both indexed tools must have executed");
+
+        // Verify history has tool_result blocks in index order (tool_0, tool_1).
+        let history = agent.history();
+        let tool_result_msg = history
+            .iter()
+            .find(|m| {
+                m.role == Role::User
+                    && m.content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            })
+            .expect("must have a tool result message");
+
+        let ids: Vec<&str> = tool_result_msg
+            .content
+            .iter()
+            .filter_map(|b| {
+                if let ContentBlock::ToolResult { tool_use_id, .. } = b {
+                    Some(tool_use_id.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            ids,
+            vec!["tool_0", "tool_1"],
+            "indexed tool_result blocks must appear in index order"
+        );
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -474,7 +474,10 @@ async fn execute_tool_calls(
         })
         .collect();
 
-    for call in &parsed {
+    let batch_size = parsed.len();
+    let show_index = batch_size > 1;
+
+    for (i, call) in parsed.iter().enumerate() {
         assistant_content.push(ContentBlock::ToolUse {
             id: call.id.clone(),
             name: call.name.clone(),
@@ -484,6 +487,7 @@ async fn execute_tool_calls(
             id: call.id.clone(),
             name: call.name.clone(),
             input: call.input.clone(),
+            index: if show_index { Some(i as u64 + 1) } else { None },
         });
     }
 
@@ -528,6 +532,7 @@ async fn execute_tool_calls(
     let mut futures = futures::stream::FuturesUnordered::new();
 
     for (i, call) in parsed.iter().enumerate() {
+        let display_index = if show_index { Some(i as u64 + 1) } else { None };
         let id = call.id.clone();
         let name = call.name.clone();
         let input = call.input.clone();
@@ -543,6 +548,7 @@ async fn execute_tool_calls(
                 name,
                 content: slots[i].as_ref().expect("just-set").2.clone(),
                 is_error: true,
+                index: display_index,
             });
             continue;
         }
@@ -554,6 +560,7 @@ async fn execute_tool_calls(
                 name,
                 content: msg,
                 is_error: true,
+                index: display_index,
             });
             continue;
         }
@@ -567,12 +574,14 @@ async fn execute_tool_calls(
                     name,
                     content: msg,
                     is_error: true,
+                    index: display_index,
                 });
                 continue;
             }
         };
 
         // The tool reference borrows &ToolRegistry which outlives the futures.
+        let idx_for_closure = i;
         futures.push(async move {
             let (content, is_error) = match tool.execute(input).await {
                 Ok(result) => {
@@ -592,7 +601,7 @@ async fn execute_tool_calls(
                 }
                 Err(e) => (e.to_string(), true),
             };
-            (i, id, name, content, is_error)
+            (idx_for_closure, id, name, content, is_error)
         });
     }
 
@@ -600,11 +609,13 @@ async fn execute_tool_calls(
     // immediately and fills its slot for ordered reassembly.
     while let Some(result) = futures.next().await {
         let (i, id, name, content, is_error) = result;
+        let display_index = if show_index { Some(i as u64 + 1) } else { None };
         let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
             id: id.clone(),
             name: name.clone(),
             content: content.clone(),
             is_error,
+            index: display_index,
         });
         slots[i] = Some((id, name, content, is_error));
     }

--- a/src/backend/ollama.rs
+++ b/src/backend/ollama.rs
@@ -63,8 +63,15 @@ impl OllamaParser {
                     "{}".to_string()
                 };
 
-                events.push(StreamEvent::ToolUseStart { id, name });
-                events.push(StreamEvent::ToolUseDelta(arguments));
+                events.push(StreamEvent::ToolUseStart {
+                    id,
+                    name,
+                    index: Some(idx as u64),
+                });
+                events.push(StreamEvent::ToolUseDelta {
+                    chunk: arguments,
+                    index: Some(idx as u64),
+                });
                 events.push(StreamEvent::ToolUseDone);
             }
         }
@@ -316,9 +323,11 @@ mod tests {
         let events = parser.parse_chunk(chunk).unwrap();
         assert_eq!(events.len(), 3);
         assert!(
-            matches!(&events[0], StreamEvent::ToolUseStart { id, name } if id == "call_1" && name == "bash")
+            matches!(&events[0], StreamEvent::ToolUseStart { id, name, .. } if id == "call_1" && name == "bash")
         );
-        assert!(matches!(&events[1], StreamEvent::ToolUseDelta(args) if args.contains("ls")));
+        assert!(
+            matches!(&events[1], StreamEvent::ToolUseDelta { chunk: args, .. } if args.contains("ls"))
+        );
         assert!(matches!(&events[2], StreamEvent::ToolUseDone));
     }
 
@@ -329,12 +338,12 @@ mod tests {
         let events = parser.parse_chunk(chunk).unwrap();
         assert_eq!(events.len(), 6);
         assert!(matches!(&events[0], StreamEvent::ToolUseStart { name, .. } if name == "bash"));
-        assert!(matches!(&events[1], StreamEvent::ToolUseDelta(_)));
+        assert!(matches!(&events[1], StreamEvent::ToolUseDelta { .. }));
         assert!(matches!(&events[2], StreamEvent::ToolUseDone));
         assert!(
             matches!(&events[3], StreamEvent::ToolUseStart { name, .. } if name == "read_file")
         );
-        assert!(matches!(&events[4], StreamEvent::ToolUseDelta(_)));
+        assert!(matches!(&events[4], StreamEvent::ToolUseDelta { .. }));
         assert!(matches!(&events[5], StreamEvent::ToolUseDone));
     }
 
@@ -662,7 +671,7 @@ mod tests {
         let chunk = r#"{"message":{"tool_calls":[{"function":{"name":"bash","arguments":{"command":"ls"}}}]}}"#;
         let events = parser.parse_chunk(chunk).unwrap();
         assert_eq!(events.len(), 3);
-        if let StreamEvent::ToolUseStart { id, name } = &events[0] {
+        if let StreamEvent::ToolUseStart { id, name, .. } = &events[0] {
             assert_eq!(name, "bash");
             assert_eq!(id, "tool_0", "should generate fallback ID with index");
         } else {
@@ -678,7 +687,7 @@ mod tests {
         assert_eq!(events.len(), 4);
         assert!(matches!(&events[0], StreamEvent::TextDelta(t) if t == "Thinking..."));
         assert!(matches!(&events[1], StreamEvent::ToolUseStart { .. }));
-        assert!(matches!(&events[2], StreamEvent::ToolUseDelta(_)));
+        assert!(matches!(&events[2], StreamEvent::ToolUseDelta { .. }));
         assert!(matches!(&events[3], StreamEvent::ToolUseDone));
     }
 }

--- a/src/backend/ollama.rs
+++ b/src/backend/ollama.rs
@@ -240,6 +240,7 @@ impl OllamaBackend {
                 })
                 .collect();
             body["tools"] = serde_json::json!(tools_json);
+            body["parallel_tool_calls"] = serde_json::json!(true);
         }
 
         body
@@ -445,6 +446,7 @@ mod tests {
         assert_eq!(tools[0]["function"]["name"], "bash");
         assert_eq!(tools[0]["function"]["description"], "Execute bash commands");
         assert_eq!(tools[0]["function"]["parameters"]["type"], "object");
+        assert_eq!(body["parallel_tool_calls"], true);
     }
 
     #[test]
@@ -469,6 +471,10 @@ mod tests {
         assert!(
             body.get("tools").is_none(),
             "should not include tools field when empty"
+        );
+        assert!(
+            body.get("parallel_tool_calls").is_none(),
+            "should not include parallel_tool_calls when no tools provided"
         );
     }
 

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -77,8 +77,11 @@ impl VertexSseParser {
                             anyhow::anyhow!("tool_use content_block_start missing 'name'")
                         })?
                         .to_string();
-                    self.event_buffer
-                        .push(StreamEvent::ToolUseStart { id, name });
+                    self.event_buffer.push(StreamEvent::ToolUseStart {
+                        id,
+                        name,
+                        index: None,
+                    });
                 }
             }
             "content_block_delta" => {
@@ -90,7 +93,8 @@ impl VertexSseParser {
                         .as_str()
                         .ok_or_else(|| anyhow::anyhow!("input_json_delta missing 'partial_json'"))?
                         .to_string();
-                    self.event_buffer.push(StreamEvent::ToolUseDelta(chunk));
+                    self.event_buffer
+                        .push(StreamEvent::ToolUseDelta { chunk, index: None });
                 } else {
                     let text = json["delta"]["text"].as_str().unwrap_or("").to_string();
                     self.event_buffer.push(StreamEvent::TextDelta(text));
@@ -414,9 +418,10 @@ mod tests {
         let data = r#"{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"bash"}}"#;
         let result = parser.parse(data).expect("should parse successfully");
         match result {
-            Some(StreamEvent::ToolUseStart { id, name }) => {
+            Some(StreamEvent::ToolUseStart { id, name, index }) => {
                 assert_eq!(id, "toolu_01");
                 assert_eq!(name, "bash");
+                assert_eq!(index, None);
             }
             other => panic!("expected ToolUseStart, got {:?}", other),
         }
@@ -428,8 +433,9 @@ mod tests {
         let data = r#"{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":"}}"#;
         let result = parser.parse(data).expect("should parse successfully");
         match result {
-            Some(StreamEvent::ToolUseDelta(chunk)) => {
+            Some(StreamEvent::ToolUseDelta { chunk, index }) => {
                 assert_eq!(chunk, "{\"command\":");
+                assert_eq!(index, None);
             }
             other => panic!("expected ToolUseDelta, got {:?}", other),
         }

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -100,14 +100,17 @@ impl ZaiSseParser {
                         self.event_buffer.push(StreamEvent::ToolUseStart {
                             id,
                             name: name.to_string(),
+                            index: Some(index),
                         });
                     }
 
                     if let Some(arguments) = function.get("arguments").and_then(|v| v.as_str())
                         && !arguments.is_empty()
                     {
-                        self.event_buffer
-                            .push(StreamEvent::ToolUseDelta(arguments.to_string()));
+                        self.event_buffer.push(StreamEvent::ToolUseDelta {
+                            chunk: arguments.to_string(),
+                            index: Some(index),
+                        });
                     }
                 }
             }
@@ -574,7 +577,7 @@ mod tests {
             "Should be ToolUseStart, got: {:?}",
             event
         );
-        if let Some(StreamEvent::ToolUseStart { id, name }) = event {
+        if let Some(StreamEvent::ToolUseStart { id, name, .. }) = event {
             assert_eq!(name, "bash");
             // For OpenAI-compatible format, we generate our own ID
             assert!(!id.is_empty(), "ID should not be empty");
@@ -594,11 +597,11 @@ mod tests {
         let event = result.unwrap();
         assert!(event.is_some(), "Should return Some(event)");
         assert!(
-            matches!(event, Some(StreamEvent::ToolUseDelta(_))),
+            matches!(event, Some(StreamEvent::ToolUseDelta { .. })),
             "Should be ToolUseDelta, got: {:?}",
             event
         );
-        if let Some(StreamEvent::ToolUseDelta(delta)) = event {
+        if let Some(StreamEvent::ToolUseDelta { chunk: delta, .. }) = event {
             assert_eq!(delta, "{\"comm");
         }
     }
@@ -724,7 +727,7 @@ mod tests {
         assert!(result2.is_ok());
         let event2 = result2.unwrap();
         assert!(event2.is_some());
-        if let Some(StreamEvent::ToolUseDelta(delta)) = event2 {
+        if let Some(StreamEvent::ToolUseDelta { chunk: delta, .. }) = event2 {
             assert_eq!(delta, "ls");
         } else {
             panic!("Second event should be ToolUseDelta for bash");
@@ -744,7 +747,7 @@ mod tests {
         assert!(result4.is_ok());
         let event4 = result4.unwrap();
         assert!(event4.is_some());
-        if let Some(StreamEvent::ToolUseDelta(delta)) = event4 {
+        if let Some(StreamEvent::ToolUseDelta { chunk: delta, .. }) = event4 {
             assert_eq!(delta, "tmp");
         } else {
             panic!("Fourth event should be ToolUseDelta for read_file");

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -267,6 +267,7 @@ impl ZaiBackend {
                 })
                 .collect();
             body["tools"] = serde_json::json!(tools_json);
+            body["parallel_tool_calls"] = serde_json::json!(true);
         }
 
         body
@@ -524,6 +525,9 @@ mod tests {
         assert_eq!(tools[1]["type"], "function");
         assert_eq!(tools[1]["function"]["name"], "read_file");
         assert_eq!(tools[1]["function"]["description"], "Read a file");
+
+        // Verify parallel_tool_calls is enabled
+        assert_eq!(body["parallel_tool_calls"], true);
     }
 
     #[test]
@@ -546,6 +550,10 @@ mod tests {
             body.get("tools").is_none()
                 || body["tools"].as_array().map_or(true, |arr| arr.is_empty()),
             "body should not include tools field or it should be empty when no tools provided"
+        );
+        assert!(
+            body.get("parallel_tool_calls").is_none(),
+            "body should not include parallel_tool_calls when no tools provided"
         );
     }
 

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -118,32 +118,24 @@ async fn run_text<W: Write, R: BufRead>(
                 anyhow::bail!("LLM error: {}", msg);
             }
             AgentEvent::ToolUseReceived {
-                id, name, input, ..
+                name, input, index, ..
             } => {
-                let idx = id
-                    .strip_prefix("tool_")
-                    .and_then(|s| s.parse::<u64>().ok())
-                    .map(|i| i + 1);
-                match idx {
+                match index {
                     Some(i) => writeln!(writer, "\n[tool({}): {}] {}", i, name, input)?,
                     None => writeln!(writer, "\n[tool: {}] {}", name, input)?,
                 };
             }
             AgentEvent::ToolResult {
-                id,
                 name,
                 content,
                 is_error,
+                index,
                 ..
             } => {
-                let idx = id
-                    .strip_prefix("tool_")
-                    .and_then(|s| s.parse::<u64>().ok())
-                    .map(|i| i + 1);
                 if is_error {
                     writeln!(writer, "[error from {}]: {}", name, content)?;
                 } else {
-                    match idx {
+                    match index {
                         Some(i) => writeln!(writer, "[result({}): {}]: {}", i, name, content)?,
                         None => writeln!(writer, "[result from {}]: {}", name, content)?,
                     };
@@ -451,6 +443,7 @@ mod tests {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
                 input: serde_json::json!({"command": "ls"}),
+                index: None,
             },
             AgentEvent::ResponseComplete(String::new()),
         ];
@@ -471,6 +464,7 @@ mod tests {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "file1.txt".to_string(),
+                index: None,
                 is_error: false,
             },
             AgentEvent::ResponseComplete(String::new()),
@@ -488,6 +482,7 @@ mod tests {
             AgentEvent::ToolResult {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
+                index: None,
                 content: "permission denied".to_string(),
                 is_error: true,
             },
@@ -588,11 +583,13 @@ mod tests {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
                 input: serde_json::json!({"command": "ls"}),
+                index: None,
             },
             AgentEvent::ToolResult {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "file.txt".to_string(),
+                index: None,
                 is_error: false,
             },
             AgentEvent::TokenReceived("done".to_string()),
@@ -610,6 +607,7 @@ mod tests {
             AgentEvent::ToolUseReceived {
                 id: "t1".to_string(),
                 name: "bash".to_string(),
+                index: None,
                 input: serde_json::json!({"command": "ls"}),
             },
             AgentEvent::ToolResult {
@@ -617,6 +615,7 @@ mod tests {
                 name: "bash".to_string(),
                 content: "file.txt".to_string(),
                 is_error: false,
+                index: None,
             },
             AgentEvent::TokenReceived("The directory contains file.txt.".to_string()),
             AgentEvent::ResponseComplete("The directory contains file.txt.".to_string()),

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -124,6 +124,7 @@ async fn run_text<W: Write, R: BufRead>(
                 name,
                 content,
                 is_error,
+                ..
             } => {
                 if is_error {
                     writeln!(writer, "[error from {}]: {}", name, content)?;
@@ -450,6 +451,7 @@ mod tests {
     async fn tool_result_success_prints_result_content() {
         let events = vec![
             AgentEvent::ToolResult {
+                id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "file1.txt".to_string(),
                 is_error: false,
@@ -467,6 +469,7 @@ mod tests {
     async fn tool_result_error_prints_error_label() {
         let events = vec![
             AgentEvent::ToolResult {
+                id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "permission denied".to_string(),
                 is_error: true,
@@ -570,6 +573,7 @@ mod tests {
                 input: serde_json::json!({"command": "ls"}),
             },
             AgentEvent::ToolResult {
+                id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "file.txt".to_string(),
                 is_error: false,
@@ -592,6 +596,7 @@ mod tests {
                 input: serde_json::json!({"command": "ls"}),
             },
             AgentEvent::ToolResult {
+                id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "file.txt".to_string(),
                 is_error: false,

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -117,19 +117,36 @@ async fn run_text<W: Write, R: BufRead>(
                 eprintln!("\nError: {}", msg);
                 anyhow::bail!("LLM error: {}", msg);
             }
-            AgentEvent::ToolUseReceived { name, input, .. } => {
-                writeln!(writer, "\n[tool: {}] {}", name, input)?;
+            AgentEvent::ToolUseReceived {
+                id, name, input, ..
+            } => {
+                let idx = id
+                    .strip_prefix("tool_")
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .map(|i| i + 1);
+                match idx {
+                    Some(i) => writeln!(writer, "\n[tool({}): {}] {}", i, name, input)?,
+                    None => writeln!(writer, "\n[tool: {}] {}", name, input)?,
+                };
             }
             AgentEvent::ToolResult {
+                id,
                 name,
                 content,
                 is_error,
                 ..
             } => {
+                let idx = id
+                    .strip_prefix("tool_")
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .map(|i| i + 1);
                 if is_error {
                     writeln!(writer, "[error from {}]: {}", name, content)?;
                 } else {
-                    writeln!(writer, "[result from {}]: {}", name, content)?;
+                    match idx {
+                        Some(i) => writeln!(writer, "[result({}): {}]: {}", i, name, content)?,
+                        None => writeln!(writer, "[result from {}]: {}", name, content)?,
+                    };
                 }
             }
             AgentEvent::Usage { .. } => {}

--- a/src/frontend/tui/conversation_area.rs
+++ b/src/frontend/tui/conversation_area.rs
@@ -46,6 +46,8 @@ impl ConversationRole {
 pub struct ConversationEntry {
     pub role: ConversationRole,
     pub content: String,
+    #[allow(dead_code)]
+    tool_index: Option<u64>,
     cached_lines: Vec<Line<'static>>,
     cached_wrapped_count: u16,
     cached_width: u16,
@@ -53,10 +55,23 @@ pub struct ConversationEntry {
 
 impl ConversationEntry {
     pub fn new(role: ConversationRole, content: String) -> Self {
-        let cached_lines = render_entry_lines(&role, &content);
+        let cached_lines = render_entry_lines(&role, &content, None);
         Self {
             role,
             content,
+            tool_index: None,
+            cached_lines,
+            cached_wrapped_count: 0,
+            cached_width: 0,
+        }
+    }
+
+    pub fn new_indexed(role: ConversationRole, content: String, index: u64) -> Self {
+        let cached_lines = render_entry_lines(&role, &content, Some(index));
+        Self {
+            role,
+            content,
+            tool_index: Some(index),
             cached_lines,
             cached_wrapped_count: 0,
             cached_width: 0,
@@ -86,6 +101,7 @@ impl ConversationEntry {
         Self {
             role,
             content,
+            tool_index: None,
             cached_lines: all_lines,
             cached_wrapped_count: 0,
             cached_width: 0,
@@ -108,14 +124,26 @@ impl ConversationEntry {
     }
 }
 
+fn format_label(role: &ConversationRole, index: Option<u64>) -> String {
+    match index {
+        Some(i) => match role {
+            ConversationRole::ToolUse => format!("[Tool({})]:", i),
+            ConversationRole::ToolResult => format!("[Result({})]:", i),
+            _ => format!("{}:", role.display_label()),
+        },
+        None => format!("{}:", role.display_label()),
+    }
+}
+
 fn render_role_lines(
     role: &ConversationRole,
     content: &str,
     trailing_blank: bool,
+    tool_index: Option<u64>,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     lines.push(Line::from(Span::styled(
-        format!("{}:", role.display_label()),
+        format_label(role, tool_index),
         Style::default().fg(role.color()),
     )));
     let display_content = maybe_truncate(content, role);
@@ -135,14 +163,18 @@ fn render_role_lines(
     lines
 }
 
-fn render_entry_lines(role: &ConversationRole, content: &str) -> Vec<Line<'static>> {
-    render_role_lines(role, content, true)
+fn render_entry_lines(
+    role: &ConversationRole,
+    content: &str,
+    tool_index: Option<u64>,
+) -> Vec<Line<'static>> {
+    render_role_lines(role, content, true, tool_index)
 }
 
 // TODO: For long responses with complex markdown, this O(response_size) per-frame
 // cost during streaming could become a bottleneck. Consider caching if it becomes an issue.
 fn render_current_response_lines(current_response: &str) -> Vec<Line<'static>> {
-    render_role_lines(&ConversationRole::Assistant, current_response, false)
+    render_role_lines(&ConversationRole::Assistant, current_response, false, None)
 }
 
 fn estimate_wrapped_count(lines: &[Line<'_>], text_width: u16) -> u16 {

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -352,6 +352,7 @@ pub fn handle_agent_event(
             name,
             content,
             is_error,
+            ..
         } => {
             let role = if is_error {
                 ConversationRole::Error

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -308,15 +308,6 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
     }
 }
 
-/// Extract a 1-based display index from a tool call ID.
-/// OpenAI-compatible backends use `tool_0`, `tool_1`, etc.
-/// Anthropic backends use opaque IDs — returns None.
-fn extract_tool_index(id: &str) -> Option<u64> {
-    id.strip_prefix("tool_")
-        .and_then(|s| s.parse::<u64>().ok())
-        .map(|i| i + 1)
-}
-
 pub fn handle_agent_event(
     app: &mut App,
     event: AgentEvent,
@@ -350,7 +341,7 @@ pub fn handle_agent_event(
             app.git_branch = status_line::detect_git_branch();
         }
         AgentEvent::ToolUseReceived {
-            id, name, input, ..
+            name, input, index, ..
         } => {
             if !app.current_response.is_empty() {
                 app.conversation.push(ConversationEntry::new(
@@ -359,16 +350,15 @@ pub fn handle_agent_event(
                 ));
             }
             let width = app.text_width as usize;
-            let index = extract_tool_index(&id);
             let entry = app.tool_use_entry(&name, &input, width, index);
             app.conversation.push(entry);
             app.scroll_offset = 0;
         }
         AgentEvent::ToolResult {
-            id,
             name,
             content,
             is_error,
+            index,
             ..
         } => {
             let role = if is_error {
@@ -386,14 +376,9 @@ pub fn handle_agent_event(
                 }
                 Err(_) => content,
             };
-            let index = if is_error {
-                None
-            } else {
-                extract_tool_index(&id)
-            };
             let entry = match index {
-                Some(idx) => ConversationEntry::new_indexed(role, display, idx),
-                None => ConversationEntry::new(role, display),
+                Some(idx) if !is_error => ConversationEntry::new_indexed(role, display, idx),
+                _ => ConversationEntry::new(role, display),
             };
             app.conversation.push(entry);
             app.scroll_offset = 0;
@@ -828,6 +813,7 @@ mod tests {
             id: "t1".to_string(),
             name: "bash".to_string(),
             input: serde_json::json!({"command": "ls"}),
+            index: None,
         };
 
         handle_agent_event(&mut app, event, Some(&mut logger)).expect("handle event");
@@ -1022,6 +1008,7 @@ mod tests {
         let event = AgentEvent::ToolUseReceived {
             id: "t1".to_string(),
             name: "bash".to_string(),
+            index: None,
             input: serde_json::json!({"command": "ls"}),
         };
         handle_agent_event(&mut app, event, None).expect("handle event");
@@ -1059,6 +1046,7 @@ mod tests {
 
         let event = AgentEvent::ToolUseReceived {
             id: "t1".to_string(),
+            index: None,
             name: "bash".to_string(),
             input: serde_json::json!({"command": "ls"}),
         };
@@ -1566,6 +1554,7 @@ mod tests {
                 "old_string": "fn old() {}",
                 "new_string": "fn new() {}"
             }),
+            index: None,
         };
         handle_agent_event(&mut app, event, None).expect("handle event");
 

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -121,7 +121,7 @@ impl App {
                         Some(ConversationEntry::new(role.clone(), text.clone()))
                     }
                     crate::types::ContentBlock::ToolUse { name, input, .. } => {
-                        Some(self.tool_use_entry(name, input, self.text_width as usize))
+                        Some(self.tool_use_entry(name, input, self.text_width as usize, None))
                     }
                     crate::types::ContentBlock::ToolResult {
                         content, is_error, ..
@@ -193,6 +193,7 @@ impl App {
         name: &str,
         input: &serde_json::Value,
         width: usize,
+        tool_index: Option<u64>,
     ) -> ConversationEntry {
         let effective_width = if width == 0 { 80 } else { width };
         let content = self.tool_use_markdown(name, input);
@@ -217,7 +218,10 @@ impl App {
             }
             _ => {}
         }
-        ConversationEntry::new(ConversationRole::ToolUse, content)
+        match tool_index {
+            Some(idx) => ConversationEntry::new_indexed(ConversationRole::ToolUse, content, idx),
+            None => ConversationEntry::new(ConversationRole::ToolUse, content),
+        }
     }
 
     pub fn handle_scroll_key(&mut self, key: &KeyEvent) -> bool {
@@ -304,6 +308,15 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
     }
 }
 
+/// Extract a 1-based display index from a tool call ID.
+/// OpenAI-compatible backends use `tool_0`, `tool_1`, etc.
+/// Anthropic backends use opaque IDs — returns None.
+fn extract_tool_index(id: &str) -> Option<u64> {
+    id.strip_prefix("tool_")
+        .and_then(|s| s.parse::<u64>().ok())
+        .map(|i| i + 1)
+}
+
 pub fn handle_agent_event(
     app: &mut App,
     event: AgentEvent,
@@ -336,7 +349,9 @@ pub fn handle_agent_event(
             app.scroll_offset = 0;
             app.git_branch = status_line::detect_git_branch();
         }
-        AgentEvent::ToolUseReceived { name, input, .. } => {
+        AgentEvent::ToolUseReceived {
+            id, name, input, ..
+        } => {
             if !app.current_response.is_empty() {
                 app.conversation.push(ConversationEntry::new(
                     ConversationRole::Assistant,
@@ -344,11 +359,13 @@ pub fn handle_agent_event(
                 ));
             }
             let width = app.text_width as usize;
-            let entry = app.tool_use_entry(&name, &input, width);
+            let index = extract_tool_index(&id);
+            let entry = app.tool_use_entry(&name, &input, width, index);
             app.conversation.push(entry);
             app.scroll_offset = 0;
         }
         AgentEvent::ToolResult {
+            id,
             name,
             content,
             is_error,
@@ -369,7 +386,16 @@ pub fn handle_agent_event(
                 }
                 Err(_) => content,
             };
-            app.conversation.push(ConversationEntry::new(role, display));
+            let index = if is_error {
+                None
+            } else {
+                extract_tool_index(&id)
+            };
+            let entry = match index {
+                Some(idx) => ConversationEntry::new_indexed(role, display, idx),
+                None => ConversationEntry::new(role, display),
+            };
+            app.conversation.push(entry);
             app.scroll_offset = 0;
         }
         AgentEvent::ToolConfirmationRequired { name, input, .. } => {
@@ -585,7 +611,7 @@ async fn run_app(
                                     _ => unreachable!(),
                                 };
                                 let width = app.text_width as usize;
-                                let entry = app.tool_use_entry(&name, &input, width);
+                                let entry = app.tool_use_entry(&name, &input, width, None);
                                 app.conversation.push(entry);
                                 let sent = app
                                     .confirmation_tx
@@ -1478,7 +1504,7 @@ mod tests {
             "old_string": "let x = 1;",
             "new_string": "let x = 42;"
         });
-        let entry = app.tool_use_entry("edit_file", &input, 80);
+        let entry = app.tool_use_entry("edit_file", &input, 80, None);
         assert_eq!(entry.role, ConversationRole::ToolUse);
         // The diff renderer produces spans with colour styles; verify that
         // at least one span has a coloured foreground (indicating diff styling)
@@ -1501,7 +1527,7 @@ mod tests {
             "path": "hello.txt",
             "content": "Hello, world!\n"
         });
-        let entry = app.tool_use_entry("write_file", &input, 80);
+        let entry = app.tool_use_entry("write_file", &input, 80, None);
         assert_eq!(entry.role, ConversationRole::ToolUse);
         // write_file renders as a syntax-highlighted code block (green + markers)
         let has_plus_marker = entry
@@ -1518,7 +1544,7 @@ mod tests {
     fn regression_non_diff_tool_use_still_renders_via_markdown() {
         let app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
         let input = serde_json::json!({"command": "ls -la"});
-        let entry = app.tool_use_entry("bash", &input, 80);
+        let entry = app.tool_use_entry("bash", &input, 80, None);
         assert_eq!(entry.role, ConversationRole::ToolUse);
         // The content (markdown string) should mention the tool name.
         assert!(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -244,6 +244,7 @@ mod tests {
                 id: "tool-1".to_string(),
                 name: "bash".to_string(),
                 input: serde_json::json!({"command": "ls"}),
+                index: None,
             };
             logger.log_event(&event).expect("Failed to log event");
         }
@@ -265,6 +266,7 @@ mod tests {
                 name: "bash".to_string(),
                 content: "output".to_string(),
                 is_error: false,
+                index: None,
             };
             logger.log_event(&event).expect("Failed to log event");
         }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -109,6 +109,7 @@ impl Logger {
                 name,
                 content,
                 is_error,
+                ..
             } => {
                 self.log_tool_result(name, content, *is_error)?;
             }
@@ -260,6 +261,7 @@ mod tests {
         {
             let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
             let event = AgentEvent::ToolResult {
+                id: "t1".to_string(),
                 name: "bash".to_string(),
                 content: "output".to_string(),
                 is_error: false,

--- a/src/types.rs
+++ b/src/types.rs
@@ -210,8 +210,17 @@ pub enum StreamEvent {
     ToolUseStart {
         id: String,
         name: String,
+        /// Tool index for OpenAI-compatible streaming where multiple tool calls
+        /// are interleaved. `None` for Anthropic-style backends.
+        index: Option<u64>,
     },
-    ToolUseDelta(String),
+    ToolUseDelta {
+        chunk: String,
+        /// Tool index for OpenAI-compatible streaming where multiple tool calls
+        /// are interleaved in a single response. `None` for Anthropic-style
+        /// backends where per-tool `ToolUseDone` signals handle sequencing.
+        index: Option<u64>,
+    },
     ToolUseDone,
     /// Token usage and stop reason reported by the backend at the end of a response.
     Usage {
@@ -464,9 +473,10 @@ mod tests {
         let event = StreamEvent::ToolUseStart {
             id: "tool-123".to_string(),
             name: "bash".to_string(),
+            index: None,
         };
         assert!(matches!(event, StreamEvent::ToolUseStart { .. }));
-        if let StreamEvent::ToolUseStart { id, name } = event {
+        if let StreamEvent::ToolUseStart { id, name, .. } = event {
             assert_eq!(id, "tool-123");
             assert_eq!(name, "bash");
         }
@@ -474,9 +484,12 @@ mod tests {
 
     #[test]
     fn stream_event_tool_use_delta_variant_contains_string_delta() {
-        let event = StreamEvent::ToolUseDelta("{".to_string());
-        assert!(matches!(event, StreamEvent::ToolUseDelta(_)));
-        if let StreamEvent::ToolUseDelta(delta) = event {
+        let event = StreamEvent::ToolUseDelta {
+            chunk: "{".to_string(),
+            index: None,
+        };
+        assert!(matches!(event, StreamEvent::ToolUseDelta { .. }));
+        if let StreamEvent::ToolUseDelta { chunk: delta, .. } = event {
             assert_eq!(delta, "{");
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -232,6 +232,7 @@ pub enum AgentEvent {
         input: serde_json::Value,
     },
     ToolResult {
+        id: String,
         name: String,
         content: String,
         is_error: bool,
@@ -508,19 +509,22 @@ mod tests {
     }
 
     #[test]
-    fn agent_event_tool_result_variant_contains_name_content_and_error_flag() {
+    fn agent_event_tool_result_variant_contains_id_name_content_and_error_flag() {
         let event = AgentEvent::ToolResult {
+            id: "tool-123".to_string(),
             name: "bash".to_string(),
             content: "file1.txt".to_string(),
             is_error: false,
         };
         assert!(matches!(event, AgentEvent::ToolResult { .. }));
         if let AgentEvent::ToolResult {
+            id,
             name,
             content,
             is_error,
         } = event
         {
+            assert_eq!(id, "tool-123");
             assert_eq!(name, "bash");
             assert_eq!(content, "file1.txt");
             assert!(!is_error);

--- a/src/types.rs
+++ b/src/types.rs
@@ -239,12 +239,16 @@ pub enum AgentEvent {
         id: String,
         name: String,
         input: serde_json::Value,
+        /// 1-based index of this tool call within its batch.
+        index: Option<u64>,
     },
     ToolResult {
         id: String,
         name: String,
         content: String,
         is_error: bool,
+        /// 1-based index of this tool call within its batch.
+        index: Option<u64>,
     },
     ToolConfirmationRequired {
         id: String,
@@ -507,12 +511,14 @@ mod tests {
             id: "tool-123".to_string(),
             name: "bash".to_string(),
             input: input.clone(),
+            index: None,
         };
         assert!(matches!(event, AgentEvent::ToolUseReceived { .. }));
         if let AgentEvent::ToolUseReceived {
             id,
             name,
             input: event_input,
+            ..
         } = event
         {
             assert_eq!(id, "tool-123");
@@ -528,6 +534,7 @@ mod tests {
             name: "bash".to_string(),
             content: "file1.txt".to_string(),
             is_error: false,
+            index: None,
         };
         assert!(matches!(event, AgentEvent::ToolResult { .. }));
         if let AgentEvent::ToolResult {
@@ -535,6 +542,7 @@ mod tests {
             name,
             content,
             is_error,
+            ..
         } = event
         {
             assert_eq!(id, "tool-123");

--- a/tests/zai_test.rs
+++ b/tests/zai_test.rs
@@ -55,7 +55,7 @@ fn test_parse_sse_tool_use_start() {
     let data = r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"bash","arguments":""}}]}}]}"#;
     let event = parser.parse(data).unwrap();
     match event {
-        Some(illustrious_manager::types::StreamEvent::ToolUseStart { id, name }) => {
+        Some(illustrious_manager::types::StreamEvent::ToolUseStart { id, name, .. }) => {
             assert_eq!(name, "bash");
             assert_eq!(id, "tool_0");
         }
@@ -70,7 +70,7 @@ fn test_parse_sse_tool_use_delta() {
         r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ls"}}]}}]}"#;
     let event = parser.parse(data).unwrap();
     match event {
-        Some(illustrious_manager::types::StreamEvent::ToolUseDelta(delta)) => {
+        Some(illustrious_manager::types::StreamEvent::ToolUseDelta { chunk: delta, .. }) => {
             assert_eq!(delta, "ls");
         }
         other => panic!("Expected ToolUseDelta, got {:?}", other),


### PR DESCRIPTION
Closes #134

Foundational change for future sub-agent fan-out: tools called within a single LLM response are now dispatched concurrently while preserving `tool_use` / `tool_result` block ordering required by Anthropic-style backends.

Implementation plan posted as a comment below.