### PR TITLE
feat: additional vim keybinds (gg/G/b/e/w)

### DIFF
--- a/src/frontend/tui/input_area.rs
+++ b/src/frontend/tui/input_area.rs
@@ -1,8 +1,8 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders};
-use ratatui_textarea::{CursorMove, TextArea, WrapMode};
+use ratatui_textarea::{CursorMove, DataCursor, TextArea, WrapMode};
 
 const INSERT_TITLE: &str = " -- INSERT -- ";
 const NORMAL_TITLE: &str = " -- NORMAL -- ";
@@ -82,6 +82,30 @@ impl<'a> InputArea<'a> {
                     self.textarea.insert_newline();
                     self.textarea.move_cursor(CursorMove::Up);
                     self.set_mode(InputMode::Insert);
+                    true
+                }
+                KeyEvent {
+                    code: KeyCode::Char('w'),
+                    modifiers: KeyModifiers::NONE,
+                    ..
+                } => {
+                    self.textarea.move_cursor(CursorMove::WordForward);
+                    true
+                }
+                KeyEvent {
+                    code: KeyCode::Char('b'),
+                    modifiers: KeyModifiers::NONE,
+                    ..
+                } => {
+                    self.textarea.move_cursor(CursorMove::WordBack);
+                    true
+                }
+                KeyEvent {
+                    code: KeyCode::Char('e'),
+                    modifiers: KeyModifiers::NONE,
+                    ..
+                } => {
+                    self.textarea.move_cursor(CursorMove::WordEnd);
                     true
                 }
                 _ => false,
@@ -196,6 +220,10 @@ impl<'a> InputArea<'a> {
 
     pub fn render(&self, frame: &mut ratatui::Frame, area: Rect) {
         frame.render_widget(&self.textarea, area);
+    }
+
+    pub fn cursor(&self) -> DataCursor {
+        self.textarea.cursor()
     }
 }
 
@@ -587,5 +615,90 @@ mod tests {
         });
         let height = input.height_for_width(60, 24);
         assert!(height >= MIN_HEIGHT);
+    }
+
+    #[test]
+    fn normal_mode_w_moves_cursor_word_forward() {
+        let mut input = InputArea::new();
+        input.set_text("hello world");
+        input.set_mode(InputMode::Normal);
+        // Move cursor to start via Home key equivalent (Head)
+        input.input(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        let col_before = input.cursor().1;
+        let consumed = input.input(char_key('w'));
+        assert!(consumed, "w should be consumed in Normal mode");
+        let col_after = input.cursor().1;
+        assert!(
+            col_after > col_before,
+            "w should move cursor forward: before={col_before} after={col_after}"
+        );
+    }
+
+    #[test]
+    fn normal_mode_b_moves_cursor_word_back() {
+        let mut input = InputArea::new();
+        input.set_text("hello world");
+        input.set_mode(InputMode::Normal);
+        // Move cursor forward with w first, then test b moves back
+        input.input(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        input.input(char_key('w'));
+        let col_before = input.cursor().1;
+        let consumed = input.input(char_key('b'));
+        assert!(consumed, "b should be consumed in Normal mode");
+        let col_after = input.cursor().1;
+        assert!(
+            col_after < col_before,
+            "b should move cursor back: before={col_before} after={col_after}"
+        );
+    }
+
+    #[test]
+    fn normal_mode_e_moves_cursor_word_end() {
+        let mut input = InputArea::new();
+        input.set_text("hello world");
+        input.set_mode(InputMode::Normal);
+        input.input(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        let col_before = input.cursor().1;
+        let consumed = input.input(char_key('e'));
+        assert!(consumed, "e should be consumed in Normal mode");
+        let col_after = input.cursor().1;
+        assert!(
+            col_after > col_before,
+            "e should move cursor to word end: before={col_before} after={col_after}"
+        );
+    }
+
+    #[test]
+    fn insert_mode_w_inserts_literal() {
+        let mut input = InputArea::new();
+        assert_eq!(input.mode(), &InputMode::Insert);
+        input.input(char_key('w'));
+        assert_eq!(
+            input.text(),
+            "w",
+            "w in Insert mode should insert literal 'w'"
+        );
+    }
+
+    #[test]
+    fn insert_mode_b_inserts_literal() {
+        let mut input = InputArea::new();
+        input.input(char_key('b'));
+        assert_eq!(
+            input.text(),
+            "b",
+            "b in Insert mode should insert literal 'b'"
+        );
+    }
+
+    #[test]
+    fn insert_mode_e_inserts_literal() {
+        let mut input = InputArea::new();
+        input.input(char_key('e'));
+        assert_eq!(
+            input.text(),
+            "e",
+            "e in Insert mode should insert literal 'e'"
+        );
     }
 }

--- a/src/frontend/tui/input_area.rs
+++ b/src/frontend/tui/input_area.rs
@@ -2,7 +2,9 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::widgets::{Block, Borders};
-use ratatui_textarea::{CursorMove, DataCursor, TextArea, WrapMode};
+#[cfg(test)]
+use ratatui_textarea::DataCursor;
+use ratatui_textarea::{CursorMove, TextArea, WrapMode};
 
 const INSERT_TITLE: &str = " -- INSERT -- ";
 const NORMAL_TITLE: &str = " -- NORMAL -- ";
@@ -222,7 +224,8 @@ impl<'a> InputArea<'a> {
         frame.render_widget(&self.textarea, area);
     }
 
-    pub fn cursor(&self) -> DataCursor {
+    #[cfg(test)]
+    pub(super) fn cursor(&self) -> DataCursor {
         self.textarea.cursor()
     }
 }
@@ -622,15 +625,13 @@ mod tests {
         let mut input = InputArea::new();
         input.set_text("hello world");
         input.set_mode(InputMode::Normal);
-        // Move cursor to start via Home key equivalent (Head)
         input.input(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
-        let col_before = input.cursor().1;
         let consumed = input.input(char_key('w'));
         assert!(consumed, "w should be consumed in Normal mode");
-        let col_after = input.cursor().1;
-        assert!(
-            col_after > col_before,
-            "w should move cursor forward: before={col_before} after={col_after}"
+        assert_eq!(
+            input.cursor().1,
+            6,
+            "w from col 0 on 'hello world' should land at col 6 (start of 'world')"
         );
     }
 
@@ -639,16 +640,14 @@ mod tests {
         let mut input = InputArea::new();
         input.set_text("hello world");
         input.set_mode(InputMode::Normal);
-        // Move cursor forward with w first, then test b moves back
         input.input(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
-        input.input(char_key('w'));
-        let col_before = input.cursor().1;
+        input.input(char_key('w')); // now at col 6
         let consumed = input.input(char_key('b'));
         assert!(consumed, "b should be consumed in Normal mode");
-        let col_after = input.cursor().1;
-        assert!(
-            col_after < col_before,
-            "b should move cursor back: before={col_before} after={col_after}"
+        assert_eq!(
+            input.cursor().1,
+            0,
+            "b from col 6 on 'hello world' should return to col 0"
         );
     }
 
@@ -658,13 +657,12 @@ mod tests {
         input.set_text("hello world");
         input.set_mode(InputMode::Normal);
         input.input(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
-        let col_before = input.cursor().1;
         let consumed = input.input(char_key('e'));
         assert!(consumed, "e should be consumed in Normal mode");
-        let col_after = input.cursor().1;
-        assert!(
-            col_after > col_before,
-            "e should move cursor to word end: before={col_before} after={col_after}"
+        assert_eq!(
+            input.cursor().1,
+            4,
+            "e from col 0 on 'hello world' should land at col 4 (end of 'hello')"
         );
     }
 

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -65,7 +65,7 @@ pub struct App {
     pub model: String,
     pub git_branch: Option<String>,
     pub working_dir: std::path::PathBuf,
-    pub pending_g: bool,
+    pending_g: bool,
     tools: std::sync::Arc<ToolRegistry>,
 }
 
@@ -2481,6 +2481,84 @@ mod tests {
         assert!(
             !app.pending_g,
             "pending_g should be false after reset_for_session_switch"
+        );
+    }
+
+    #[test]
+    fn gg_inert_in_session_picker_state() {
+        let mut app = app_with_content(10);
+        app.set_state(AppState::SessionPicker);
+        let before = app.scroll_offset;
+        let g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        assert!(!app.handle_scroll_key(&g));
+        assert!(!app.handle_scroll_key(&g));
+        assert_eq!(app.scroll_offset, before);
+        assert!(!app.pending_g);
+    }
+
+    #[test]
+    fn gg_inert_in_tasks_picker_state() {
+        let mut app = app_with_content(10);
+        app.set_state(AppState::TasksPicker);
+        let before = app.scroll_offset;
+        let g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        assert!(!app.handle_scroll_key(&g));
+        assert!(!app.handle_scroll_key(&g));
+        assert_eq!(app.scroll_offset, before);
+        assert!(!app.pending_g);
+    }
+
+    #[test]
+    fn gg_inert_in_tool_confirmation_state() {
+        let mut app = app_with_content(10);
+        app.set_state(AppState::ToolConfirmation {
+            name: "bash".to_string(),
+            input: serde_json::json!({}),
+            index: 1,
+        });
+        let before = app.scroll_offset;
+        let g = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        assert!(!app.handle_scroll_key(&g));
+        assert!(!app.handle_scroll_key(&g));
+        assert_eq!(app.scroll_offset, before);
+        assert!(!app.pending_g);
+    }
+
+    #[test]
+    fn capital_g_inert_in_session_picker_state() {
+        let mut app = app_with_content(10);
+        app.scroll_offset = 10;
+        app.set_state(AppState::SessionPicker);
+        let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
+        assert!(!app.handle_scroll_key(&key));
+        assert_eq!(app.scroll_offset, 10);
+    }
+
+    #[test]
+    fn set_state_non_input_clears_pending_g() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        app.pending_g = true;
+
+        app.set_state(AppState::Streaming);
+        assert!(!app.pending_g, "Streaming state should clear pending_g");
+
+        app.pending_g = true;
+        app.set_state(AppState::SessionPicker);
+        assert!(!app.pending_g, "SessionPicker state should clear pending_g");
+
+        app.pending_g = true;
+        app.set_state(AppState::TasksPicker);
+        assert!(!app.pending_g, "TasksPicker state should clear pending_g");
+
+        app.pending_g = true;
+        app.set_state(AppState::ToolConfirmation {
+            name: "bash".to_string(),
+            input: serde_json::json!({}),
+            index: 1,
+        });
+        assert!(
+            !app.pending_g,
+            "ToolConfirmation state should clear pending_g"
         );
     }
 }

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -65,6 +65,7 @@ pub struct App {
     pub model: String,
     pub git_branch: Option<String>,
     pub working_dir: std::path::PathBuf,
+    pub pending_g: bool,
     tools: std::sync::Arc<ToolRegistry>,
 }
 
@@ -73,15 +74,25 @@ impl App {
         self.state = state;
         match &self.state {
             AppState::Input => self.input.set_mode(InputMode::Insert),
-            AppState::Streaming => self.input.set_mode(InputMode::Streaming),
+            AppState::Streaming => {
+                self.input.set_mode(InputMode::Streaming);
+                self.pending_g = false;
+            }
             AppState::ToolConfirmation { name, input, .. } => {
                 self.input.set_mode(InputMode::ToolConfirmation {
                     name: name.clone(),
                     input: input.clone(),
                 });
+                self.pending_g = false;
             }
-            AppState::SessionPicker => self.input.set_mode(InputMode::SessionPicker),
-            AppState::TasksPicker => self.input.set_mode(InputMode::TasksPicker),
+            AppState::SessionPicker => {
+                self.input.set_mode(InputMode::SessionPicker);
+                self.pending_g = false;
+            }
+            AppState::TasksPicker => {
+                self.input.set_mode(InputMode::TasksPicker);
+                self.pending_g = false;
+            }
         }
     }
 
@@ -104,6 +115,7 @@ impl App {
             model: String::new(),
             git_branch: None,
             working_dir: std::path::PathBuf::new(),
+            pending_g: false,
             tools,
         }
     }
@@ -268,6 +280,7 @@ impl App {
     }
 
     pub fn handle_scroll_key(&mut self, key: &KeyEvent) -> bool {
+        let is_normal = self.input.mode() == &InputMode::Normal;
         match key {
             KeyEvent {
                 code: KeyCode::Char('u'),
@@ -287,7 +300,33 @@ impl App {
                 self.scroll_down(amount);
                 true
             }
-            _ => false,
+            KeyEvent {
+                code: KeyCode::Char('g'),
+                modifiers: KeyModifiers::NONE,
+                ..
+            } if is_normal => {
+                if self.pending_g {
+                    self.pending_g = false;
+                    let max = self.max_scroll();
+                    self.scroll_offset = max;
+                } else {
+                    self.pending_g = true;
+                }
+                true
+            }
+            KeyEvent {
+                code: KeyCode::Char('G'),
+                modifiers,
+                ..
+            } if is_normal && modifiers.contains(KeyModifiers::SHIFT) => {
+                self.scroll_offset = 0;
+                self.pending_g = false;
+                true
+            }
+            _ => {
+                self.pending_g = false;
+                false
+            }
         }
     }
 
@@ -297,6 +336,7 @@ impl App {
         self.last_input_total = 0;
         self.tasks_picker = None;
         self.session_picker = None;
+        self.pending_g = false;
     }
 
     fn max_scroll(&mut self) -> u16 {
@@ -2325,6 +2365,122 @@ mod tests {
         assert!(
             app.cancel_token.is_none(),
             "cancel_token should be cleared after Interrupted"
+        );
+    }
+
+    #[test]
+    fn single_g_sets_pending_flag() {
+        let mut app = app_with_content(10);
+        app.input.set_mode(InputMode::Normal);
+        let before_offset = app.scroll_offset;
+        let key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        let consumed = app.handle_scroll_key(&key);
+        assert!(consumed, "g key should be consumed in Normal mode");
+        assert!(app.pending_g, "pending_g should be true after single g");
+        assert_eq!(
+            app.scroll_offset, before_offset,
+            "scroll should not change on single g"
+        );
+    }
+
+    #[test]
+    fn gg_jumps_to_top() {
+        let mut app = app_with_content(10);
+        app.input.set_mode(InputMode::Normal);
+        let max = app.max_scroll();
+        assert!(max > 0, "content should be scrollable");
+        let g_key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        app.handle_scroll_key(&g_key);
+        app.handle_scroll_key(&g_key);
+        assert_eq!(
+            app.scroll_offset, max,
+            "gg should set scroll_offset to max_scroll()"
+        );
+        assert!(!app.pending_g, "pending_g should be cleared after gg");
+    }
+
+    #[test]
+    fn capital_g_jumps_to_bottom() {
+        let mut app = app_with_content(10);
+        app.input.set_mode(InputMode::Normal);
+        app.scroll_offset = 20;
+        let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
+        let consumed = app.handle_scroll_key(&key);
+        assert!(consumed, "G should be consumed in Normal mode");
+        assert_eq!(app.scroll_offset, 0, "G should set scroll_offset to 0");
+        assert!(!app.pending_g, "pending_g should be cleared after G");
+    }
+
+    #[test]
+    fn non_g_key_clears_pending_g() {
+        let mut app = app_with_content(10);
+        app.input.set_mode(InputMode::Normal);
+        let g_key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        app.handle_scroll_key(&g_key);
+        assert!(app.pending_g);
+        // press 'j' — not a scroll key, falls through
+        let j_key = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        let consumed = app.handle_scroll_key(&j_key);
+        assert!(!consumed, "j should not be consumed by scroll handler");
+        assert!(!app.pending_g, "pending_g should be cleared by non-g key");
+    }
+
+    #[test]
+    fn gg_inert_in_insert_mode() {
+        let mut app = app_with_content(10);
+        // default mode is Insert (from App::new)
+        assert_eq!(app.input.mode(), &InputMode::Insert);
+        let before_offset = app.scroll_offset;
+        let g_key = KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE);
+        let consumed1 = app.handle_scroll_key(&g_key);
+        let consumed2 = app.handle_scroll_key(&g_key);
+        assert!(!consumed1, "g should not be consumed in Insert mode");
+        assert!(!consumed2, "g should not be consumed in Insert mode");
+        assert_eq!(
+            app.scroll_offset, before_offset,
+            "scroll should not change in Insert mode"
+        );
+        assert!(
+            !app.pending_g,
+            "pending_g should remain false in Insert mode"
+        );
+    }
+
+    #[test]
+    fn capital_g_inert_in_insert_mode() {
+        let mut app = app_with_content(10);
+        app.scroll_offset = 15;
+        assert_eq!(app.input.mode(), &InputMode::Insert);
+        let key = KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT);
+        let consumed = app.handle_scroll_key(&key);
+        assert!(!consumed, "G should not be consumed in Insert mode");
+        assert_eq!(
+            app.scroll_offset, 15,
+            "scroll should not change in Insert mode"
+        );
+    }
+
+    #[test]
+    fn ctrl_u_still_works_in_insert_mode() {
+        let mut app = app_with_content(10);
+        app.scroll_offset = 0;
+        app.scroll_up(10);
+        let before = app.scroll_offset;
+        assert!(before > 0);
+        // ctrl-u should work regardless of mode
+        let key = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
+        let consumed = app.handle_scroll_key(&key);
+        assert!(consumed, "ctrl-u should always be consumed");
+    }
+
+    #[test]
+    fn reset_for_session_switch_clears_pending_g() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        app.pending_g = true;
+        app.reset_for_session_switch();
+        assert!(
+            !app.pending_g,
+            "pending_g should be false after reset_for_session_switch"
         );
     }
 }


### PR DESCRIPTION
Closes #156

Add vim keybinds `gg`/`G` for conversation viewport scroll (top/bottom) and `b`/`e`/`w` for Normal-mode word cursor motions in the input area.

Implementation plan posted as a comment below.
