### PR TITLE
Checkpoint session WAL on exit so the .db is self-contained

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -156,6 +156,14 @@ impl Agent {
             .await
     }
 
+    /// Checkpoint the WAL of the current session into the main DB file.
+    ///
+    /// Errors are returned but callers are expected to log and swallow them so
+    /// the frontend's `Result` is preserved.
+    pub async fn checkpoint_session(&self) -> Result<()> {
+        self.session.lock().await.checkpoint().await
+    }
+
     /// If the current session has no messages, delete its DB file from disk.
     pub async fn cleanup_empty_session(&self) -> Result<()> {
         let session = self.session.lock().await;

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -571,6 +571,13 @@ async fn run_app(
                                     SessionPickerAction::Select(session_id) => {
                                         app.session_picker = None;
                                         app.set_state(AppState::Input);
+                                        // Checkpoint current session WAL before switching
+                                        if let Err(e) = agent.checkpoint_session().await {
+                                            app.conversation.push(ConversationEntry::new(
+                                                ConversationRole::Error,
+                                                format!("Failed to checkpoint session: {e}"),
+                                            ));
+                                        }
                                         // Clean up current session if empty
                                         if let Err(e) = agent.cleanup_empty_session().await {
                                             app.conversation.push(ConversationEntry::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,9 +213,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    if let Err(e) = agent.checkpoint_session().await
-        && cli.debug
-    {
+    if let Err(e) = agent.checkpoint_session().await {
         eprintln!("checkpoint_session failed: {e}");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,6 +213,12 @@ async fn main() -> Result<()> {
         }
     };
 
+    if let Err(e) = agent.checkpoint_session().await
+        && cli.debug
+    {
+        eprintln!("checkpoint_session failed: {e}");
+    }
+
     if let Err(e) = agent.cleanup_empty_session().await
         && cli.debug
     {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -142,6 +142,20 @@ impl Session {
         TaskRepo::new(self)
     }
 
+    /// Checkpoint the WAL into the main DB file and truncate the WAL sidecar.
+    ///
+    /// Must be called before dropping the session when a clean, self-contained `.db`
+    /// is required (e.g. on graceful exit or session switch).
+    pub async fn checkpoint(&self) -> Result<()> {
+        let mut rows = self
+            .conn
+            .query("PRAGMA wal_checkpoint(TRUNCATE)", ())
+            .await
+            .context("Failed to execute wal_checkpoint pragma")?;
+        while rows.next().await?.is_some() {}
+        Ok(())
+    }
+
     pub fn delete_db(&self) -> Result<()> {
         for suffix in ["", "-wal", "-shm"] {
             let path = if suffix.is_empty() {
@@ -562,6 +576,76 @@ mod tests {
             .await
             .expect("insert");
         assert!(!session.conversation().is_empty().await.expect("is_empty"));
+    }
+
+    #[tokio::test]
+    async fn checkpoint_succeeds_on_empty_session() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        session.checkpoint().await.expect("checkpoint");
+    }
+
+    #[tokio::test]
+    async fn checkpoint_consolidates_wal_into_main_db_file() {
+        let dir = TempDir::new().expect("temp dir");
+        let id = uuid::Uuid::now_v7().to_string();
+
+        {
+            let session = Session::new(Some(id.clone()), dir.path().to_path_buf())
+                .await
+                .expect("create");
+            session
+                .conversation()
+                .insert_message(&Message::text(Role::User, "persisted via wal".to_string()))
+                .await
+                .expect("insert");
+            session.checkpoint().await.expect("checkpoint");
+        }
+
+        // Remove sidecar files so the next open sees only the main .db.
+        let wal = dir.path().join(format!("{id}.db-wal"));
+        let shm = dir.path().join(format!("{id}.db-shm"));
+        if wal.exists() {
+            std::fs::remove_file(&wal).expect("remove wal");
+        }
+        if shm.exists() {
+            std::fs::remove_file(&shm).expect("remove shm");
+        }
+
+        let session = Session::new(Some(id), dir.path().to_path_buf())
+            .await
+            .expect("reopen");
+        let history = session.conversation().load_history().await.expect("load");
+        assert_eq!(history.len(), 1);
+        match &history[0].content[0] {
+            ContentBlock::Text(t) => assert_eq!(t, "persisted via wal"),
+            _ => panic!("expected text block"),
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_leaves_wal_file_zero_length_or_absent() {
+        let dir = TempDir::new().expect("temp dir");
+        let session = Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create");
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "hello".to_string()))
+            .await
+            .expect("insert");
+        session.checkpoint().await.expect("checkpoint");
+
+        let wal_path = dir.path().join(format!("{}.db-wal", session.id));
+        if wal_path.exists() {
+            assert_eq!(
+                std::fs::metadata(&wal_path).expect("metadata").len(),
+                0,
+                "WAL should be zero-length after checkpoint"
+            );
+        }
     }
 
     #[tokio::test]

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -216,3 +216,54 @@ async fn cleanup_empty_session_integration_retains_db_when_messages_exist() {
     agent.cleanup_empty_session().await.expect("cleanup");
     assert!(db_path.exists());
 }
+
+#[tokio::test]
+async fn agent_checkpoint_session_persists_messages_to_main_db() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let dir_path = dir.keep();
+
+    let id = uuid::Uuid::now_v7().to_string();
+    let session = Session::new(Some(id.clone()), dir_path.clone())
+        .await
+        .expect("session");
+    session
+        .conversation()
+        .insert_message(&Message::text(Role::User, "regression message".to_string()))
+        .await
+        .expect("insert");
+
+    let db_path = dir_path.join(format!("{id}.db"));
+    let config = RequestConfig {
+        model: "test".to_string(),
+        max_tokens: 100,
+        tools: vec![],
+    };
+    let agent = Agent::new(
+        Box::new(MockBackend::new(vec![])),
+        config,
+        Arc::new(TokioMutex::new(session)),
+    )
+    .await;
+
+    agent.checkpoint_session().await.expect("checkpoint");
+
+    // Drop agent (and therefore the connection) before removing sidecars.
+    drop(agent);
+
+    let wal = dir_path.join(format!("{id}.db-wal"));
+    let shm = dir_path.join(format!("{id}.db-shm"));
+    if wal.exists() {
+        std::fs::remove_file(&wal).expect("remove wal");
+    }
+    if shm.exists() {
+        std::fs::remove_file(&shm).expect("remove shm");
+    }
+
+    // Reopen DB with no WAL — messages must be in the main file.
+    let session2 = Session::new(Some(id), dir_path.clone())
+        .await
+        .expect("reopen");
+    let history = session2.conversation().load_history().await.expect("load");
+    assert_eq!(history.len(), 1);
+    assert!(db_path.exists());
+}


### PR DESCRIPTION
Closes #149

Checkpoint the session WAL on graceful exit (and on TUI session-switch) so the `.db` file is self-contained and `-wal` is empty/absent. Eliminates the "empty database" surprise when copying or inspecting a session DB out of `sessions_dir`.

Implementation plan posted as a comment below.
