### PR TITLE
Add separate subagent token counter to status line

### DIFF
--- a/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__status_line__tests__render_status_line_with_subagent_usage.snap
+++ b/src/frontend/tui/snapshots/illustrious_manager__frontend__tui__status_line__tests__render_status_line_with_subagent_usage.snap
@@ -1,0 +1,5 @@
+---
+source: src/frontend/tui/status_line.rs
+expression: terminal.backend()
+---
+" ↑12.5k ↓3.2k  ↗↑4.0k ↓800   main                                          claude-sonnet-4-20250514  /home/user/project "

--- a/src/frontend/tui/status_line.rs
+++ b/src/frontend/tui/status_line.rs
@@ -142,7 +142,6 @@ pub fn build_status_line(info: &StatusLineInfo<'_>, width: u16) -> Line<'static>
     let right_width: usize = right_spans.iter().map(|s| s.width()).sum();
     let total_width = width as usize;
 
-    // Determine whether the subagent span fits.
     let include_subagent = if let Some(ref sub_span) = subagent_span {
         let left_width_with = parent_span.width() + sub_span.width() + branch_span.width();
         left_width_with + right_width <= total_width

--- a/src/frontend/tui/status_line.rs
+++ b/src/frontend/tui/status_line.rs
@@ -27,6 +27,7 @@ pub struct StatusLineInfo<'a> {
     pub git_branch: Option<&'a str>,
     pub working_dir: &'a std::path::Path,
     pub usage: &'a TokenUsage,
+    pub subagent_usage: Option<&'a TokenUsage>,
 }
 
 /// Estimate token counts from a slice of conversation messages.
@@ -102,16 +103,30 @@ pub fn build_status_line(info: &StatusLineInfo<'_>, width: u16) -> Line<'static>
     let branch_str = info.git_branch.unwrap_or("no git");
     let dir_str = compact_path(info.working_dir);
 
-    let left_spans = vec![
-        Span::styled(
-            format!(" {usage_str} "),
-            Style::default().fg(Color::White).bg(STATUS_BG),
-        ),
-        Span::styled(
-            format!("  {branch_str} "),
-            Style::default().fg(Color::Cyan).bg(STATUS_BG),
-        ),
-    ];
+    let subagent_span: Option<Span<'static>> = info.subagent_usage.and_then(|su| {
+        if su.input_tokens + su.output_tokens > 0 {
+            let s = format!(
+                " ↗↑{} ↓{} ",
+                format_token_count(su.input_tokens),
+                format_token_count(su.output_tokens)
+            );
+            Some(Span::styled(
+                s,
+                Style::default().fg(Color::Green).bg(STATUS_BG),
+            ))
+        } else {
+            None
+        }
+    });
+
+    let parent_span = Span::styled(
+        format!(" {usage_str} "),
+        Style::default().fg(Color::White).bg(STATUS_BG),
+    );
+    let branch_span = Span::styled(
+        format!("  {branch_str} "),
+        Style::default().fg(Color::Cyan).bg(STATUS_BG),
+    );
 
     let right_spans = vec![
         Span::styled(
@@ -124,9 +139,24 @@ pub fn build_status_line(info: &StatusLineInfo<'_>, width: u16) -> Line<'static>
         ),
     ];
 
-    let left_width: usize = left_spans.iter().map(|s| s.width()).sum();
     let right_width: usize = right_spans.iter().map(|s| s.width()).sum();
     let total_width = width as usize;
+
+    // Determine whether the subagent span fits.
+    let include_subagent = if let Some(ref sub_span) = subagent_span {
+        let left_width_with = parent_span.width() + sub_span.width() + branch_span.width();
+        left_width_with + right_width <= total_width
+    } else {
+        false
+    };
+
+    let mut left_spans = vec![parent_span];
+    if include_subagent {
+        left_spans.push(subagent_span.expect("checked above"));
+    }
+    left_spans.push(branch_span);
+
+    let left_width: usize = left_spans.iter().map(|s| s.width()).sum();
     let gap = total_width.saturating_sub(left_width + right_width);
 
     let mut spans = left_spans;
@@ -183,6 +213,7 @@ mod tests {
             git_branch,
             working_dir,
             usage,
+            subagent_usage: None,
         }
     }
 
@@ -471,5 +502,120 @@ mod tests {
         let (input, output) = estimate_usage_from_messages(&messages);
         assert_eq!(input, 10, "40 chars / 4 = 10 input tokens");
         assert_eq!(output, 0);
+    }
+
+    #[test]
+    fn build_status_line_with_subagent_usage_zero_omits_span() {
+        let (model, branch, dir, usage) = test_info();
+        let subagent_zero = TokenUsage::default();
+        let info = StatusLineInfo {
+            model: &model,
+            git_branch: branch.as_deref(),
+            working_dir: &dir,
+            usage: &usage,
+            subagent_usage: Some(&subagent_zero),
+        };
+        let line = build_status_line(&info, 120);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            !text.contains('↗'),
+            "zero subagent usage should not render ↗ glyph"
+        );
+    }
+
+    #[test]
+    fn build_status_line_with_subagent_usage_renders_green_span() {
+        let (model, branch, dir, usage) = test_info();
+        let subagent = TokenUsage {
+            input_tokens: 300,
+            output_tokens: 120,
+            ..Default::default()
+        };
+        let info = StatusLineInfo {
+            model: &model,
+            git_branch: branch.as_deref(),
+            working_dir: &dir,
+            usage: &usage,
+            subagent_usage: Some(&subagent),
+        };
+        let line = build_status_line(&info, 120);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            text.contains('↗'),
+            "non-zero subagent usage should render ↗ glyph"
+        );
+        assert!(text.contains("↑300"), "should show subagent input tokens");
+        assert!(text.contains("↓120"), "should show subagent output tokens");
+
+        // The subagent span must be Color::Green
+        let green_span = line.spans.iter().find(|s| s.content.contains('↗'));
+        assert!(green_span.is_some(), "should find the ↗ span");
+        assert_eq!(
+            green_span.expect("checked").style.fg,
+            Some(Color::Green),
+            "subagent span should be green"
+        );
+    }
+
+    #[test]
+    fn build_status_line_subagent_span_dropped_on_narrow_terminal() {
+        let (model, branch, dir, usage) = test_info();
+        let subagent = TokenUsage {
+            input_tokens: 300,
+            output_tokens: 120,
+            ..Default::default()
+        };
+        let info = StatusLineInfo {
+            model: &model,
+            git_branch: branch.as_deref(),
+            working_dir: &dir,
+            usage: &usage,
+            subagent_usage: Some(&subagent),
+        };
+        // Use a very narrow width where the subagent span won't fit
+        let line = build_status_line(&info, 30);
+        let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
+        assert!(
+            !text.contains('↗'),
+            "subagent span should be dropped on narrow terminal (width=30)"
+        );
+        // Parent counter must still be present
+        assert!(text.contains('↑'), "parent counter must not be dropped");
+    }
+
+    #[test]
+    fn render_status_line_with_subagent_usage_snapshot() {
+        use std::path::PathBuf;
+        let model = "claude-sonnet-4-20250514".to_string();
+        let branch = Some("main".to_string());
+        let dir = PathBuf::from("/home/user/project");
+        let usage = TokenUsage {
+            input_tokens: 12500,
+            output_tokens: 3200,
+            ..Default::default()
+        };
+        let subagent = TokenUsage {
+            input_tokens: 4000,
+            output_tokens: 800,
+            ..Default::default()
+        };
+        let info = StatusLineInfo {
+            model: &model,
+            git_branch: branch.as_deref(),
+            working_dir: &dir,
+            usage: &usage,
+            subagent_usage: Some(&subagent),
+        };
+
+        let backend = ratatui::backend::TestBackend::new(120, 1);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
+        terminal
+            .draw(|frame| {
+                let area = ratatui::layout::Rect::new(0, 0, 120, 1);
+                render_status_line(&info, frame, area);
+            })
+            .expect("draw");
+
+        insta::assert_snapshot!("render_status_line_with_subagent_usage", terminal.backend());
     }
 }

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -52,6 +52,7 @@ pub struct App {
     pub text_width: u16,
     pub session_picker: Option<SessionPicker>,
     pub usage: TokenUsage,
+    pub subagent_usage: TokenUsage,
     /// The input_tokens value reported by the last Usage event. The API always
     /// reports the full context size, so we subtract the previous value to
     /// count only the newly added (non-cached) input tokens per turn.
@@ -90,6 +91,7 @@ impl App {
             text_width: 0,
             session_picker: None,
             usage: TokenUsage::default(),
+            subagent_usage: TokenUsage::default(),
             last_input_total: 0,
             model: String::new(),
             git_branch: None,
@@ -328,11 +330,17 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
 
     app.input.render(frame, chunks[1]);
 
+    let subagent_ref = if app.subagent_usage.input_tokens + app.subagent_usage.output_tokens > 0 {
+        Some(&app.subagent_usage)
+    } else {
+        None
+    };
     let info = StatusLineInfo {
         model: &app.model,
         git_branch: app.git_branch.as_deref(),
         working_dir: &app.working_dir,
         usage: &app.usage,
+        subagent_usage: subagent_ref,
     };
     status_line::render_status_line(&info, frame, chunks[2]);
 
@@ -442,7 +450,7 @@ pub fn handle_agent_event(
             output_tokens,
             ..
         } => {
-            app.usage.add(input_tokens, output_tokens);
+            app.subagent_usage.add(input_tokens, output_tokens);
         }
     }
     Ok(())
@@ -599,6 +607,7 @@ async fn run_app(
                                                         app.current_response.clear();
                                                         app.scroll_offset = 0;
                                                         app.usage = TokenUsage::default();
+                                                        app.subagent_usage = TokenUsage::default();
                                                         app.last_input_total = 0;
                                                         app.load_history(&history);
                                                         agent.load_session(session).await;
@@ -1018,10 +1027,10 @@ mod tests {
     }
 
     #[test]
-    fn subagent_usage_event_aggregates_into_app_usage() {
+    fn subagent_usage_event_feeds_subagent_usage_only() {
         let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
-        assert_eq!(app.usage.input_tokens, 0);
-        assert_eq!(app.usage.output_tokens, 0);
+        assert_eq!(app.subagent_usage.input_tokens, 0);
+        assert_eq!(app.subagent_usage.output_tokens, 0);
 
         let event = AgentEvent::SubAgentUsage {
             input_tokens: 200,
@@ -1030,9 +1039,13 @@ mod tests {
         };
         handle_agent_event(&mut app, event, None).expect("handle SubAgentUsage");
 
-        assert_eq!(app.usage.input_tokens, 200);
-        assert_eq!(app.usage.output_tokens, 80);
-        // SubAgentUsage does not update last_input_total (no deduplication logic needed)
+        // SubAgentUsage must NOT touch app.usage
+        assert_eq!(app.usage.input_tokens, 0, "parent usage must stay zero");
+        assert_eq!(app.usage.output_tokens, 0, "parent usage must stay zero");
+
+        // SubAgentUsage MUST accumulate into app.subagent_usage
+        assert_eq!(app.subagent_usage.input_tokens, 200);
+        assert_eq!(app.subagent_usage.output_tokens, 80);
         assert_eq!(app.last_input_total, 0);
 
         // A subsequent SubAgentUsage should add on top.
@@ -1043,8 +1056,60 @@ mod tests {
         };
         handle_agent_event(&mut app, event2, None).expect("handle second SubAgentUsage");
 
-        assert_eq!(app.usage.input_tokens, 250);
-        assert_eq!(app.usage.output_tokens, 110);
+        assert_eq!(app.subagent_usage.input_tokens, 250);
+        assert_eq!(app.subagent_usage.output_tokens, 110);
+        // parent still untouched
+        assert_eq!(app.usage.input_tokens, 0);
+    }
+
+    #[test]
+    fn parent_usage_event_does_not_touch_subagent_usage() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        let event = AgentEvent::Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            stop_reason: "end_turn".to_string(),
+        };
+        handle_agent_event(&mut app, event, None).expect("handle Usage");
+
+        assert_eq!(app.usage.input_tokens, 100);
+        assert_eq!(
+            app.subagent_usage.input_tokens, 0,
+            "subagent_usage must be untouched by Usage event"
+        );
+        assert_eq!(
+            app.subagent_usage.output_tokens, 0,
+            "subagent_usage must be untouched by Usage event"
+        );
+    }
+
+    #[test]
+    fn session_switch_resets_both_usage_counters() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        // Simulate some accumulated usage
+        app.usage.add(500, 200);
+        app.subagent_usage.add(300, 100);
+        assert_eq!(app.usage.input_tokens, 500);
+        assert_eq!(app.subagent_usage.input_tokens, 300);
+
+        // Simulate the session-switch reset block
+        app.usage = TokenUsage::default();
+        app.subagent_usage = TokenUsage::default();
+        app.last_input_total = 0;
+
+        assert_eq!(
+            app.usage.input_tokens, 0,
+            "usage should be reset on session switch"
+        );
+        assert_eq!(app.usage.output_tokens, 0);
+        assert_eq!(
+            app.subagent_usage.input_tokens, 0,
+            "subagent_usage should be reset on session switch"
+        );
+        assert_eq!(app.subagent_usage.output_tokens, 0);
+        assert_eq!(app.last_input_total, 0);
     }
 
     #[test]

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -283,6 +283,12 @@ impl App {
         }
     }
 
+    pub fn reset_for_session_switch(&mut self) {
+        self.usage = TokenUsage::default();
+        self.subagent_usage = TokenUsage::default();
+        self.last_input_total = 0;
+    }
+
     fn max_scroll(&mut self) -> u16 {
         if self.text_width == 0 {
             return 0;
@@ -330,17 +336,12 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
 
     app.input.render(frame, chunks[1]);
 
-    let subagent_ref = if app.subagent_usage.input_tokens + app.subagent_usage.output_tokens > 0 {
-        Some(&app.subagent_usage)
-    } else {
-        None
-    };
     let info = StatusLineInfo {
         model: &app.model,
         git_branch: app.git_branch.as_deref(),
         working_dir: &app.working_dir,
         usage: &app.usage,
-        subagent_usage: subagent_ref,
+        subagent_usage: Some(&app.subagent_usage),
     };
     status_line::render_status_line(&info, frame, chunks[2]);
 
@@ -606,9 +607,7 @@ async fn run_app(
                                                         app.conversation.clear();
                                                         app.current_response.clear();
                                                         app.scroll_offset = 0;
-                                                        app.usage = TokenUsage::default();
-                                                        app.subagent_usage = TokenUsage::default();
-                                                        app.last_input_total = 0;
+                                                        app.reset_for_session_switch();
                                                         app.load_history(&history);
                                                         agent.load_session(session).await;
                                                     }
@@ -1088,25 +1087,17 @@ mod tests {
     fn session_switch_resets_both_usage_counters() {
         let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
 
-        // Simulate some accumulated usage
         app.usage.add(500, 200);
         app.subagent_usage.add(300, 100);
-        assert_eq!(app.usage.input_tokens, 500);
-        assert_eq!(app.subagent_usage.input_tokens, 300);
+        app.last_input_total = 500;
 
-        // Simulate the session-switch reset block
-        app.usage = TokenUsage::default();
-        app.subagent_usage = TokenUsage::default();
-        app.last_input_total = 0;
+        app.reset_for_session_switch();
 
-        assert_eq!(
-            app.usage.input_tokens, 0,
-            "usage should be reset on session switch"
-        );
+        assert_eq!(app.usage.input_tokens, 0, "usage should be reset");
         assert_eq!(app.usage.output_tokens, 0);
         assert_eq!(
             app.subagent_usage.input_tokens, 0,
-            "subagent_usage should be reset on session switch"
+            "subagent_usage should be reset"
         );
         assert_eq!(app.subagent_usage.output_tokens, 0);
         assert_eq!(app.last_input_total, 0);
@@ -1144,6 +1135,34 @@ mod tests {
         assert!(
             rendered.contains("↓500"),
             "status line should show output tokens"
+        );
+    }
+
+    #[test]
+    fn render_app_with_subagent_usage_shows_arrow_glyph() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        app.model = "test-model".to_string();
+        app.usage.add(1000, 500);
+        app.subagent_usage.add(300, 100);
+        app.git_branch = Some("main".to_string());
+        app.working_dir = std::path::PathBuf::from("/test/project");
+
+        let backend = ratatui::backend::TestBackend::new(120, 20);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
+        terminal
+            .draw(|frame| {
+                render_app(&mut app, frame);
+            })
+            .expect("draw");
+
+        let rendered = format!("{:?}", terminal.backend());
+        assert!(
+            rendered.contains('↗'),
+            "status line should show ↗ glyph when subagent_usage is non-zero"
+        );
+        assert!(
+            rendered.contains("↑300"),
+            "status line should show subagent input tokens"
         );
     }
 


### PR DESCRIPTION
## Implementation Plan: Separate Subagent Token Counter on Status Line

Closes #150.

### Analysis

Today, both `AgentEvent::Usage` (parent) and `AgentEvent::SubAgentUsage` (subagent) accumulate into a single `App::usage` field, then render as one `↑in ↓out` block on the status line. The issue requests visual separation: a second token block (green) appears to the right of the parent counter only when subagent tokens have been recorded.

The change is **purely frontend display** — `AgentEvent::SubAgentUsage` already carries the subagent counts; the agent layer needs no changes.

### Deliverables

1. **`src/frontend/tui/status_line.rs`**
   - Add `subagent_usage: Option<&'a TokenUsage>` to `StatusLineInfo`.
   - In `build_status_line()`, when `subagent_usage` is `Some` and has non-zero totals, insert a second styled span (`Color::Green`) with format `↗↑{in} ↓{out}` immediately after the parent token span (still on the left side, before the git branch).
   - When `None` or zero totals, render exactly the current layout (no extra span, no extra spacing).
   - Width handling: if the right-side spans would overflow, drop the subagent span first (it has lower priority than the parent counter). Parent counter is never dropped.

2. **`src/frontend/tui/tui_app.rs`**
   - Add `pub subagent_usage: TokenUsage` field to `App`.
   - Initialize to `TokenUsage::default()` in `App::new()`.
   - Change `AgentEvent::SubAgentUsage` handler to call `app.subagent_usage.add(...)` instead of `app.usage.add(...)`.
   - In `render_app()`, populate `StatusLineInfo.subagent_usage` with `Some(&app.subagent_usage)` when totals are non-zero, else `None`.
   - In the session-switch reset block (around line 601), reset `app.subagent_usage = TokenUsage::default()` alongside `app.usage`.

3. **Tests**
   - Update existing test `subagent_usage_event_aggregates_into_app_usage` → rename + rewrite to assert subagent events feed `app.subagent_usage` only and leave `app.usage` at zero. Add the inverse: parent `Usage` events do not touch `app.subagent_usage`.
   - Add unit test: session-switch resets both `app.usage` and `app.subagent_usage`.
   - Add unit test in `status_line.rs` for the conditional render — `build_status_line_with_subagent_usage_zero_omits_span` (no second counter when `Some(&zero)`) and `build_status_line_with_subagent_usage_renders_green_span`.
   - Add insta snapshot test `render_status_line_with_subagent_usage` (80×1) showing the second counter in green.
   - Update existing `render_status_line` and `render_status_line_narrow` snapshots — only if struct-init changes break them; populating `subagent_usage: None` should keep output identical, so ideally no diff.

### Acceptance Criteria

- [ ] `App.subagent_usage: TokenUsage` field exists and is initialized to default.
- [ ] `AgentEvent::SubAgentUsage` only mutates `subagent_usage`; `AgentEvent::Usage` only mutates `usage`. (Verified by two unit tests.)
- [ ] `StatusLineInfo` has `subagent_usage: Option<&TokenUsage>`.
- [ ] When subagent tokens are zero/absent, the rendered status line is byte-identical to the current implementation (existing snapshots unchanged).
- [ ] When subagent tokens are non-zero, a second token block renders to the right of the parent block in `Color::Green` with the `↗` prefix glyph.
- [ ] Session switching zeroes both counters.
- [ ] On a narrow terminal where space is tight, the subagent span is omitted before the parent span.
- [ ] New snapshot `render_status_line_with_subagent_usage` is committed.
- [ ] `cargo fmt`, `cargo clippy`, `cargo test` pass.

### Testing Approach

Test infrastructure already exists (insta, ratatui `TestBackend`). New tests live in:
- `src/frontend/tui/status_line.rs` `mod tests`: render & build-level tests + new insta snapshot.
- `src/frontend/tui/tui_app.rs` `mod tests`: event-handler unit tests + session reset test.

Behaviors to verify:
- Happy path: subagent event → only `subagent_usage` increments.
- Inverse: parent `Usage` event → only `usage` increments, `subagent_usage` stays zero.
- Render: `Some(&non_zero)` produces a green span with `↗` glyph; `Some(&zero)` and `None` both produce no extra span.
- Reset: session-switch zeros both counters.
- Width fallback: on narrow widths, subagent span is dropped first (assert via inspecting span list / snapshot at narrow width with non-zero subagent usage).

### Risks & Open Questions

1. **Glyph rendering** — `↗` may render inconsistently in some terminals. Issue suggests it; we'll use it as specified.
2. **Width algorithm** — current `build_status_line` computes a single gap from total left/right widths and panics nothing on overflow (it just truncates via terminal). We need an explicit "drop subagent if `left + right > width`" check. This is new logic with its own test.
3. **`is_estimated` semantics** — `load_history` seeds estimated parent tokens. Subagent tokens are never estimated (they only arrive from real events), so `subagent_usage.is_estimated` will always be false. No special handling.
4. **No backend / agent / persistence changes** — confirmed by grep; `AgentEvent::SubAgentUsage` is already piped through.
