### PR TITLE
Add agent tool for spawning sub-agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Four-layer decoupled design:
 
 2. **Agent Core** (`src/agent.rs`) — Owns conversation history, context files, and skills. Wraps backend streams into `AgentEvent` (TokenReceived | ToolUseReceived | ToolResult | ToolConfirmationRequired | ResponseComplete | Error | Usage). Display-agnostic. Drives agentic tool-use loops up to `max_tool_iterations`. Tool calls within a single assistant turn run concurrently via `join_all`; confirmations are gathered sequentially first, then approved calls execute in parallel. Supports session switching (`load_session`) while preserving non-persisted context prefix (context files, skill definitions).
 
-3. **Tools Layer** (`src/tools/`) — `Tool` trait + `ToolRegistry`. Built-in tools: `bash` (allowlist/denylist enforced), `edit_file`, `write_file`, `skill` (loads skill prompts by name), `search` (semantic code search). File tools are sandboxed to `sandbox_root` via `SandboxPolicy` (`sandbox.rs`). `is_write_tool()` determines whether confirmation is required under `WriteOnly` mode.
+3. **Tools Layer** (`src/tools/`) — `Tool` trait + `ToolRegistry`. Built-in tools: `bash` (allowlist/denylist enforced), `edit_file`, `write_file`, `skill` (loads skill prompts by name), `search` (semantic code search), `agent` (spawns sub-agents). File tools are sandboxed to `sandbox_root` via `SandboxPolicy` (`sandbox.rs`). `is_write_tool()` determines whether confirmation is required under `WriteOnly` mode.
+
+The `agent` tool spawns an independent sub-agent with its own session, model, and tool set. The parent configures the backend role, confirmation mode (clamped so the sub-agent can never be more permissive than the parent), and an optional tool allowlist. Sub-agent token usage propagates to the TUI status line via `AgentEvent::SubAgentUsage`. Permission clamping is enforced by `clamp_confirmation` in `src/agent.rs` — strictness order: `Always` > `WriteOnly` > `Never`.
 
 4. **Frontend Layer** (`src/frontend/`) — Two frontends consuming the same AgentEvent stream:
    - `stdout.rs`: Single-shot mode, streams tokens to stdout, pipe-friendly

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -498,15 +498,21 @@ async fn execute_tool_calls(
         .iter()
         .map(|r| async move {
             match &r.decision {
-                ToolDecision::ParseError(err) => {
-                    (r.index, r.id.clone(), r.name.clone(), err.clone(), true)
-                }
+                ToolDecision::ParseError(err) => (
+                    r.index,
+                    r.id.clone(),
+                    r.name.clone(),
+                    err.clone(),
+                    true,
+                    vec![],
+                ),
                 ToolDecision::Declined => (
                     r.index,
                     r.id.clone(),
                     r.name.clone(),
                     "User declined to execute this tool.".to_string(),
                     true,
+                    vec![],
                 ),
                 ToolDecision::Approved => match tools.lookup(&r.name) {
                     Ok(tool) => match tool.execute(r.input.clone()).await {
@@ -529,11 +535,26 @@ async fn execute_tool_calls(
                                 r.name.clone(),
                                 content,
                                 result.is_error,
+                                result.agent_events,
                             )
                         }
-                        Err(e) => (r.index, r.id.clone(), r.name.clone(), e.to_string(), true),
+                        Err(e) => (
+                            r.index,
+                            r.id.clone(),
+                            r.name.clone(),
+                            e.to_string(),
+                            true,
+                            vec![],
+                        ),
                     },
-                    Err(e) => (r.index, r.id.clone(), r.name.clone(), e.to_string(), true),
+                    Err(e) => (
+                        r.index,
+                        r.id.clone(),
+                        r.name.clone(),
+                        e.to_string(),
+                        true,
+                        vec![],
+                    ),
                 },
             }
         })
@@ -542,7 +563,10 @@ async fn execute_tool_calls(
     let results = join_all(futures).await;
 
     let mut tool_result_blocks: Vec<ContentBlock> = Vec::with_capacity(results.len());
-    for (index, id, name, content, is_error) in results {
+    for (index, id, name, content, is_error, agent_events) in results {
+        for extra_event in agent_events {
+            let _ = event_tx.unbounded_send(extra_event);
+        }
         let _ = event_tx.unbounded_send(AgentEvent::ToolResult {
             name: name.clone(),
             content: content.clone(),
@@ -560,6 +584,217 @@ async fn execute_tool_calls(
 }
 
 pub(crate) const DEFAULT_MAX_TOKENS: u32 = 8_192;
+
+/// Outcome of a headless sub-agent run.
+pub struct HeadlessOutcome {
+    pub text: String,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub tool_call_count: u32,
+    pub is_error: bool,
+    pub error_message: Option<String>,
+}
+
+/// Drive an `Agent` to completion without a human in the loop.
+///
+/// Any `ToolConfirmationRequired` event causes an immediate error — sub-agents
+/// must be configured with a confirmation mode that does not require human input.
+pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
+    let stream = match agent.send(prompt, None).await {
+        Ok(s) => s,
+        Err(e) => {
+            return HeadlessOutcome {
+                text: String::new(),
+                input_tokens: 0,
+                output_tokens: 0,
+                tool_call_count: 0,
+                is_error: true,
+                error_message: Some(e.to_string()),
+            };
+        }
+    };
+
+    let mut stream = stream;
+    let mut text = String::new();
+    let mut input_tokens: u32 = 0;
+    let mut output_tokens: u32 = 0;
+    let mut tool_call_count: u32 = 0;
+    let mut is_error = false;
+    let mut error_message: Option<String> = None;
+
+    while let Some(event) = stream.next().await {
+        match event {
+            AgentEvent::TokenReceived(t) => text.push_str(&t),
+            AgentEvent::ResponseComplete(_) => {}
+            AgentEvent::ToolUseReceived { .. } => tool_call_count += 1,
+            AgentEvent::ToolResult { .. } => {}
+            AgentEvent::ToolConfirmationRequired { name, .. } => {
+                is_error = true;
+                error_message = Some(format!(
+                    "Sub-agent required confirmation for tool '{name}' but no human is present. \
+                     Set a less restrictive confirmation mode for the sub-agent."
+                ));
+                break;
+            }
+            AgentEvent::Error(msg) => {
+                is_error = true;
+                error_message = Some(msg);
+            }
+            AgentEvent::Usage {
+                input_tokens: it,
+                output_tokens: ot,
+                ..
+            } => {
+                input_tokens = input_tokens.saturating_add(it);
+                output_tokens = output_tokens.saturating_add(ot);
+            }
+            AgentEvent::SubAgentUsage { .. } => {}
+        }
+    }
+
+    HeadlessOutcome {
+        text,
+        input_tokens,
+        output_tokens,
+        tool_call_count,
+        is_error,
+        error_message,
+    }
+}
+
+/// Returns the stricter of two confirmation modes.
+///
+/// Strictness ordering: `Always` > `WriteOnly` > `Never`.
+/// The sub-agent can never be more permissive than the parent.
+pub fn clamp_confirmation(
+    parent: &ConfirmationMode,
+    requested: Option<&ConfirmationMode>,
+) -> ConfirmationMode {
+    let requested = match requested {
+        Some(r) => r,
+        None => return parent.clone(),
+    };
+
+    match (parent, requested) {
+        (ConfirmationMode::Always, _) => ConfirmationMode::Always,
+        (ConfirmationMode::WriteOnly, ConfirmationMode::Always) => ConfirmationMode::Always,
+        (ConfirmationMode::WriteOnly, _) => ConfirmationMode::WriteOnly,
+        (ConfirmationMode::Never, ConfirmationMode::Always) => ConfirmationMode::Always,
+        (ConfirmationMode::Never, ConfirmationMode::WriteOnly) => ConfirmationMode::WriteOnly,
+        (ConfirmationMode::Never, ConfirmationMode::Never) => ConfirmationMode::Never,
+    }
+}
+
+/// Builds a fresh `ToolRegistry` for a sub-agent.
+///
+/// The closure receives the sub-agent's session so that session-bound tools
+/// (e.g. task tools) are wired to the sub-agent rather than the parent.
+pub type RegistryBuilder =
+    Box<dyn Fn(Arc<tokio::sync::Mutex<Session>>) -> anyhow::Result<ToolRegistry> + Send + Sync>;
+
+/// Factory used by `AgentTool` to spawn independent sub-agents.
+pub struct AgentSpawner {
+    pub factory: Arc<BackendFactory>,
+    pub app_config: Arc<crate::config::AppConfig>,
+    pub registry_builder: RegistryBuilder,
+    pub parent_confirmation: ConfirmationMode,
+    pub skills: std::collections::HashMap<String, std::path::PathBuf>,
+}
+
+impl AgentSpawner {
+    pub async fn spawn(
+        &self,
+        role: &str,
+        confirmation: ConfirmationMode,
+        tool_allowlist: Option<&[String]>,
+        prompt: String,
+    ) -> HeadlessOutcome {
+        let session = match Session::new(None, self.app_config.sessions_dir.clone()).await {
+            Ok(s) => Arc::new(tokio::sync::Mutex::new(s)),
+            Err(e) => {
+                return HeadlessOutcome {
+                    text: String::new(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    tool_call_count: 0,
+                    is_error: true,
+                    error_message: Some(format!("Failed to create sub-agent session: {e}")),
+                };
+            }
+        };
+
+        let registry = match (self.registry_builder)(Arc::clone(&session)) {
+            Ok(r) => r,
+            Err(e) => {
+                return HeadlessOutcome {
+                    text: String::new(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    tool_call_count: 0,
+                    is_error: true,
+                    error_message: Some(format!("Failed to build sub-agent registry: {e}")),
+                };
+            }
+        };
+
+        let registry = if let Some(allowlist) = tool_allowlist {
+            registry.into_filtered(allowlist)
+        } else {
+            registry
+        };
+
+        let tool_config = ToolsConfig {
+            confirmation,
+            ..self.app_config.tools.clone()
+        };
+
+        let selection = match self.factory.for_role(role).await {
+            Ok(s) => s,
+            Err(e) => {
+                return HeadlessOutcome {
+                    text: String::new(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    tool_call_count: 0,
+                    is_error: true,
+                    error_message: Some(format!("Failed to resolve role '{role}': {e}")),
+                };
+            }
+        };
+
+        let agent =
+            match spawn_agent_with_selection(selection, &tool_config, session, registry).await {
+                Ok(a) => a,
+                Err(e) => {
+                    return HeadlessOutcome {
+                        text: String::new(),
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        tool_call_count: 0,
+                        is_error: true,
+                        error_message: Some(format!("Failed to spawn sub-agent: {e}")),
+                    };
+                }
+            };
+
+        let agent = match agent.with_context_files() {
+            Ok(a) => a,
+            Err(e) => {
+                return HeadlessOutcome {
+                    text: String::new(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    tool_call_count: 0,
+                    is_error: true,
+                    error_message: Some(format!("Failed to load context files: {e}")),
+                };
+            }
+        };
+
+        let agent = agent.with_skills(&self.skills);
+        run_headless(&agent, prompt).await
+    }
+}
 
 /// Spawn a fresh `Agent` for the given named role using the shared `BackendFactory`.
 ///
@@ -706,6 +941,7 @@ mod tests {
             Ok(ToolExecResult {
                 content: vec![ContentBlock::Text(self.output.clone())],
                 is_error: false,
+                agent_events: vec![],
             })
         }
     }
@@ -1760,6 +1996,7 @@ mod tests {
             Ok(ToolExecResult {
                 content: vec![ContentBlock::Text(format!("slept {}ms", ms))],
                 is_error: false,
+                agent_events: vec![],
             })
         }
     }
@@ -1928,6 +2165,7 @@ mod tests {
                     Ok(ToolExecResult {
                         content: vec![ContentBlock::Text(format!("ok call {n}"))],
                         is_error: false,
+                        agent_events: vec![],
                     })
                 }
             }
@@ -2180,5 +2418,120 @@ mod tests {
             assert!(is_error, "rejected tool should produce error result");
             assert_eq!(*index, 2);
         }
+    }
+
+    // ── clamp_confirmation ────────────────────────────────────────────────
+
+    #[test]
+    fn clamp_confirmation_picks_stricter() {
+        use super::clamp_confirmation;
+        use crate::config::ConfirmationMode::{Always, Never, WriteOnly};
+
+        // parent=Always: always wins
+        assert_eq!(clamp_confirmation(&Always, Some(&Always)), Always);
+        assert_eq!(clamp_confirmation(&Always, Some(&WriteOnly)), Always);
+        assert_eq!(clamp_confirmation(&Always, Some(&Never)), Always);
+
+        // parent=WriteOnly
+        assert_eq!(clamp_confirmation(&WriteOnly, Some(&Always)), Always);
+        assert_eq!(clamp_confirmation(&WriteOnly, Some(&WriteOnly)), WriteOnly);
+        assert_eq!(clamp_confirmation(&WriteOnly, Some(&Never)), WriteOnly);
+
+        // parent=Never: requested takes precedence unless it's also Never
+        assert_eq!(clamp_confirmation(&Never, Some(&Always)), Always);
+        assert_eq!(clamp_confirmation(&Never, Some(&WriteOnly)), WriteOnly);
+        assert_eq!(clamp_confirmation(&Never, Some(&Never)), Never);
+
+        // None requested → fall back to parent
+        assert_eq!(clamp_confirmation(&WriteOnly, None), WriteOnly);
+        assert_eq!(clamp_confirmation(&Always, None), Always);
+        assert_eq!(clamp_confirmation(&Never, None), Never);
+    }
+
+    // ── run_headless ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn run_headless_collects_text_and_usage() {
+        use super::run_headless;
+
+        let backend = SequencedBackend::new(vec![vec![
+            Ok(StreamEvent::TextDelta("hello".to_string())),
+            Ok(StreamEvent::TextDelta(" world".to_string())),
+            Ok(StreamEvent::Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+                stop_reason: "end_turn".to_string(),
+            }),
+            Ok(StreamEvent::Done),
+        ]]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
+        let outcome = run_headless(&agent, "hi".to_string()).await;
+
+        assert!(!outcome.is_error);
+        assert_eq!(outcome.text, "hello world");
+        assert_eq!(outcome.input_tokens, 10);
+        assert_eq!(outcome.output_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn run_headless_auto_rejects_confirmations() {
+        use super::run_headless;
+
+        let backend = SequencedBackend::new(vec![
+            // First turn: emit a write tool — this triggers ToolConfirmationRequired
+            // because there's no confirmation_rx, leading to a Declined result.
+            // The agent re-sends with the declined result, then we return text.
+            tool_call_response("t1", "write_file", r#"{}"#),
+            text_response("done"),
+        ]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let mut registry = ToolRegistry::new();
+        registry
+            .register(Box::new(EchoTool::write_tool("write_file", "written")))
+            .expect("register");
+        // Use Always mode so the tool would normally require confirmation.
+        let tool_config = ToolsConfig {
+            confirmation: ConfirmationMode::Always,
+            ..Default::default()
+        };
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
+            .await
+            .with_tools(registry)
+            .with_tool_config(&tool_config);
+
+        // run_headless sends None for confirmation_rx so confirmations → declined.
+        let outcome = run_headless(&agent, "write".to_string()).await;
+
+        // No ToolConfirmationRequired surfaces as an error in headless mode because
+        // the agent internally treats "no rx → declined" and produces an error ToolResult,
+        // then continues. The final outcome is not is_error unless the backend fails.
+        assert!(!outcome.is_error || outcome.error_message.is_some());
+    }
+
+    #[tokio::test]
+    async fn run_headless_backend_error_sets_is_error() {
+        use super::run_headless;
+
+        let backend = SequencedBackend::new(vec![vec![Err(anyhow::anyhow!("connection lost"))]]);
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
+        let outcome = run_headless(&agent, "fail".to_string()).await;
+
+        assert!(outcome.is_error);
+        let msg = outcome.error_message.expect("should have error message");
+        assert!(msg.contains("connection lost"));
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -590,7 +590,6 @@ pub struct HeadlessOutcome {
     pub text: String,
     pub input_tokens: u32,
     pub output_tokens: u32,
-    pub tool_call_count: u32,
     pub is_error: bool,
     pub error_message: Option<String>,
 }
@@ -607,7 +606,6 @@ pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
                 text: String::new(),
                 input_tokens: 0,
                 output_tokens: 0,
-                tool_call_count: 0,
                 is_error: true,
                 error_message: Some(e.to_string()),
             };
@@ -618,7 +616,6 @@ pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
     let mut text = String::new();
     let mut input_tokens: u32 = 0;
     let mut output_tokens: u32 = 0;
-    let mut tool_call_count: u32 = 0;
     let mut is_error = false;
     let mut error_message: Option<String> = None;
 
@@ -626,7 +623,7 @@ pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
         match event {
             AgentEvent::TokenReceived(t) => text.push_str(&t),
             AgentEvent::ResponseComplete(_) => {}
-            AgentEvent::ToolUseReceived { .. } => tool_call_count += 1,
+            AgentEvent::ToolUseReceived { .. } => {}
             AgentEvent::ToolResult { .. } => {}
             AgentEvent::ToolConfirmationRequired { name, .. } => {
                 is_error = true;
@@ -639,6 +636,7 @@ pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
             AgentEvent::Error(msg) => {
                 is_error = true;
                 error_message = Some(msg);
+                break;
             }
             AgentEvent::Usage {
                 input_tokens: it,
@@ -656,7 +654,6 @@ pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
         text,
         input_tokens,
         output_tokens,
-        tool_call_count,
         is_error,
         error_message,
     }
@@ -716,7 +713,6 @@ impl AgentSpawner {
                     text: String::new(),
                     input_tokens: 0,
                     output_tokens: 0,
-                    tool_call_count: 0,
                     is_error: true,
                     error_message: Some(format!("Failed to create sub-agent session: {e}")),
                 };
@@ -730,7 +726,6 @@ impl AgentSpawner {
                     text: String::new(),
                     input_tokens: 0,
                     output_tokens: 0,
-                    tool_call_count: 0,
                     is_error: true,
                     error_message: Some(format!("Failed to build sub-agent registry: {e}")),
                 };
@@ -755,7 +750,6 @@ impl AgentSpawner {
                     text: String::new(),
                     input_tokens: 0,
                     output_tokens: 0,
-                    tool_call_count: 0,
                     is_error: true,
                     error_message: Some(format!("Failed to resolve role '{role}': {e}")),
                 };
@@ -770,7 +764,6 @@ impl AgentSpawner {
                         text: String::new(),
                         input_tokens: 0,
                         output_tokens: 0,
-                        tool_call_count: 0,
                         is_error: true,
                         error_message: Some(format!("Failed to spawn sub-agent: {e}")),
                     };
@@ -784,7 +777,6 @@ impl AgentSpawner {
                     text: String::new(),
                     input_tokens: 0,
                     output_tokens: 0,
-                    tool_call_count: 0,
                     is_error: true,
                     error_message: Some(format!("Failed to load context files: {e}")),
                 };
@@ -2482,10 +2474,10 @@ mod tests {
     async fn run_headless_auto_rejects_confirmations() {
         use super::run_headless;
 
+        // In Always mode the agent emits ToolConfirmationRequired before checking
+        // the rx. run_headless has no rx and no user, so it treats the event as a
+        // hard error: is_error = true with a descriptive error_message, and stops.
         let backend = SequencedBackend::new(vec![
-            // First turn: emit a write tool — this triggers ToolConfirmationRequired
-            // because there's no confirmation_rx, leading to a Declined result.
-            // The agent re-sends with the declined result, then we return text.
             tool_call_response("t1", "write_file", r#"{}"#),
             text_response("done"),
         ]);
@@ -2498,7 +2490,6 @@ mod tests {
         registry
             .register(Box::new(EchoTool::write_tool("write_file", "written")))
             .expect("register");
-        // Use Always mode so the tool would normally require confirmation.
         let tool_config = ToolsConfig {
             confirmation: ConfirmationMode::Always,
             ..Default::default()
@@ -2508,13 +2499,24 @@ mod tests {
             .with_tools(registry)
             .with_tool_config(&tool_config);
 
-        // run_headless sends None for confirmation_rx so confirmations → declined.
         let outcome = run_headless(&agent, "write".to_string()).await;
 
-        // No ToolConfirmationRequired surfaces as an error in headless mode because
-        // the agent internally treats "no rx → declined" and produces an error ToolResult,
-        // then continues. The final outcome is not is_error unless the backend fails.
-        assert!(!outcome.is_error || outcome.error_message.is_some());
+        // ToolConfirmationRequired received with no human present → hard error.
+        assert!(
+            outcome.is_error,
+            "confirmation required with no human present must set is_error"
+        );
+        let msg = outcome
+            .error_message
+            .expect("error_message must be set when is_error is true");
+        assert!(
+            msg.contains("write_file"),
+            "error message should name the offending tool; got: {msg}"
+        );
+        assert!(
+            msg.contains("confirmation"),
+            "error message should mention confirmation; got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -146,6 +146,12 @@ async fn run_text<W: Write, R: BufRead>(
 
 // Collects a single LLM response from the stream, returning the final text and
 // whether an error occurred.
+//
+// Not the same as `agent::run_headless`: this function is interactive (prompts
+// the user for tool confirmations, streams tokens to a logger, works with a
+// confirm channel) and display-coupled (lives in the frontend layer). By
+// contrast, `run_headless` is fully non-interactive (auto-rejects confirmations,
+// accumulates usage totals, no logger) and lives in the agent layer.
 async fn collect_response<R: BufRead>(
     stream: &mut BoxStream<AgentEvent>,
     confirm_tx: mpsc::UnboundedSender<ConfirmationResponse>,

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -135,6 +135,7 @@ async fn run_text<W: Write, R: BufRead>(
                 }
             }
             AgentEvent::Usage { .. } => {}
+            AgentEvent::SubAgentUsage { .. } => {}
             AgentEvent::ToolConfirmationRequired { name, input, .. } => {
                 handle_confirmation(confirm_tx.clone(), is_tty, stdin, &name, &input)?;
             }
@@ -183,6 +184,7 @@ async fn collect_response<R: BufRead>(
                 break;
             }
             AgentEvent::Usage { .. } => {}
+            AgentEvent::SubAgentUsage { .. } => {}
             AgentEvent::ToolConfirmationRequired { name, .. } if !is_tty => {
                 let _ = confirm_tx.unbounded_send(ConfirmationResponse::Rejected);
                 is_error = true;

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -403,6 +403,7 @@ pub fn handle_agent_event(
                     let result = crate::tools::ToolResult {
                         content: vec![crate::types::ContentBlock::Text(content)],
                         is_error: false,
+                        agent_events: vec![],
                     };
                     tool.markdown_output(&result)
                 }
@@ -435,6 +436,13 @@ pub fn handle_agent_event(
             let new_input = input_tokens.saturating_sub(app.last_input_total);
             app.last_input_total = input_tokens;
             app.usage.add(new_input, output_tokens);
+        }
+        AgentEvent::SubAgentUsage {
+            input_tokens,
+            output_tokens,
+            ..
+        } => {
+            app.usage.add(input_tokens, output_tokens);
         }
     }
     Ok(())
@@ -1000,6 +1008,36 @@ mod tests {
         );
         assert_eq!(app.usage.output_tokens, 330);
         assert_eq!(app.last_input_total, 850);
+    }
+
+    #[test]
+    fn subagent_usage_event_aggregates_into_app_usage() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        assert_eq!(app.usage.input_tokens, 0);
+        assert_eq!(app.usage.output_tokens, 0);
+
+        let event = AgentEvent::SubAgentUsage {
+            input_tokens: 200,
+            output_tokens: 80,
+            role: "default".to_string(),
+        };
+        handle_agent_event(&mut app, event, None).expect("handle SubAgentUsage");
+
+        assert_eq!(app.usage.input_tokens, 200);
+        assert_eq!(app.usage.output_tokens, 80);
+        // SubAgentUsage does not update last_input_total (no deduplication logic needed)
+        assert_eq!(app.last_input_total, 0);
+
+        // A subsequent SubAgentUsage should add on top.
+        let event2 = AgentEvent::SubAgentUsage {
+            input_tokens: 50,
+            output_tokens: 30,
+            role: "fast".to_string(),
+        };
+        handle_agent_event(&mut app, event2, None).expect("handle second SubAgentUsage");
+
+        assert_eq!(app.usage.input_tokens, 250);
+        assert_eq!(app.usage.output_tokens, 110);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,12 @@ async fn main() -> Result<()> {
         let bash_denylist = app_config.tools.bash_denylist.clone();
         let parent_confirmation = app_config.tools.confirmation.clone();
 
+        // OnceLock lets the registry_builder closure reference the spawner it will
+        // be part of, enabling sub-agents to spawn further sub-agents.
+        let spawner_cell: Arc<std::sync::OnceLock<Arc<agent::AgentSpawner>>> =
+            Arc::new(std::sync::OnceLock::new());
+        let spawner_cell_clone = Arc::clone(&spawner_cell);
+
         let spawner = Arc::new(agent::AgentSpawner {
             factory: factory_clone,
             app_config: app_config_clone,
@@ -202,11 +208,23 @@ async fn main() -> Result<()> {
                 reg.register(Box::new(ListTasksTool::new(Arc::clone(&sub_session))))?;
                 reg.register(Box::new(UpdateTaskTool::new(Arc::clone(&sub_session))))?;
                 reg.register(Box::new(DeleteTaskTool::new(Arc::clone(&sub_session))))?;
+                // Include the agent tool so sub-agents can spawn further sub-agents.
+                if let Some(spawner) = spawner_cell_clone.get() {
+                    reg.register(Box::new(AgentTool::new(Arc::clone(spawner))))?;
+                }
                 Ok(reg)
             }),
             parent_confirmation: app_config.tools.confirmation.clone(),
             skills: skills.clone(),
         });
+
+        // Populate the cell so the closure can reference the spawner.
+        // set() only fails if called twice; this is the only call site.
+        spawner_cell
+            .set(Arc::clone(&spawner))
+            .ok()
+            .expect("spawner_cell set exactly once at startup");
+
         registry.register(Box::new(AgentTool::new(spawner)))?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use backend::BackendFactory;
 use logging::Logger;
 use session::Session;
 use tools::ToolRegistry;
+use tools::agent::AgentTool;
 use tools::bash::BashTool;
 use tools::edit_file::EditFile;
 use tools::sandbox::SandboxPolicy;
@@ -138,7 +139,8 @@ async fn main() -> Result<()> {
     );
     config::validate(&app_config, cli.config.as_deref())?;
 
-    let factory = BackendFactory::new(app_config.clone());
+    let factory = Arc::new(BackendFactory::new(app_config.clone()));
+    let app_config_arc = Arc::new(app_config.clone());
 
     let mut registry = ToolRegistry::new();
     registry.register(Box::new(BashTool::new(
@@ -167,6 +169,46 @@ async fn main() -> Result<()> {
     registry.register(Box::new(ListTasksTool::new(Arc::clone(&session_arc))))?;
     registry.register(Box::new(UpdateTaskTool::new(Arc::clone(&session_arc))))?;
     registry.register(Box::new(DeleteTaskTool::new(Arc::clone(&session_arc))))?;
+
+    {
+        let factory_clone = Arc::clone(&factory);
+        let app_config_clone = Arc::clone(&app_config_arc);
+        let skills_clone = skills.clone();
+        let sandbox_root = app_config.tools.sandbox_root.clone();
+        let bash_allowlist = app_config.tools.bash_allowlist.clone();
+        let bash_denylist = app_config.tools.bash_denylist.clone();
+        let parent_confirmation = app_config.tools.confirmation.clone();
+
+        let spawner = Arc::new(agent::AgentSpawner {
+            factory: factory_clone,
+            app_config: app_config_clone,
+            registry_builder: Box::new(move |sub_session| {
+                let sandbox_policy = SandboxPolicy::new(std::path::Path::new(&sandbox_root));
+                let mut reg = ToolRegistry::new();
+                reg.register(Box::new(BashTool::new(
+                    bash_allowlist.clone(),
+                    bash_denylist.clone(),
+                    std::path::PathBuf::from(&sandbox_root),
+                    parent_confirmation.clone(),
+                    Box::new(|_| true),
+                )))?;
+                reg.register(Box::new(EditFile::new(sandbox_policy.clone())))?;
+                reg.register(Box::new(WriteFileTool::new(sandbox_policy)))?;
+                reg.register(Box::new(SearchTool::new(std::path::PathBuf::from(
+                    &sandbox_root,
+                ))))?;
+                reg.register(Box::new(SkillTool::new(&skills_clone)))?;
+                reg.register(Box::new(CreateTaskTool::new(Arc::clone(&sub_session))))?;
+                reg.register(Box::new(ListTasksTool::new(Arc::clone(&sub_session))))?;
+                reg.register(Box::new(UpdateTaskTool::new(Arc::clone(&sub_session))))?;
+                reg.register(Box::new(DeleteTaskTool::new(Arc::clone(&sub_session))))?;
+                Ok(reg)
+            }),
+            parent_confirmation: app_config.tools.confirmation.clone(),
+            skills: skills.clone(),
+        });
+        registry.register(Box::new(AgentTool::new(spawner)))?;
+    }
 
     let agent = Arc::new(
         spawn_agent(

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ pub mod types;
 
 use anyhow::Result;
 use clap::Parser;
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -142,91 +143,15 @@ async fn main() -> Result<()> {
     let factory = Arc::new(BackendFactory::new(app_config.clone()));
     let app_config_arc = Arc::new(app_config.clone());
 
-    let mut registry = ToolRegistry::new();
-    registry.register(Box::new(BashTool::new(
-        app_config.tools.bash_allowlist.clone(),
-        app_config.tools.bash_denylist.clone(),
-        std::path::PathBuf::from(&app_config.tools.sandbox_root),
-        app_config.tools.confirmation.clone(),
-        Box::new(|_| true),
-    )))?;
-
-    let sandbox_policy = SandboxPolicy::new(std::path::Path::new(&app_config.tools.sandbox_root));
-    registry.register(Box::new(EditFile::new(sandbox_policy.clone())))?;
-    registry.register(Box::new(WriteFileTool::new(sandbox_policy)))?;
-
-    registry.register(Box::new(SearchTool::new(std::path::PathBuf::from(
-        &app_config.tools.sandbox_root,
-    ))))?;
-
     let skills = discover_skills_from_env();
-    registry.register(Box::new(SkillTool::new(&skills)))?;
 
     let session = Session::new(cli.session_id.clone(), app_config.sessions_dir.clone()).await?;
     let session_arc = Arc::new(tokio::sync::Mutex::new(session));
 
-    registry.register(Box::new(CreateTaskTool::new(Arc::clone(&session_arc))))?;
-    registry.register(Box::new(ListTasksTool::new(Arc::clone(&session_arc))))?;
-    registry.register(Box::new(UpdateTaskTool::new(Arc::clone(&session_arc))))?;
-    registry.register(Box::new(DeleteTaskTool::new(Arc::clone(&session_arc))))?;
+    let mut registry =
+        build_tool_registry(Arc::clone(&session_arc), &app_config.tools, &skills, None)?;
 
-    {
-        let factory_clone = Arc::clone(&factory);
-        let app_config_clone = Arc::clone(&app_config_arc);
-        let skills_clone = skills.clone();
-        let sandbox_root = app_config.tools.sandbox_root.clone();
-        let bash_allowlist = app_config.tools.bash_allowlist.clone();
-        let bash_denylist = app_config.tools.bash_denylist.clone();
-        let parent_confirmation = app_config.tools.confirmation.clone();
-
-        // OnceLock lets the registry_builder closure reference the spawner it will
-        // be part of, enabling sub-agents to spawn further sub-agents.
-        let spawner_cell: Arc<std::sync::OnceLock<Arc<agent::AgentSpawner>>> =
-            Arc::new(std::sync::OnceLock::new());
-        let spawner_cell_clone = Arc::clone(&spawner_cell);
-
-        let spawner = Arc::new(agent::AgentSpawner {
-            factory: factory_clone,
-            app_config: app_config_clone,
-            registry_builder: Box::new(move |sub_session| {
-                let sandbox_policy = SandboxPolicy::new(std::path::Path::new(&sandbox_root));
-                let mut reg = ToolRegistry::new();
-                reg.register(Box::new(BashTool::new(
-                    bash_allowlist.clone(),
-                    bash_denylist.clone(),
-                    std::path::PathBuf::from(&sandbox_root),
-                    parent_confirmation.clone(),
-                    Box::new(|_| true),
-                )))?;
-                reg.register(Box::new(EditFile::new(sandbox_policy.clone())))?;
-                reg.register(Box::new(WriteFileTool::new(sandbox_policy)))?;
-                reg.register(Box::new(SearchTool::new(std::path::PathBuf::from(
-                    &sandbox_root,
-                ))))?;
-                reg.register(Box::new(SkillTool::new(&skills_clone)))?;
-                reg.register(Box::new(CreateTaskTool::new(Arc::clone(&sub_session))))?;
-                reg.register(Box::new(ListTasksTool::new(Arc::clone(&sub_session))))?;
-                reg.register(Box::new(UpdateTaskTool::new(Arc::clone(&sub_session))))?;
-                reg.register(Box::new(DeleteTaskTool::new(Arc::clone(&sub_session))))?;
-                // Include the agent tool so sub-agents can spawn further sub-agents.
-                if let Some(spawner) = spawner_cell_clone.get() {
-                    reg.register(Box::new(AgentTool::new(Arc::clone(spawner))))?;
-                }
-                Ok(reg)
-            }),
-            parent_confirmation: app_config.tools.confirmation.clone(),
-            skills: skills.clone(),
-        });
-
-        // Populate the cell so the closure can reference the spawner.
-        // set() only fails if called twice; this is the only call site.
-        spawner_cell
-            .set(Arc::clone(&spawner))
-            .ok()
-            .expect("spawner_cell set exactly once at startup");
-
-        registry.register(Box::new(AgentTool::new(spawner)))?;
-    }
+    build_agent_spawner_and_register(&mut registry, &factory, &app_config_arc, &skills)?;
 
     let agent = Arc::new(
         spawn_agent(
@@ -289,6 +214,84 @@ async fn main() -> Result<()> {
     }
 
     eprintln!("Session ID: {}", agent.session_id().await);
+    Ok(())
+}
+
+/// Build a `ToolRegistry` with the standard tool set.
+///
+/// `agent_tool` is `Some` for sub-agent registries (enabling recursive spawning)
+/// and `None` for the parent registry, where `build_agent_spawner_and_register`
+/// adds `AgentTool` after constructing the spawner.
+fn build_tool_registry(
+    session: Arc<tokio::sync::Mutex<Session>>,
+    tools_config: &config::ToolsConfig,
+    skills: &HashMap<String, PathBuf>,
+    agent_tool: Option<AgentTool>,
+) -> Result<ToolRegistry> {
+    let sandbox_policy = SandboxPolicy::new(Path::new(&tools_config.sandbox_root));
+    let mut reg = ToolRegistry::new();
+    reg.register(Box::new(BashTool::new(
+        tools_config.bash_allowlist.clone(),
+        tools_config.bash_denylist.clone(),
+        PathBuf::from(&tools_config.sandbox_root),
+        tools_config.confirmation.clone(),
+        Box::new(|_| true),
+    )))?;
+    reg.register(Box::new(EditFile::new(sandbox_policy.clone())))?;
+    reg.register(Box::new(WriteFileTool::new(sandbox_policy)))?;
+    reg.register(Box::new(SearchTool::new(PathBuf::from(
+        &tools_config.sandbox_root,
+    ))))?;
+    reg.register(Box::new(SkillTool::new(skills)))?;
+    reg.register(Box::new(CreateTaskTool::new(Arc::clone(&session))))?;
+    reg.register(Box::new(ListTasksTool::new(Arc::clone(&session))))?;
+    reg.register(Box::new(UpdateTaskTool::new(Arc::clone(&session))))?;
+    reg.register(Box::new(DeleteTaskTool::new(session)))?;
+    if let Some(tool) = agent_tool {
+        reg.register(Box::new(tool))?;
+    }
+    Ok(reg)
+}
+
+/// Construct the `AgentSpawner` and register `AgentTool` into `registry`.
+///
+/// Uses a `OnceLock` to break the circular reference between the spawner and
+/// the `registry_builder` closure that references it, enabling sub-agents to
+/// spawn further sub-agents.
+fn build_agent_spawner_and_register(
+    registry: &mut ToolRegistry,
+    factory: &Arc<BackendFactory>,
+    app_config: &Arc<config::AppConfig>,
+    skills: &HashMap<String, PathBuf>,
+) -> Result<()> {
+    let factory_clone = Arc::clone(factory);
+    let app_config_clone = Arc::clone(app_config);
+    let skills_clone = skills.clone();
+    let tools_config = app_config.tools.clone();
+
+    let spawner_cell: Arc<std::sync::OnceLock<Arc<agent::AgentSpawner>>> =
+        Arc::new(std::sync::OnceLock::new());
+    let spawner_cell_clone = Arc::clone(&spawner_cell);
+
+    let spawner = Arc::new(agent::AgentSpawner {
+        factory: factory_clone,
+        app_config: app_config_clone,
+        registry_builder: Box::new(move |sub_session| {
+            let agent_tool = spawner_cell_clone
+                .get()
+                .map(|s| AgentTool::new(Arc::clone(s)));
+            build_tool_registry(sub_session, &tools_config, &skills_clone, agent_tool)
+        }),
+        parent_confirmation: app_config.tools.confirmation.clone(),
+        skills: skills.clone(),
+    });
+
+    spawner_cell
+        .set(Arc::clone(&spawner))
+        .ok()
+        .expect("spawner_cell set exactly once at startup");
+
+    registry.register(Box::new(AgentTool::new(spawner)))?;
     Ok(())
 }
 

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -1,0 +1,439 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::agent::{AgentSpawner, clamp_confirmation};
+use crate::config::ConfirmationMode;
+use crate::tools::{Tool, ToolError, ToolResult};
+use crate::types::ContentBlock;
+
+pub struct AgentTool {
+    spawner: Arc<AgentSpawner>,
+}
+
+impl AgentTool {
+    pub fn new(spawner: Arc<AgentSpawner>) -> Self {
+        Self { spawner }
+    }
+}
+
+#[async_trait]
+impl Tool for AgentTool {
+    fn name(&self) -> &str {
+        "agent"
+    }
+
+    fn description(&self) -> &str {
+        "Spawn an independent sub-agent to run a focused task in its own session. \
+         The sub-agent has its own conversation history and tool set. \
+         Returns the sub-agent's final response text."
+    }
+
+    fn input_schema(&self) -> &Value {
+        static SCHEMA: std::sync::OnceLock<Value> = std::sync::OnceLock::new();
+        SCHEMA.get_or_init(|| {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "The task or question for the sub-agent to handle."
+                    },
+                    "role": {
+                        "type": "string",
+                        "description": "Named model role from [models] config. Defaults to 'default'."
+                    },
+                    "confirmation": {
+                        "type": "string",
+                        "enum": ["Always", "WriteOnly", "Never"],
+                        "description": "Confirmation mode for the sub-agent. Clamped to be no more permissive than the parent."
+                    },
+                    "tools": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Explicit allowlist of tool names for the sub-agent. If omitted, inherits the parent's tool set."
+                    }
+                },
+                "required": ["prompt"]
+            })
+        })
+    }
+
+    fn is_write_tool(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+        let prompt = input["prompt"]
+            .as_str()
+            .ok_or_else(|| ToolError::InvalidInput {
+                message: "Missing required field 'prompt'".to_string(),
+            })?
+            .to_string();
+
+        let role = input["role"].as_str().unwrap_or("default").to_string();
+
+        let requested_confirmation = input["confirmation"].as_str().and_then(|s| match s {
+            "Always" => Some(ConfirmationMode::Always),
+            "WriteOnly" => Some(ConfirmationMode::WriteOnly),
+            "Never" => Some(ConfirmationMode::Never),
+            _ => None,
+        });
+
+        let confirmation = clamp_confirmation(
+            &self.spawner.parent_confirmation,
+            requested_confirmation.as_ref(),
+        );
+
+        let tool_allowlist: Option<Vec<String>> = input["tools"].as_array().map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        });
+
+        let outcome = self
+            .spawner
+            .spawn(&role, confirmation, tool_allowlist.as_deref(), prompt)
+            .await;
+
+        if outcome.is_error {
+            let msg = outcome
+                .error_message
+                .unwrap_or_else(|| "Sub-agent failed".to_string());
+            Ok(ToolResult {
+                content: vec![ContentBlock::Text(msg)],
+                is_error: true,
+                agent_events: vec![],
+            })
+        } else {
+            let usage_event = crate::types::AgentEvent::SubAgentUsage {
+                input_tokens: outcome.input_tokens,
+                output_tokens: outcome.output_tokens,
+                role: role.clone(),
+            };
+            Ok(ToolResult {
+                content: vec![ContentBlock::Text(outcome.text)],
+                is_error: false,
+                agent_events: vec![usage_event],
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::{AgentSpawner, HeadlessOutcome};
+    use crate::config::{AppConfig, ConfirmationMode, ToolsConfig};
+    use crate::session::Session;
+    use crate::tools::ToolRegistry;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use tokio::sync::Mutex as TokioMutex;
+
+    // ── Fake AgentSpawner ─────────────────────────────────────────────────
+
+    /// A canned spawner that returns a fixed outcome without hitting any backend.
+    struct FakeSpawner {
+        outcome: HeadlessOutcome,
+        captured_role: std::sync::Mutex<Option<String>>,
+        captured_confirmation: std::sync::Mutex<Option<ConfirmationMode>>,
+        captured_allowlist: std::sync::Mutex<Option<Option<Vec<String>>>>,
+    }
+
+    impl FakeSpawner {
+        fn new(outcome: HeadlessOutcome) -> Arc<Self> {
+            Arc::new(Self {
+                outcome,
+                captured_role: std::sync::Mutex::new(None),
+                captured_confirmation: std::sync::Mutex::new(None),
+                captured_allowlist: std::sync::Mutex::new(None),
+            })
+        }
+    }
+
+    // We can't easily use AgentSpawner directly in unit tests without a real
+    // BackendFactory, so we test AgentTool via a thin shim that bypasses
+    // AgentSpawner while exercising the same Tool trait surface.
+
+    /// A test-only AgentTool-like struct backed by a FakeSpawner.
+    struct FakeAgentTool {
+        spawner: Arc<FakeSpawner>,
+        parent_confirmation: ConfirmationMode,
+    }
+
+    #[async_trait]
+    impl Tool for FakeAgentTool {
+        fn name(&self) -> &str {
+            "agent"
+        }
+        fn description(&self) -> &str {
+            "fake agent tool"
+        }
+        fn input_schema(&self) -> &Value {
+            static SCHEMA: std::sync::OnceLock<Value> = std::sync::OnceLock::new();
+            SCHEMA.get_or_init(|| serde_json::json!({"type":"object","properties":{}}))
+        }
+        fn is_write_tool(&self) -> bool {
+            true
+        }
+        async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
+            let prompt = input["prompt"]
+                .as_str()
+                .ok_or_else(|| ToolError::InvalidInput {
+                    message: "Missing 'prompt'".to_string(),
+                })?
+                .to_string();
+
+            let role = input["role"].as_str().unwrap_or("default").to_string();
+
+            let requested_confirmation = input["confirmation"].as_str().and_then(|s| match s {
+                "Always" => Some(ConfirmationMode::Always),
+                "WriteOnly" => Some(ConfirmationMode::WriteOnly),
+                "Never" => Some(ConfirmationMode::Never),
+                _ => None,
+            });
+
+            let confirmation =
+                clamp_confirmation(&self.parent_confirmation, requested_confirmation.as_ref());
+
+            let tool_allowlist: Option<Vec<String>> = input["tools"].as_array().map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            });
+
+            *self.spawner.captured_role.lock().expect("lock") = Some(role);
+            *self.spawner.captured_confirmation.lock().expect("lock") = Some(confirmation);
+            *self.spawner.captured_allowlist.lock().expect("lock") = Some(tool_allowlist);
+
+            let _ = prompt;
+            let outcome = &self.spawner.outcome;
+
+            if outcome.is_error {
+                Ok(ToolResult {
+                    content: vec![ContentBlock::Text(
+                        outcome
+                            .error_message
+                            .clone()
+                            .unwrap_or_else(|| "error".to_string()),
+                    )],
+                    is_error: true,
+                    agent_events: vec![],
+                })
+            } else {
+                Ok(ToolResult {
+                    content: vec![ContentBlock::Text(outcome.text.clone())],
+                    is_error: false,
+                    agent_events: vec![],
+                })
+            }
+        }
+    }
+
+    fn ok_outcome(text: &str) -> HeadlessOutcome {
+        HeadlessOutcome {
+            text: text.to_string(),
+            input_tokens: 10,
+            output_tokens: 5,
+            tool_call_count: 0,
+            is_error: false,
+            error_message: None,
+        }
+    }
+
+    fn err_outcome(msg: &str) -> HeadlessOutcome {
+        HeadlessOutcome {
+            text: String::new(),
+            input_tokens: 0,
+            output_tokens: 0,
+            tool_call_count: 0,
+            is_error: true,
+            error_message: Some(msg.to_string()),
+        }
+    }
+
+    fn fake_tool(outcome: HeadlessOutcome, parent: ConfirmationMode) -> FakeAgentTool {
+        FakeAgentTool {
+            spawner: FakeSpawner::new(outcome),
+            parent_confirmation: parent,
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_tool_returns_final_text_from_subagent() {
+        let tool = fake_tool(ok_outcome("sub-agent result"), ConfirmationMode::Never);
+        let input = serde_json::json!({"prompt": "do something"});
+        let result = tool.execute(input).await.expect("execute should succeed");
+        assert!(!result.is_error);
+        assert!(matches!(&result.content[0], ContentBlock::Text(t) if t == "sub-agent result"));
+    }
+
+    #[tokio::test]
+    async fn agent_tool_surfaces_backend_error_as_error_result() {
+        let tool = fake_tool(err_outcome("backend exploded"), ConfirmationMode::Never);
+        let input = serde_json::json!({"prompt": "do something"});
+        let result = tool.execute(input).await.expect("execute should succeed");
+        assert!(result.is_error);
+        assert!(
+            matches!(&result.content[0], ContentBlock::Text(t) if t.contains("backend exploded"))
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_tool_clamps_confirmation_mode_never_requested_always_parent() {
+        let tool = fake_tool(ok_outcome("ok"), ConfirmationMode::Always);
+        let input = serde_json::json!({"prompt": "do", "confirmation": "Never"});
+        tool.execute(input).await.expect("ok");
+        let captured = tool
+            .spawner
+            .captured_confirmation
+            .lock()
+            .expect("lock")
+            .clone()
+            .expect("should be set");
+        assert_eq!(
+            captured,
+            ConfirmationMode::Always,
+            "Never requested but parent is Always → should be clamped to Always"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_tool_restricts_tools_when_allowlist_provided() {
+        let tool = fake_tool(ok_outcome("ok"), ConfirmationMode::Never);
+        let input = serde_json::json!({"prompt": "do", "tools": ["bash", "search"]});
+        tool.execute(input).await.expect("ok");
+        let captured = tool
+            .spawner
+            .captured_allowlist
+            .lock()
+            .expect("lock")
+            .clone()
+            .expect("should be set");
+        let list = captured.expect("allowlist should be Some");
+        assert_eq!(list, vec!["bash".to_string(), "search".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn agent_tool_no_tools_field_means_no_allowlist() {
+        let tool = fake_tool(ok_outcome("ok"), ConfirmationMode::Never);
+        let input = serde_json::json!({"prompt": "do"});
+        tool.execute(input).await.expect("ok");
+        let captured = tool
+            .spawner
+            .captured_allowlist
+            .lock()
+            .expect("lock")
+            .clone()
+            .expect("should be set");
+        assert!(
+            captured.is_none(),
+            "no 'tools' field → allowlist should be None"
+        );
+    }
+
+    // ── Integration test: AgentTool creates a new session DB ──────────────
+
+    #[tokio::test]
+    async fn agent_tool_creates_new_session_db() {
+        use crate::backend::{BackendSelection, LlmBackend};
+        use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
+        use anyhow::Result;
+        use async_trait::async_trait;
+        use futures::stream;
+
+        struct ImmediateTextBackend;
+
+        #[async_trait]
+        impl LlmBackend for ImmediateTextBackend {
+            async fn send_message(
+                &self,
+                _: &[Message],
+                _: &RequestConfig,
+            ) -> Result<BoxStream<Result<StreamEvent>>> {
+                Ok(Box::pin(stream::iter(vec![
+                    Ok(StreamEvent::TextDelta("done".to_string())),
+                    Ok(StreamEvent::Done),
+                ])))
+            }
+        }
+
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.path().to_path_buf();
+
+        let app_config = Arc::new(AppConfig {
+            backend: "vertex".to_string(),
+            vertex: crate::config::VertexConfig {
+                project: "test".to_string(),
+                region: "us-east5".to_string(),
+                model: "claude-test".to_string(),
+            },
+            zai: None,
+            ollama: None,
+            tools: ToolsConfig {
+                confirmation: ConfirmationMode::Never,
+                ..Default::default()
+            },
+            sessions_dir: dir_path.clone(),
+            models: BTreeMap::new(),
+        });
+
+        let spawner = Arc::new(AgentSpawner {
+            factory: Arc::new(crate::backend::BackendFactory::new((*app_config).clone())),
+            app_config: Arc::clone(&app_config),
+            registry_builder: Box::new(move |_session| Ok(ToolRegistry::new())),
+            parent_confirmation: ConfirmationMode::Never,
+            skills: std::collections::HashMap::new(),
+        });
+
+        // Override factory with a fake backend via spawn_agent_with_selection directly.
+        // We do this by building a custom AgentSpawner that uses ImmediateTextBackend.
+        let dir_path2 = dir_path.clone();
+        let spawner2 = Arc::new(AgentSpawner {
+            factory: spawner.factory.clone(),
+            app_config: Arc::clone(&app_config),
+            registry_builder: Box::new(move |session_arc| {
+                let _ = session_arc;
+                Ok(ToolRegistry::new())
+            }),
+            parent_confirmation: ConfirmationMode::Never,
+            skills: std::collections::HashMap::new(),
+        });
+
+        // Count .db files before
+        let count_before = std::fs::read_dir(&dir_path)
+            .expect("read dir")
+            .filter(|e| {
+                e.as_ref()
+                    .ok()
+                    .and_then(|e| e.path().extension().map(|x| x == "db"))
+                    .unwrap_or(false)
+            })
+            .count();
+
+        // We can't easily wire a fake backend through BackendFactory without real auth.
+        // Instead, verify that the session is created (the DB file appears) by directly
+        // calling Session::new and checking that it persists.
+        let _session = Session::new(None, dir_path.clone())
+            .await
+            .expect("create session");
+
+        let count_after = std::fs::read_dir(&dir_path)
+            .expect("read dir")
+            .filter(|e| {
+                e.as_ref()
+                    .ok()
+                    .and_then(|e| e.path().extension().map(|x| x == "db"))
+                    .unwrap_or(false)
+            })
+            .count();
+
+        assert_eq!(
+            count_after,
+            count_before + 1,
+            "a new session DB should be created"
+        );
+    }
+}

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -3,13 +3,44 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::Value;
 
-use crate::agent::{AgentSpawner, clamp_confirmation};
+use crate::agent::{AgentSpawner, HeadlessOutcome, clamp_confirmation};
 use crate::config::ConfirmationMode;
 use crate::tools::{Tool, ToolError, ToolResult};
 use crate::types::ContentBlock;
 
+/// Trait allowing `AgentTool` to be tested with a fake spawner.
+#[async_trait]
+pub trait SubAgentSpawner: Send + Sync {
+    async fn spawn(
+        &self,
+        role: &str,
+        confirmation: ConfirmationMode,
+        tool_allowlist: Option<&[String]>,
+        prompt: String,
+    ) -> HeadlessOutcome;
+
+    fn parent_confirmation(&self) -> &ConfirmationMode;
+}
+
+#[async_trait]
+impl SubAgentSpawner for AgentSpawner {
+    async fn spawn(
+        &self,
+        role: &str,
+        confirmation: ConfirmationMode,
+        tool_allowlist: Option<&[String]>,
+        prompt: String,
+    ) -> HeadlessOutcome {
+        AgentSpawner::spawn(self, role, confirmation, tool_allowlist, prompt).await
+    }
+
+    fn parent_confirmation(&self) -> &ConfirmationMode {
+        &self.parent_confirmation
+    }
+}
+
 pub struct AgentTool {
-    spawner: Arc<AgentSpawner>,
+    spawner: Arc<dyn SubAgentSpawner>,
 }
 
 impl AgentTool {
@@ -27,7 +58,11 @@ impl Tool for AgentTool {
     fn description(&self) -> &str {
         "Spawn an independent sub-agent to run a focused task in its own session. \
          The sub-agent has its own conversation history and tool set. \
-         Returns the sub-agent's final response text."
+         Returns the sub-agent's final response text.\n\n\
+         NOTE: Sub-agents inherit the parent's confirmation mode by default. \
+         In `WriteOnly` or `Always` mode the sub-agent cannot perform write tool calls \
+         without aborting — pass `confirmation: \"Never\"` only when the parent also \
+         runs in `Never` mode (clamping prevents elevation beyond the parent)."
     }
 
     fn input_schema(&self) -> &Value {
@@ -82,7 +117,7 @@ impl Tool for AgentTool {
         });
 
         let confirmation = clamp_confirmation(
-            &self.spawner.parent_confirmation,
+            self.spawner.parent_confirmation(),
             requested_confirmation.as_ref(),
         );
 
@@ -124,28 +159,26 @@ impl Tool for AgentTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::{AgentSpawner, HeadlessOutcome};
-    use crate::config::{AppConfig, ConfirmationMode, ToolsConfig};
-    use crate::session::Session;
-    use crate::tools::ToolRegistry;
-    use std::collections::BTreeMap;
+    use crate::agent::HeadlessOutcome;
+    use crate::config::ConfirmationMode;
+    use crate::types::ContentBlock;
     use std::sync::Arc;
-    use tokio::sync::Mutex as TokioMutex;
 
-    // ── Fake AgentSpawner ─────────────────────────────────────────────────
+    // ── Fake spawner ──────────────────────────────────────────────────────
 
-    /// A canned spawner that returns a fixed outcome without hitting any backend.
     struct FakeSpawner {
         outcome: HeadlessOutcome,
+        parent: ConfirmationMode,
         captured_role: std::sync::Mutex<Option<String>>,
         captured_confirmation: std::sync::Mutex<Option<ConfirmationMode>>,
         captured_allowlist: std::sync::Mutex<Option<Option<Vec<String>>>>,
     }
 
     impl FakeSpawner {
-        fn new(outcome: HeadlessOutcome) -> Arc<Self> {
+        fn new(outcome: HeadlessOutcome, parent: ConfirmationMode) -> Arc<Self> {
             Arc::new(Self {
                 outcome,
+                parent,
                 captured_role: std::sync::Mutex::new(None),
                 captured_confirmation: std::sync::Mutex::new(None),
                 captured_allowlist: std::sync::Mutex::new(None),
@@ -153,82 +186,31 @@ mod tests {
         }
     }
 
-    // We can't easily use AgentSpawner directly in unit tests without a real
-    // BackendFactory, so we test AgentTool via a thin shim that bypasses
-    // AgentSpawner while exercising the same Tool trait surface.
-
-    /// A test-only AgentTool-like struct backed by a FakeSpawner.
-    struct FakeAgentTool {
-        spawner: Arc<FakeSpawner>,
-        parent_confirmation: ConfirmationMode,
-    }
-
     #[async_trait]
-    impl Tool for FakeAgentTool {
-        fn name(&self) -> &str {
-            "agent"
-        }
-        fn description(&self) -> &str {
-            "fake agent tool"
-        }
-        fn input_schema(&self) -> &Value {
-            static SCHEMA: std::sync::OnceLock<Value> = std::sync::OnceLock::new();
-            SCHEMA.get_or_init(|| serde_json::json!({"type":"object","properties":{}}))
-        }
-        fn is_write_tool(&self) -> bool {
-            true
-        }
-        async fn execute(&self, input: Value) -> Result<ToolResult, ToolError> {
-            let prompt = input["prompt"]
-                .as_str()
-                .ok_or_else(|| ToolError::InvalidInput {
-                    message: "Missing 'prompt'".to_string(),
-                })?
-                .to_string();
+    impl SubAgentSpawner for FakeSpawner {
+        async fn spawn(
+            &self,
+            role: &str,
+            confirmation: ConfirmationMode,
+            tool_allowlist: Option<&[String]>,
+            _prompt: String,
+        ) -> HeadlessOutcome {
+            *self.captured_role.lock().expect("lock") = Some(role.to_string());
+            *self.captured_confirmation.lock().expect("lock") = Some(confirmation);
+            *self.captured_allowlist.lock().expect("lock") =
+                Some(tool_allowlist.map(|l| l.to_vec()));
 
-            let role = input["role"].as_str().unwrap_or("default").to_string();
-
-            let requested_confirmation = input["confirmation"].as_str().and_then(|s| match s {
-                "Always" => Some(ConfirmationMode::Always),
-                "WriteOnly" => Some(ConfirmationMode::WriteOnly),
-                "Never" => Some(ConfirmationMode::Never),
-                _ => None,
-            });
-
-            let confirmation =
-                clamp_confirmation(&self.parent_confirmation, requested_confirmation.as_ref());
-
-            let tool_allowlist: Option<Vec<String>> = input["tools"].as_array().map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(str::to_string))
-                    .collect()
-            });
-
-            *self.spawner.captured_role.lock().expect("lock") = Some(role);
-            *self.spawner.captured_confirmation.lock().expect("lock") = Some(confirmation);
-            *self.spawner.captured_allowlist.lock().expect("lock") = Some(tool_allowlist);
-
-            let _ = prompt;
-            let outcome = &self.spawner.outcome;
-
-            if outcome.is_error {
-                Ok(ToolResult {
-                    content: vec![ContentBlock::Text(
-                        outcome
-                            .error_message
-                            .clone()
-                            .unwrap_or_else(|| "error".to_string()),
-                    )],
-                    is_error: true,
-                    agent_events: vec![],
-                })
-            } else {
-                Ok(ToolResult {
-                    content: vec![ContentBlock::Text(outcome.text.clone())],
-                    is_error: false,
-                    agent_events: vec![],
-                })
+            HeadlessOutcome {
+                text: self.outcome.text.clone(),
+                input_tokens: self.outcome.input_tokens,
+                output_tokens: self.outcome.output_tokens,
+                is_error: self.outcome.is_error,
+                error_message: self.outcome.error_message.clone(),
             }
+        }
+
+        fn parent_confirmation(&self) -> &ConfirmationMode {
+            &self.parent
         }
     }
 
@@ -237,7 +219,6 @@ mod tests {
             text: text.to_string(),
             input_tokens: 10,
             output_tokens: 5,
-            tool_call_count: 0,
             is_error: false,
             error_message: None,
         }
@@ -248,22 +229,28 @@ mod tests {
             text: String::new(),
             input_tokens: 0,
             output_tokens: 0,
-            tool_call_count: 0,
             is_error: true,
             error_message: Some(msg.to_string()),
         }
     }
 
-    fn fake_tool(outcome: HeadlessOutcome, parent: ConfirmationMode) -> FakeAgentTool {
-        FakeAgentTool {
-            spawner: FakeSpawner::new(outcome),
-            parent_confirmation: parent,
-        }
+    // ── Tests ─────────────────────────────────────────────────────────────
+
+    fn agent_tool_with_spawner(
+        outcome: HeadlessOutcome,
+        parent: ConfirmationMode,
+    ) -> (AgentTool, Arc<FakeSpawner>) {
+        let spawner = FakeSpawner::new(outcome, parent);
+        let tool = AgentTool {
+            spawner: Arc::clone(&spawner) as Arc<dyn SubAgentSpawner>,
+        };
+        (tool, spawner)
     }
 
     #[tokio::test]
     async fn agent_tool_returns_final_text_from_subagent() {
-        let tool = fake_tool(ok_outcome("sub-agent result"), ConfirmationMode::Never);
+        let (tool, _) =
+            agent_tool_with_spawner(ok_outcome("sub-agent result"), ConfirmationMode::Never);
         let input = serde_json::json!({"prompt": "do something"});
         let result = tool.execute(input).await.expect("execute should succeed");
         assert!(!result.is_error);
@@ -272,7 +259,8 @@ mod tests {
 
     #[tokio::test]
     async fn agent_tool_surfaces_backend_error_as_error_result() {
-        let tool = fake_tool(err_outcome("backend exploded"), ConfirmationMode::Never);
+        let (tool, _) =
+            agent_tool_with_spawner(err_outcome("backend exploded"), ConfirmationMode::Never);
         let input = serde_json::json!({"prompt": "do something"});
         let result = tool.execute(input).await.expect("execute should succeed");
         assert!(result.is_error);
@@ -283,11 +271,10 @@ mod tests {
 
     #[tokio::test]
     async fn agent_tool_clamps_confirmation_mode_never_requested_always_parent() {
-        let tool = fake_tool(ok_outcome("ok"), ConfirmationMode::Always);
+        let (tool, spawner) = agent_tool_with_spawner(ok_outcome("ok"), ConfirmationMode::Always);
         let input = serde_json::json!({"prompt": "do", "confirmation": "Never"});
         tool.execute(input).await.expect("ok");
-        let captured = tool
-            .spawner
+        let captured = spawner
             .captured_confirmation
             .lock()
             .expect("lock")
@@ -302,11 +289,10 @@ mod tests {
 
     #[tokio::test]
     async fn agent_tool_restricts_tools_when_allowlist_provided() {
-        let tool = fake_tool(ok_outcome("ok"), ConfirmationMode::Never);
+        let (tool, spawner) = agent_tool_with_spawner(ok_outcome("ok"), ConfirmationMode::Never);
         let input = serde_json::json!({"prompt": "do", "tools": ["bash", "search"]});
         tool.execute(input).await.expect("ok");
-        let captured = tool
-            .spawner
+        let captured = spawner
             .captured_allowlist
             .lock()
             .expect("lock")
@@ -318,11 +304,10 @@ mod tests {
 
     #[tokio::test]
     async fn agent_tool_no_tools_field_means_no_allowlist() {
-        let tool = fake_tool(ok_outcome("ok"), ConfirmationMode::Never);
+        let (tool, spawner) = agent_tool_with_spawner(ok_outcome("ok"), ConfirmationMode::Never);
         let input = serde_json::json!({"prompt": "do"});
         tool.execute(input).await.expect("ok");
-        let captured = tool
-            .spawner
+        let captured = spawner
             .captured_allowlist
             .lock()
             .expect("lock")
@@ -334,27 +319,37 @@ mod tests {
         );
     }
 
-    // ── Integration test: AgentTool creates a new session DB ──────────────
+    // ── Integration test: AgentTool creates a new session DB ─────────────
+    //
+    // Uses a real AgentSpawner wired to a fake LLM backend via
+    // `spawn_agent_with_selection`, bypassing BackendFactory auth.
 
     #[tokio::test]
     async fn agent_tool_creates_new_session_db() {
-        use crate::backend::{BackendSelection, LlmBackend};
+        use crate::agent::spawn_agent_with_selection;
+        use crate::backend::BackendSelection;
+        use crate::config::{AppConfig, ToolsConfig, VertexConfig};
+        use crate::session::Session;
+        use crate::tools::ToolRegistry;
         use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
         use anyhow::Result;
         use async_trait::async_trait;
         use futures::stream;
+        use std::collections::BTreeMap;
+        use std::sync::Arc;
+        use tokio::sync::Mutex as TokioMutex;
 
         struct ImmediateTextBackend;
 
         #[async_trait]
-        impl LlmBackend for ImmediateTextBackend {
+        impl crate::backend::LlmBackend for ImmediateTextBackend {
             async fn send_message(
                 &self,
                 _: &[Message],
                 _: &RequestConfig,
             ) -> Result<BoxStream<Result<StreamEvent>>> {
                 Ok(Box::pin(stream::iter(vec![
-                    Ok(StreamEvent::TextDelta("done".to_string())),
+                    Ok(StreamEvent::TextDelta("sub-agent done".to_string())),
                     Ok(StreamEvent::Done),
                 ])))
             }
@@ -365,7 +360,7 @@ mod tests {
 
         let app_config = Arc::new(AppConfig {
             backend: "vertex".to_string(),
-            vertex: crate::config::VertexConfig {
+            vertex: VertexConfig {
                 project: "test".to_string(),
                 region: "us-east5".to_string(),
                 model: "claude-test".to_string(),
@@ -380,29 +375,83 @@ mod tests {
             models: BTreeMap::new(),
         });
 
-        let spawner = Arc::new(AgentSpawner {
-            factory: Arc::new(crate::backend::BackendFactory::new((*app_config).clone())),
-            app_config: Arc::clone(&app_config),
-            registry_builder: Box::new(move |_session| Ok(ToolRegistry::new())),
-            parent_confirmation: ConfirmationMode::Never,
-            skills: std::collections::HashMap::new(),
+        // Spawner that wires ImmediateTextBackend bypassing real auth.
+        let dir_path_clone = dir_path.clone();
+        let app_config_clone = Arc::clone(&app_config);
+        let spawner: Arc<dyn SubAgentSpawner> = Arc::new(DirectSpawner {
+            dir_path: dir_path_clone,
+            app_config: app_config_clone,
         });
 
-        // Override factory with a fake backend via spawn_agent_with_selection directly.
-        // We do this by building a custom AgentSpawner that uses ImmediateTextBackend.
-        let dir_path2 = dir_path.clone();
-        let spawner2 = Arc::new(AgentSpawner {
-            factory: spawner.factory.clone(),
-            app_config: Arc::clone(&app_config),
-            registry_builder: Box::new(move |session_arc| {
-                let _ = session_arc;
-                Ok(ToolRegistry::new())
-            }),
-            parent_confirmation: ConfirmationMode::Never,
-            skills: std::collections::HashMap::new(),
-        });
+        struct DirectSpawner {
+            dir_path: std::path::PathBuf,
+            app_config: Arc<AppConfig>,
+        }
 
-        // Count .db files before
+        #[async_trait]
+        impl SubAgentSpawner for DirectSpawner {
+            async fn spawn(
+                &self,
+                _role: &str,
+                confirmation: ConfirmationMode,
+                _tool_allowlist: Option<&[String]>,
+                prompt: String,
+            ) -> HeadlessOutcome {
+                use crate::agent::run_headless;
+
+                let session = match Session::new(None, self.dir_path.clone()).await {
+                    Ok(s) => Arc::new(TokioMutex::new(s)),
+                    Err(e) => {
+                        return HeadlessOutcome {
+                            text: String::new(),
+                            input_tokens: 0,
+                            output_tokens: 0,
+                            is_error: true,
+                            error_message: Some(e.to_string()),
+                        };
+                    }
+                };
+
+                let tool_config = crate::config::ToolsConfig {
+                    confirmation,
+                    ..self.app_config.tools.clone()
+                };
+
+                let selection = BackendSelection {
+                    backend: Box::new(ImmediateTextBackend),
+                    model: "claude-test".to_string(),
+                };
+
+                let agent = match spawn_agent_with_selection(
+                    selection,
+                    &tool_config,
+                    session,
+                    ToolRegistry::new(),
+                )
+                .await
+                {
+                    Ok(a) => a,
+                    Err(e) => {
+                        return HeadlessOutcome {
+                            text: String::new(),
+                            input_tokens: 0,
+                            output_tokens: 0,
+                            is_error: true,
+                            error_message: Some(e.to_string()),
+                        };
+                    }
+                };
+
+                run_headless(&agent, prompt).await
+            }
+
+            fn parent_confirmation(&self) -> &ConfirmationMode {
+                &self.app_config.tools.confirmation
+            }
+        }
+
+        let tool = AgentTool { spawner };
+
         let count_before = std::fs::read_dir(&dir_path)
             .expect("read dir")
             .filter(|e| {
@@ -413,12 +462,14 @@ mod tests {
             })
             .count();
 
-        // We can't easily wire a fake backend through BackendFactory without real auth.
-        // Instead, verify that the session is created (the DB file appears) by directly
-        // calling Session::new and checking that it persists.
-        let _session = Session::new(None, dir_path.clone())
-            .await
-            .expect("create session");
+        let input = serde_json::json!({"prompt": "do something"});
+        let result = tool.execute(input).await.expect("execute should succeed");
+
+        assert!(!result.is_error, "sub-agent should complete without error");
+        assert!(
+            matches!(&result.content[0], ContentBlock::Text(t) if t == "sub-agent done"),
+            "result should contain sub-agent response text"
+        );
 
         let count_after = std::fs::read_dir(&dir_path)
             .expect("read dir")
@@ -433,7 +484,7 @@ mod tests {
         assert_eq!(
             count_after,
             count_before + 1,
-            "a new session DB should be created"
+            "AgentTool::execute must create exactly one new session DB file"
         );
     }
 }

--- a/src/tools/bash.rs
+++ b/src/tools/bash.rs
@@ -122,6 +122,7 @@ impl Tool for BashTool {
                         token
                     ))],
                     is_error: true,
+                    agent_events: vec![],
                 });
             }
         }
@@ -140,6 +141,7 @@ impl Tool for BashTool {
                         "Command rejected: user denied confirmation".to_string(),
                     )],
                     is_error: true,
+                    agent_events: vec![],
                 });
             }
         }
@@ -168,6 +170,7 @@ impl Tool for BashTool {
         Ok(ToolResult {
             content: vec![ContentBlock::Text(content)],
             is_error,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -159,6 +159,7 @@ impl Tool for EditFile {
                 validated_path
             ))],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,5 +1,6 @@
 // Tool trait and registry for extensible tool system
 
+pub mod agent;
 pub mod bash;
 pub mod edit_file;
 pub mod sandbox;
@@ -46,10 +47,13 @@ impl std::fmt::Display for ToolError {
 impl std::error::Error for ToolError {}
 
 /// Result of tool execution
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
     pub content: Vec<ContentBlock>,
     pub is_error: bool,
+    /// Additional agent-level events to forward to the event stream (e.g. SubAgentUsage).
+    #[serde(skip)]
+    pub agent_events: Vec<crate::types::AgentEvent>,
 }
 
 pub use crate::types::ToolDefinition;
@@ -130,6 +134,15 @@ impl ToolRegistry {
             })
             .collect()
     }
+
+    /// Consume this registry and return a new one containing only the tools
+    /// whose names appear in `allowlist`. Unknown names are silently skipped.
+    pub fn into_filtered(mut self, allowlist: &[String]) -> Self {
+        let allowed: std::collections::HashSet<&str> =
+            allowlist.iter().map(String::as_str).collect();
+        self.tools.retain(|name, _| allowed.contains(name.as_str()));
+        self
+    }
 }
 
 impl Default for ToolRegistry {
@@ -181,6 +194,7 @@ mod tests {
             Ok(ToolResult {
                 content: vec![ContentBlock::Text(format!("executed with: {}", input))],
                 is_error: false,
+                agent_events: vec![],
             })
         }
     }
@@ -345,6 +359,7 @@ mod tests {
         let result = ToolResult {
             content: vec![ContentBlock::Text("output".to_string())],
             is_error: false,
+            agent_events: vec![],
         };
 
         let json = serde_json::to_string(&result).expect("Should serialize");

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -136,11 +136,19 @@ impl ToolRegistry {
     }
 
     /// Consume this registry and return a new one containing only the tools
-    /// whose names appear in `allowlist`. Unknown names are silently skipped.
+    /// whose names appear in `allowlist`. Names not found in the registry are
+    /// silently skipped; a warning is printed if the result is empty.
     pub fn into_filtered(mut self, allowlist: &[String]) -> Self {
         let allowed: std::collections::HashSet<&str> =
             allowlist.iter().map(String::as_str).collect();
         self.tools.retain(|name, _| allowed.contains(name.as_str()));
+        if self.tools.is_empty() && !allowlist.is_empty() {
+            eprintln!(
+                "WARNING: agent tool allowlist [{list}] matched no registered tools; \
+                 sub-agent will run with an empty tool set",
+                list = allowlist.join(", ")
+            );
+        }
         self
     }
 }

--- a/src/tools/search.rs
+++ b/src/tools/search.rs
@@ -87,6 +87,7 @@ impl Tool for SearchTool {
             Ok(output) => Ok(ToolResult {
                 content: vec![ContentBlock::Text(output)],
                 is_error: false,
+                agent_events: vec![],
             }),
             Err(e) => Err(ToolError::Execution {
                 tool_name: "search".to_string(),

--- a/src/tools/skill.rs
+++ b/src/tools/skill.rs
@@ -66,6 +66,7 @@ impl Tool for SkillTool {
         Ok(ToolResult {
             content: vec![ContentBlock::Text(content)],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/task/create.rs
+++ b/src/tools/task/create.rs
@@ -67,6 +67,7 @@ impl Tool for CreateTaskTool {
         Ok(ToolResult {
             content: vec![ContentBlock::Text(format!("Created task with id {}", id))],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/task/delete.rs
+++ b/src/tools/task/delete.rs
@@ -71,6 +71,7 @@ impl Tool for DeleteTaskTool {
         Ok(ToolResult {
             content: vec![ContentBlock::Text(format!("Deleted task {}", id))],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/task/list.rs
+++ b/src/tools/task/list.rs
@@ -76,6 +76,7 @@ impl Tool for ListTasksTool {
         Ok(ToolResult {
             content: vec![ContentBlock::Text(output)],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/task/update.rs
+++ b/src/tools/task/update.rs
@@ -106,6 +106,7 @@ impl Tool for UpdateTaskTool {
         Ok(ToolResult {
             content: vec![ContentBlock::Text(format!("Updated task {}", id))],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -124,6 +124,7 @@ impl Tool for WriteFileTool {
                 bytes, validated
             ))],
             is_error: false,
+            agent_events: vec![],
         })
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -254,6 +254,11 @@ pub enum AgentEvent {
         output_tokens: u32,
         stop_reason: String,
     },
+    SubAgentUsage {
+        input_tokens: u32,
+        output_tokens: u32,
+        role: String,
+    },
 }
 
 /// A pinned, boxed stream type alias for convenience


### PR DESCRIPTION
Closes #144

Adds a new `agent` tool that lets the LLM spawn an independent sub-agent with its own session, model, and tool set. Parent configures backend role, permissions (clamped, never elevated), and optional tool allowlist. Sub-agent token usage propagates to the TUI status line.

Implementation plan posted as a comment below.