### PR TITLE
Delete empty session on exit (issue 139)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ async fn main() -> Result<()> {
         log.flush()?;
     }
 
-    match mode {
+    let frontend_result = match mode {
         Mode::SingleShot {
             prompt,
             json_schema,
@@ -206,15 +206,21 @@ async fn main() -> Result<()> {
                 max_schema_retries,
                 logger.as_mut(),
             )
-            .await?;
+            .await
         }
         Mode::Repl { initial_prompt } => {
-            frontend::tui::run(agent.clone(), initial_prompt, logger, &app_config).await?;
+            frontend::tui::run(agent.clone(), initial_prompt, logger, &app_config).await
+        }
+    };
+
+    if let Err(e) = agent.cleanup_empty_session().await {
+        if cli.debug {
+            eprintln!("cleanup_empty_session failed: {e}");
         }
     }
 
     eprintln!("Session ID: {}", agent.session_id().await);
-    Ok(())
+    frontend_result
 }
 
 /// Build a `ToolRegistry` with the standard tool set.

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,10 +213,10 @@ async fn main() -> Result<()> {
         }
     };
 
-    if let Err(e) = agent.cleanup_empty_session().await {
-        if cli.debug {
-            eprintln!("cleanup_empty_session failed: {e}");
-        }
+    if let Err(e) = agent.cleanup_empty_session().await
+        && cli.debug
+    {
+        eprintln!("cleanup_empty_session failed: {e}");
     }
 
     eprintln!("Session ID: {}", agent.session_id().await);

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -161,3 +161,58 @@ async fn test_agent_backend_error_emits_error_event() {
         other => panic!("Expected Error, got {:?}", other),
     }
 }
+
+#[tokio::test]
+async fn cleanup_empty_session_integration_deletes_db_on_exit_with_no_messages() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let dir_path = dir.keep();
+
+    let session = Session::new(None, dir_path.clone()).await.expect("session");
+    let db_path = dir_path.join(format!("{}.db", session.id));
+    assert!(db_path.exists());
+
+    let config = RequestConfig {
+        model: "test".to_string(),
+        max_tokens: 100,
+        tools: vec![],
+    };
+    let agent = Agent::new(
+        Box::new(MockBackend::new(vec![])),
+        config,
+        Arc::new(TokioMutex::new(session)),
+    )
+    .await;
+
+    agent.cleanup_empty_session().await.expect("cleanup");
+    assert!(!db_path.exists());
+}
+
+#[tokio::test]
+async fn cleanup_empty_session_integration_retains_db_when_messages_exist() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let dir_path = dir.keep();
+
+    let session = Session::new(None, dir_path.clone()).await.expect("session");
+    session
+        .conversation()
+        .insert_message(&Message::text(Role::User, "hello".to_string()))
+        .await
+        .expect("insert");
+    let db_path = dir_path.join(format!("{}.db", session.id));
+    assert!(db_path.exists());
+
+    let config = RequestConfig {
+        model: "test".to_string(),
+        max_tokens: 100,
+        tools: vec![],
+    };
+    let agent = Agent::new(
+        Box::new(MockBackend::new(vec![])),
+        config,
+        Arc::new(TokioMutex::new(session)),
+    )
+    .await;
+
+    agent.cleanup_empty_session().await.expect("cleanup");
+    assert!(db_path.exists());
+}


### PR DESCRIPTION
Closes #139

Delete the per-session SQLite DB on app exit when no messages were ever persisted, covering all exit paths uniformly (TUI Ctrl-C, picker Close, single-shot completion, error returns) — not just the existing session-switch path.

Implementation plan posted as a comment below.
