### PR TITLE
Checkpoint session WAL on exit

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -156,6 +156,10 @@ impl Agent {
             .await
     }
 
+    pub async fn checkpoint_session(&self) -> Result<()> {
+        self.session.lock().await.checkpoint().await
+    }
+
     /// If the current session has no messages, delete its DB file from disk.
     pub async fn cleanup_empty_session(&self) -> Result<()> {
         let session = self.session.lock().await;
@@ -185,7 +189,9 @@ impl Agent {
             *history = prefix;
             history.extend(new_history);
         }
-        *self.session.lock().await = session;
+        let mut session_guard = self.session.lock().await;
+        let _ = session_guard.checkpoint().await;
+        *session_guard = session;
     }
 
     pub fn load_context_files(&self, files: Vec<ContextFile>) {
@@ -784,7 +790,9 @@ impl AgentSpawner {
         };
 
         let agent = agent.with_skills(&self.skills);
-        run_headless(&agent, prompt).await
+        let outcome = run_headless(&agent, prompt).await;
+        let _ = agent.checkpoint_session().await;
+        outcome
     }
 }
 
@@ -1878,6 +1886,35 @@ mod tests {
 
         agent.cleanup_empty_session().await.expect("cleanup");
         assert!(!db_path.exists());
+    }
+
+    #[tokio::test]
+    async fn cleanup_empty_session_still_works_after_checkpoint() {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let dir_path = dir.keep();
+
+        let session = Session::new(None, dir_path.clone()).await.expect("session");
+        let db_path = dir_path.join(format!("{}.db", session.id));
+        assert!(db_path.exists());
+
+        let config = RequestConfig {
+            model: "test".to_string(),
+            max_tokens: 100,
+            tools: vec![],
+        };
+        let agent = Agent::new(
+            Box::new(SequencedBackend::new(vec![])),
+            config,
+            Arc::new(TokioMutex::new(session)),
+        )
+        .await;
+
+        agent.checkpoint_session().await.expect("checkpoint");
+        agent.cleanup_empty_session().await.expect("cleanup");
+        assert!(
+            !db_path.exists(),
+            "empty session must be deleted even after checkpoint"
+        );
     }
 
     #[tokio::test]

--- a/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__status_line__tests__render_status_line_with_subagent_usage.snap
+++ b/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__status_line__tests__render_status_line_with_subagent_usage.snap
@@ -1,0 +1,5 @@
+---
+source: src/frontend/tui/status_line.rs
+expression: terminal.backend()
+---
+" ↑5.0k ↓1.0k   main  ↗↑2.0k ↓500   claude-sonnet-4-20250514  /home/user/project "

--- a/src/frontend/tui/status_line.rs
+++ b/src/frontend/tui/status_line.rs
@@ -27,6 +27,7 @@ pub struct StatusLineInfo<'a> {
     pub git_branch: Option<&'a str>,
     pub working_dir: &'a std::path::Path,
     pub usage: &'a TokenUsage,
+    pub subagent_usage: Option<&'a TokenUsage>,
 }
 
 /// Estimate token counts from a slice of conversation messages.
@@ -102,7 +103,18 @@ pub fn build_status_line(info: &StatusLineInfo<'_>, width: u16) -> Line<'static>
     let branch_str = info.git_branch.unwrap_or("no git");
     let dir_str = compact_path(info.working_dir);
 
-    let left_spans = vec![
+    let subagent_span: Option<Span<'static>> = info.subagent_usage.and_then(|su| {
+        if su.input_tokens == 0 && su.output_tokens == 0 {
+            return None;
+        }
+        let su_str = format!("↗{}", format_token_usage(su));
+        Some(Span::styled(
+            format!(" {su_str} "),
+            Style::default().fg(Color::Green).bg(STATUS_BG),
+        ))
+    });
+
+    let mut left_spans = vec![
         Span::styled(
             format!(" {usage_str} "),
             Style::default().fg(Color::White).bg(STATUS_BG),
@@ -124,9 +136,19 @@ pub fn build_status_line(info: &StatusLineInfo<'_>, width: u16) -> Line<'static>
         ),
     ];
 
-    let left_width: usize = left_spans.iter().map(|s| s.width()).sum();
+    let base_left_width: usize = left_spans.iter().map(|s| s.width()).sum();
     let right_width: usize = right_spans.iter().map(|s| s.width()).sum();
     let total_width = width as usize;
+
+    // Include subagent block only when there is room for it.
+    if let Some(ref su_span) = subagent_span {
+        let su_width = su_span.width();
+        if base_left_width + su_width + right_width <= total_width {
+            left_spans.push(su_span.clone());
+        }
+    }
+
+    let left_width: usize = left_spans.iter().map(|s| s.width()).sum();
     let gap = total_width.saturating_sub(left_width + right_width);
 
     let mut spans = left_spans;
@@ -183,6 +205,23 @@ mod tests {
             git_branch,
             working_dir,
             usage,
+            subagent_usage: None,
+        }
+    }
+
+    fn make_info_with_subagent<'a>(
+        model: &'a str,
+        git_branch: Option<&'a str>,
+        working_dir: &'a std::path::Path,
+        usage: &'a TokenUsage,
+        subagent_usage: Option<&'a TokenUsage>,
+    ) -> StatusLineInfo<'a> {
+        StatusLineInfo {
+            model,
+            git_branch,
+            working_dir,
+            usage,
+            subagent_usage,
         }
     }
 
@@ -471,5 +510,119 @@ mod tests {
         let (input, output) = estimate_usage_from_messages(&messages);
         assert_eq!(input, 10, "40 chars / 4 = 10 input tokens");
         assert_eq!(output, 0);
+    }
+
+    #[test]
+    fn build_status_line_with_subagent_usage() {
+        let (model, branch, dir, mut usage) = test_info();
+        usage.add(5000, 1000);
+        let mut subagent_usage = TokenUsage::default();
+        subagent_usage.add(2000, 500);
+        let info = make_info_with_subagent(
+            &model,
+            branch.as_deref(),
+            &dir,
+            &usage,
+            Some(&subagent_usage),
+        );
+        let line = build_status_line(&info, 160);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(text.contains('↗'), "should contain subagent prefix");
+        assert!(
+            text.contains("↑2.0k"),
+            "should contain subagent input count"
+        );
+        assert!(
+            text.contains("↓500"),
+            "should contain subagent output count"
+        );
+        let green_span = line.spans.iter().find(|s| s.style.fg == Some(Color::Green));
+        assert!(
+            green_span.is_some(),
+            "subagent block should be Color::Green"
+        );
+    }
+
+    #[test]
+    fn build_status_line_without_subagent_usage() {
+        let (model, branch, dir, mut usage) = test_info();
+        usage.add(5000, 1000);
+        let info = make_info(&model, branch.as_deref(), &dir, &usage);
+        let line = build_status_line(&info, 120);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(!text.contains('↗'), "no subagent block when None");
+    }
+
+    #[test]
+    fn build_status_line_subagent_usage_with_zero_tokens() {
+        let (model, branch, dir, usage) = test_info();
+        let zero_subagent = TokenUsage::default();
+        let info = make_info_with_subagent(
+            &model,
+            branch.as_deref(),
+            &dir,
+            &usage,
+            Some(&zero_subagent),
+        );
+        let line = build_status_line(&info, 120);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            !text.contains('↗'),
+            "zero subagent tokens should not render a block"
+        );
+    }
+
+    #[test]
+    fn render_status_line_with_subagent_usage_snapshot() {
+        let model = "claude-sonnet-4-20250514".to_string();
+        let branch = Some("main".to_string());
+        let dir = PathBuf::from("/home/user/project");
+        let mut usage = TokenUsage::default();
+        usage.add(5000, 1000);
+        let mut subagent_usage = TokenUsage::default();
+        subagent_usage.add(2000, 500);
+        let info = make_info_with_subagent(
+            &model,
+            branch.as_deref(),
+            &dir,
+            &usage,
+            Some(&subagent_usage),
+        );
+
+        let backend = ratatui::backend::TestBackend::new(80, 1);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
+        terminal
+            .draw(|frame| {
+                let area = ratatui::layout::Rect::new(0, 0, 80, 1);
+                render_status_line(&info, frame, area);
+            })
+            .expect("draw");
+
+        insta::assert_snapshot!("render_status_line_with_subagent_usage", terminal.backend());
+    }
+
+    #[test]
+    fn build_status_line_narrow_omits_subagent_first() {
+        let (model, branch, dir, mut usage) = test_info();
+        usage.add(5000, 1000);
+        let mut subagent_usage = TokenUsage::default();
+        subagent_usage.add(2000, 500);
+        let info = make_info_with_subagent(
+            &model,
+            branch.as_deref(),
+            &dir,
+            &usage,
+            Some(&subagent_usage),
+        );
+        let line = build_status_line(&info, 40);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            !text.contains('↗'),
+            "at narrow width, subagent block should be omitted first"
+        );
+        assert!(
+            text.contains('↑'),
+            "parent token block should still be present"
+        );
     }
 }

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -52,6 +52,7 @@ pub struct App {
     pub text_width: u16,
     pub session_picker: Option<SessionPicker>,
     pub usage: TokenUsage,
+    pub subagent_usage: TokenUsage,
     /// The input_tokens value reported by the last Usage event. The API always
     /// reports the full context size, so we subtract the previous value to
     /// count only the newly added (non-cached) input tokens per turn.
@@ -90,6 +91,7 @@ impl App {
             text_width: 0,
             session_picker: None,
             usage: TokenUsage::default(),
+            subagent_usage: TokenUsage::default(),
             last_input_total: 0,
             model: String::new(),
             git_branch: None,
@@ -333,6 +335,7 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
         git_branch: app.git_branch.as_deref(),
         working_dir: &app.working_dir,
         usage: &app.usage,
+        subagent_usage: Some(&app.subagent_usage),
     };
     status_line::render_status_line(&info, frame, chunks[2]);
 
@@ -442,7 +445,7 @@ pub fn handle_agent_event(
             output_tokens,
             ..
         } => {
-            app.usage.add(input_tokens, output_tokens);
+            app.subagent_usage.add(input_tokens, output_tokens);
         }
     }
     Ok(())
@@ -571,6 +574,8 @@ async fn run_app(
                                     SessionPickerAction::Select(session_id) => {
                                         app.session_picker = None;
                                         app.set_state(AppState::Input);
+                                        // Checkpoint current session before switching
+                                        let _ = agent.checkpoint_session().await;
                                         // Clean up current session if empty
                                         if let Err(e) = agent.cleanup_empty_session().await {
                                             app.conversation.push(ConversationEntry::new(
@@ -592,6 +597,7 @@ async fn run_app(
                                                         app.current_response.clear();
                                                         app.scroll_offset = 0;
                                                         app.usage = TokenUsage::default();
+                                                        app.subagent_usage = TokenUsage::default();
                                                         app.last_input_total = 0;
                                                         app.load_history(&history);
                                                         agent.load_session(session).await;
@@ -1013,8 +1019,8 @@ mod tests {
     #[test]
     fn subagent_usage_event_aggregates_into_app_usage() {
         let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
-        assert_eq!(app.usage.input_tokens, 0);
-        assert_eq!(app.usage.output_tokens, 0);
+        assert_eq!(app.subagent_usage.input_tokens, 0);
+        assert_eq!(app.subagent_usage.output_tokens, 0);
 
         let event = AgentEvent::SubAgentUsage {
             input_tokens: 200,
@@ -1023,9 +1029,10 @@ mod tests {
         };
         handle_agent_event(&mut app, event, None).expect("handle SubAgentUsage");
 
-        assert_eq!(app.usage.input_tokens, 200);
-        assert_eq!(app.usage.output_tokens, 80);
-        // SubAgentUsage does not update last_input_total (no deduplication logic needed)
+        assert_eq!(app.subagent_usage.input_tokens, 200);
+        assert_eq!(app.subagent_usage.output_tokens, 80);
+        // SubAgentUsage does not update usage or last_input_total
+        assert_eq!(app.usage.input_tokens, 0);
         assert_eq!(app.last_input_total, 0);
 
         // A subsequent SubAgentUsage should add on top.
@@ -1036,8 +1043,8 @@ mod tests {
         };
         handle_agent_event(&mut app, event2, None).expect("handle second SubAgentUsage");
 
-        assert_eq!(app.usage.input_tokens, 250);
-        assert_eq!(app.usage.output_tokens, 110);
+        assert_eq!(app.subagent_usage.input_tokens, 250);
+        assert_eq!(app.subagent_usage.output_tokens, 110);
     }
 
     #[test]
@@ -1871,5 +1878,65 @@ mod tests {
             "claude-original",
             "model should be unchanged for blank input"
         );
+    }
+
+    #[test]
+    fn subagent_usage_event_only_increments_subagent_usage() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        let event = AgentEvent::SubAgentUsage {
+            input_tokens: 300,
+            output_tokens: 120,
+            role: "default".to_string(),
+        };
+        handle_agent_event(&mut app, event, None).expect("handle SubAgentUsage");
+
+        assert_eq!(app.subagent_usage.input_tokens, 300);
+        assert_eq!(app.subagent_usage.output_tokens, 120);
+        assert_eq!(
+            app.usage.input_tokens, 0,
+            "parent usage must not be touched"
+        );
+        assert_eq!(
+            app.usage.output_tokens, 0,
+            "parent usage must not be touched"
+        );
+    }
+
+    #[test]
+    fn usage_event_does_not_increment_subagent_usage() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        let event = AgentEvent::Usage {
+            input_tokens: 200,
+            output_tokens: 80,
+            stop_reason: "end_turn".to_string(),
+        };
+        handle_agent_event(&mut app, event, None).expect("handle Usage");
+
+        assert_eq!(
+            app.subagent_usage.input_tokens, 0,
+            "subagent_usage must stay zero after regular Usage"
+        );
+        assert_eq!(app.subagent_usage.output_tokens, 0);
+        assert_eq!(app.usage.input_tokens, 200);
+    }
+
+    #[test]
+    fn session_switch_resets_subagent_usage() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        app.subagent_usage.add(500, 200);
+        assert_eq!(app.subagent_usage.input_tokens, 500);
+
+        // Simulate what the session-switch code path does
+        app.usage = TokenUsage::default();
+        app.subagent_usage = TokenUsage::default();
+        app.last_input_total = 0;
+
+        assert_eq!(
+            app.subagent_usage.input_tokens, 0,
+            "subagent_usage should reset to zero on session switch"
+        );
+        assert_eq!(app.subagent_usage.output_tokens, 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,6 +213,12 @@ async fn main() -> Result<()> {
         }
     };
 
+    if let Err(e) = agent.checkpoint_session().await
+        && cli.debug
+    {
+        eprintln!("checkpoint_session failed: {e}");
+    }
+
     if let Err(e) = agent.cleanup_empty_session().await
         && cli.debug
     {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -142,6 +142,14 @@ impl Session {
         TaskRepo::new(self)
     }
 
+    pub async fn checkpoint(&self) -> Result<()> {
+        self.conn
+            .query("PRAGMA wal_checkpoint(TRUNCATE)", ())
+            .await
+            .context("Failed to checkpoint WAL")?;
+        Ok(())
+    }
+
     pub fn delete_db(&self) -> Result<()> {
         for suffix in ["", "-wal", "-shm"] {
             let path = if suffix.is_empty() {
@@ -601,6 +609,100 @@ mod tests {
             .await
             .expect("create");
         session.delete_db().expect("delete_db");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_is_noop_on_empty_session() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        session
+            .checkpoint()
+            .await
+            .expect("checkpoint should not error on empty session");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_flushes_wal_making_db_self_contained() {
+        let dir = TempDir::new().expect("temp dir");
+        let dir_path = dir.path().to_path_buf();
+
+        let session = Session::new(None, dir_path.clone()).await.expect("create");
+        let db_path = dir_path.join(format!("{}.db", session.id));
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "hello checkpoint".to_string()))
+            .await
+            .expect("insert");
+
+        session.checkpoint().await.expect("checkpoint");
+
+        // Open the .db with a fresh connection and verify rows are readable.
+        // This is the core requirement: data persisted by checkpoint must be
+        // accessible to any new reader of the .db file.
+        let db2 = turso::Builder::new_local(db_path.to_string_lossy().as_ref())
+            .build()
+            .await
+            .expect("open fresh db");
+        let conn2 = db2.connect().expect("connect fresh");
+        let session2 = Session {
+            id: session.id.clone(),
+            conn: conn2,
+            db_path: db_path.clone(),
+        };
+        let history = session2
+            .conversation()
+            .load_history()
+            .await
+            .expect("load history from fresh connection");
+        assert_eq!(
+            history.len(),
+            1,
+            "data must be visible from fresh connection after checkpoint"
+        );
+        match &history[0].content[0] {
+            ContentBlock::Text(t) => assert_eq!(t, "hello checkpoint"),
+            _ => panic!("expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_does_not_corrupt_data() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "first".to_string()))
+            .await
+            .expect("insert 1");
+        session.checkpoint().await.expect("checkpoint 1");
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::Assistant, "second".to_string()))
+            .await
+            .expect("insert 2");
+        session.checkpoint().await.expect("checkpoint 2");
+
+        let history = session.conversation().load_history().await.expect("load");
+        assert_eq!(
+            history.len(),
+            2,
+            "both messages must survive two checkpoints"
+        );
+        match &history[0].content[0] {
+            ContentBlock::Text(t) => assert_eq!(t, "first"),
+            _ => panic!("expected text"),
+        }
+        match &history[1].content[0] {
+            ContentBlock::Text(t) => assert_eq!(t, "second"),
+            _ => panic!("expected text"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #149

Run `PRAGMA wal_checkpoint(TRUNCATE)` on graceful exit, session switch, and after sub-agent completion so the `.db` file is self-contained without the `-wal` sidecar.

Implementation plan posted as a comment below.
