### PR TITLE
feat: display and persist thinking data from LLM backends

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -300,6 +300,7 @@ impl Agent {
 
                 let mut text_accumulated = String::new();
                 let mut thinking_accumulated = String::new();
+                let mut thinking_signature = String::new();
                 let mut tool_calls: Vec<PendingToolCall> = vec![];
                 let mut current_tool: Option<PendingToolCall> = None;
                 let mut stream = backend_stream;
@@ -327,6 +328,22 @@ impl Agent {
                                 &event_tx,
                             )
                             .await;
+                            if !thinking_accumulated.is_empty() {
+                                let thinking_msg = Message {
+                                    role: Role::Assistant,
+                                    content: vec![ContentBlock::Thinking {
+                                        text: thinking_accumulated.clone(),
+                                        signature: thinking_signature.clone(),
+                                    }],
+                                };
+                                lock(&history_arc).push(thinking_msg.clone());
+                                let _ = session
+                                    .lock()
+                                    .await
+                                    .conversation()
+                                    .insert_message(&thinking_msg)
+                                    .await;
+                            }
                             break 'outer;
                         }
                         None => break,
@@ -337,6 +354,9 @@ impl Agent {
                         Some(Ok(StreamEvent::ThinkingDelta(text))) => {
                             thinking_accumulated.push_str(&text);
                             let _ = event_tx.unbounded_send(AgentEvent::ThinkingReceived(text));
+                        }
+                        Some(Ok(StreamEvent::ThinkingSignature(sig))) => {
+                            thinking_signature = sig;
                         }
                         Some(Ok(StreamEvent::ToolUseStart { id, name })) => {
                             current_tool = Some(PendingToolCall {
@@ -371,6 +391,22 @@ impl Agent {
                             if !text_accumulated.is_empty() {
                                 persist_partial(&text_accumulated, &history_arc, &session).await;
                             }
+                            if !thinking_accumulated.is_empty() {
+                                let thinking_msg = Message {
+                                    role: Role::Assistant,
+                                    content: vec![ContentBlock::Thinking {
+                                        text: thinking_accumulated.clone(),
+                                        signature: thinking_signature.clone(),
+                                    }],
+                                };
+                                lock(&history_arc).push(thinking_msg.clone());
+                                let _ = session
+                                    .lock()
+                                    .await
+                                    .conversation()
+                                    .insert_message(&thinking_msg)
+                                    .await;
+                            }
                             record_error(&e.to_string(), &history_arc, &session, &event_tx).await;
                             break 'outer;
                         }
@@ -382,7 +418,7 @@ impl Agent {
                     if !thinking_accumulated.is_empty() {
                         content.push(ContentBlock::Thinking {
                             text: thinking_accumulated.clone(),
-                            signature: String::new(),
+                            signature: thinking_signature.clone(),
                         });
                     }
                     if !text_accumulated.is_empty() {
@@ -423,10 +459,12 @@ impl Agent {
 
                 let text_for_cancel = text_accumulated.clone();
                 let thinking_for_cancel = thinking_accumulated.clone();
+                let signature_for_cancel = thinking_signature.clone();
                 let (assistant_content, tool_result_blocks) = execute_tool_calls(
                     tool_calls,
                     text_accumulated,
                     thinking_accumulated,
+                    thinking_signature.clone(),
                     &tools,
                     &confirmation_mode,
                     &mut confirmation_rx,
@@ -452,7 +490,7 @@ impl Agent {
                             role: Role::Assistant,
                             content: vec![ContentBlock::Thinking {
                                 text: thinking_for_cancel,
-                                signature: String::new(),
+                                signature: signature_for_cancel,
                             }],
                         };
                         lock(&history_arc).push(thinking_msg.clone());
@@ -551,6 +589,7 @@ async fn execute_tool_calls(
     tool_calls: Vec<PendingToolCall>,
     text_prefix: String,
     thinking_prefix: String,
+    thinking_signature: String,
     tools: &ToolRegistry,
     confirmation_mode: &ConfirmationMode,
     confirmation_rx: &mut Option<mpsc::UnboundedReceiver<ConfirmationResponse>>,
@@ -561,7 +600,7 @@ async fn execute_tool_calls(
     if !thinking_prefix.is_empty() {
         assistant_content.push(ContentBlock::Thinking {
             text: thinking_prefix,
-            signature: String::new(),
+            signature: thinking_signature,
         });
     }
     if !text_prefix.is_empty() {
@@ -1080,6 +1119,23 @@ mod tests {
     fn text_response(text: &str) -> Vec<Result<StreamEvent>> {
         vec![
             Ok(StreamEvent::TextDelta(text.to_string())),
+            Ok(StreamEvent::Done),
+        ]
+    }
+
+    fn thinking_then_text_response(thinking: &str, text: &str) -> Vec<Result<StreamEvent>> {
+        vec![
+            Ok(StreamEvent::ThinkingDelta(thinking.to_string())),
+            Ok(StreamEvent::ThinkingSignature("sig_abc123".to_string())),
+            Ok(StreamEvent::TextDelta(text.to_string())),
+            Ok(StreamEvent::Done),
+        ]
+    }
+
+    fn thinking_only_response(thinking: &str) -> Vec<Result<StreamEvent>> {
+        vec![
+            Ok(StreamEvent::ThinkingDelta(thinking.to_string())),
+            Ok(StreamEvent::ThinkingSignature("sig_def456".to_string())),
             Ok(StreamEvent::Done),
         ]
     }
@@ -3159,5 +3215,262 @@ mod tests {
                 .any(|e| matches!(e, AgentEvent::Interrupted { .. })),
             "expected Interrupted; got: {events:?}"
         );
+    }
+
+    // ── Thinking accumulation tests (Finding 6) ──────────────────────────
+
+    #[tokio::test]
+    async fn thinking_delta_emits_thinking_received_and_accumulates() {
+        let backend = SequencedBackend::new(vec![thinking_then_text_response(
+            "reasoning about the problem",
+            "final answer",
+        )]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("think".to_string(), None, None)
+            .await
+            .expect("send should succeed");
+        let events = collect_events(stream).await;
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ThinkingReceived(t) if t == "reasoning about the problem")),
+            "expected ThinkingReceived with reasoning text"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::TokenReceived(t) if t == "final answer")),
+            "expected TokenReceived with final answer"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ResponseComplete(_))),
+            "expected ResponseComplete"
+        );
+    }
+
+    #[tokio::test]
+    async fn thinking_persisted_in_history_with_signature() {
+        let backend = SequencedBackend::new(vec![thinking_then_text_response(
+            "my reasoning",
+            "my answer",
+        )]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("think".to_string(), None, None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        let assistant_msg = history
+            .iter()
+            .find(|m| m.role == Role::Assistant)
+            .expect("should have assistant message");
+
+        let thinking_block = assistant_msg
+            .content
+            .iter()
+            .find(|b| matches!(b, ContentBlock::Thinking { .. }))
+            .expect("should have thinking block");
+        if let ContentBlock::Thinking { text, signature } = thinking_block {
+            assert_eq!(text, "my reasoning");
+            assert_eq!(
+                signature, "sig_abc123",
+                "signature should be captured from stream"
+            );
+        }
+
+        let text_block = assistant_msg
+            .content
+            .iter()
+            .find(|b| matches!(b, ContentBlock::Text(_)))
+            .expect("should have text block");
+        if let ContentBlock::Text(text) = text_block {
+            assert_eq!(text, "my answer");
+        }
+    }
+
+    #[tokio::test]
+    async fn thinking_only_response_persisted_in_history() {
+        let backend = SequencedBackend::new(vec![thinking_only_response("just thinking")]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("think".to_string(), None, None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        let assistant_msg = history
+            .iter()
+            .find(|m| m.role == Role::Assistant)
+            .expect("should have assistant message");
+
+        assert!(
+            assistant_msg
+                .content
+                .iter()
+                .any(|b| matches!(b, ContentBlock::Thinking { .. })),
+            "should have thinking block"
+        );
+    }
+
+    #[tokio::test]
+    async fn thinking_persisted_on_stream_error() {
+        let backend = SequencedBackend::new(vec![vec![
+            Ok(StreamEvent::ThinkingDelta("partial thinking".to_string())),
+            Ok(StreamEvent::ThinkingSignature("sig_err".to_string())),
+            Err(anyhow::anyhow!("stream error")),
+        ]]);
+        let agent = agent_with_mode(backend, None, ConfirmationMode::Never).await;
+
+        let stream = agent
+            .send("think".to_string(), None, None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        let has_thinking = history.iter().any(|m| {
+            m.role == Role::Assistant
+                && m.content
+                    .iter()
+                    .any(|b| matches!(b, ContentBlock::Thinking { text, signature } if text == "partial thinking" && signature == "sig_err"))
+        });
+        assert!(
+            has_thinking,
+            "thinking should be persisted even on stream error; history: {history:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn thinking_persisted_on_pre_tool_cancellation() {
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        // Backend emits thinking then blocks until cancelled
+        struct ThinkCancelBackend {
+            token: CancellationToken,
+        }
+        #[async_trait]
+        impl LlmBackend for ThinkCancelBackend {
+            async fn send_message(
+                &self,
+                _: &[Message],
+                _: &RequestConfig,
+            ) -> Result<BoxStream<Result<StreamEvent>>> {
+                let token = self.token.clone();
+                let events: Vec<Result<StreamEvent>> = vec![
+                    Ok(StreamEvent::ThinkingDelta(
+                        "thinking before cancel".to_string(),
+                    )),
+                    Ok(StreamEvent::ThinkingSignature("sig_cancel".to_string())),
+                ];
+                Ok(Box::pin(futures::stream::unfold(
+                    (events.into_iter(), token, false),
+                    |(mut iter, token, done)| async move {
+                        if done {
+                            return None;
+                        }
+                        if let Some(item) = iter.next() {
+                            return Some((item, (iter, token, false)));
+                        }
+                        token.cancelled().await;
+                        None
+                    },
+                )))
+            }
+        }
+
+        let agent = agent_with_mode(
+            ThinkCancelBackend {
+                token: cancel_clone,
+            },
+            None,
+            ConfirmationMode::Never,
+        )
+        .await;
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+            cancel.cancel();
+        });
+
+        let stream = agent
+            .send("think".to_string(), None, Some(CancellationToken::new()))
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        let has_thinking = history.iter().any(|m| {
+            m.role == Role::Assistant
+                && m.content.iter().any(|b| matches!(b, ContentBlock::Thinking { text, .. } if text == "thinking before cancel"))
+        });
+        assert!(
+            has_thinking,
+            "thinking should be persisted on pre-tool cancellation; history: {history:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn thinking_with_tool_call_includes_signature_in_assistant_message() {
+        let backend = SequencedBackend::new(vec![
+            vec![
+                Ok(StreamEvent::ThinkingDelta("let me think".to_string())),
+                Ok(StreamEvent::ThinkingSignature("sig_tool".to_string())),
+                Ok(StreamEvent::ToolUseStart {
+                    id: "t1".to_string(),
+                    name: "bash".to_string(),
+                }),
+                Ok(StreamEvent::ToolUseDelta("{}".to_string())),
+                Ok(StreamEvent::ToolUseDone),
+                Ok(StreamEvent::Done),
+            ],
+            text_response("done"),
+        ]);
+        let agent = agent_with_mode(
+            backend,
+            Some(Box::new(EchoTool::new("bash", "output"))),
+            ConfirmationMode::Never,
+        )
+        .await;
+
+        let stream = agent
+            .send("run".to_string(), None, None)
+            .await
+            .expect("send should succeed");
+        let _events = collect_events(stream).await;
+
+        let history = agent.history();
+        let assistant_with_tool = history
+            .iter()
+            .find(|m| {
+                m.role == Role::Assistant
+                    && m.content
+                        .iter()
+                        .any(|b| matches!(b, ContentBlock::ToolUse { .. }))
+            })
+            .expect("should have assistant message with tool use");
+
+        let thinking = assistant_with_tool
+            .content
+            .iter()
+            .find(|b| matches!(b, ContentBlock::Thinking { .. }));
+        assert!(
+            thinking.is_some(),
+            "thinking block should be in assistant message with tool use"
+        );
+        if let ContentBlock::Thinking { text, signature } = thinking.expect("checked above") {
+            assert_eq!(text, "let me think");
+            assert_eq!(signature, "sig_tool");
+        }
     }
 }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -79,6 +79,14 @@ impl Agent {
         self
     }
 
+    pub fn with_thinking(self, thinking: Option<crate::types::ThinkingConfig>) -> Self {
+        self.config
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .thinking = thinking;
+        self
+    }
+
     pub fn with_context_files(self) -> Result<Self> {
         let files = discover_context_files_from_env()?;
         self.load_context_files(files);
@@ -291,6 +299,7 @@ impl Agent {
                 };
 
                 let mut text_accumulated = String::new();
+                let mut thinking_accumulated = String::new();
                 let mut tool_calls: Vec<PendingToolCall> = vec![];
                 let mut current_tool: Option<PendingToolCall> = None;
                 let mut stream = backend_stream;
@@ -324,6 +333,10 @@ impl Agent {
                         Some(Ok(StreamEvent::TextDelta(text))) => {
                             text_accumulated.push_str(&text);
                             let _ = event_tx.unbounded_send(AgentEvent::TokenReceived(text));
+                        }
+                        Some(Ok(StreamEvent::ThinkingDelta(text))) => {
+                            thinking_accumulated.push_str(&text);
+                            let _ = event_tx.unbounded_send(AgentEvent::ThinkingReceived(text));
                         }
                         Some(Ok(StreamEvent::ToolUseStart { id, name })) => {
                             current_tool = Some(PendingToolCall {
@@ -366,6 +379,12 @@ impl Agent {
 
                 if tool_calls.is_empty() {
                     let mut content = vec![];
+                    if !thinking_accumulated.is_empty() {
+                        content.push(ContentBlock::Thinking {
+                            text: thinking_accumulated.clone(),
+                            signature: String::new(),
+                        });
+                    }
                     if !text_accumulated.is_empty() {
                         content.push(ContentBlock::Text(text_accumulated.clone()));
                     }
@@ -403,9 +422,11 @@ impl Agent {
                 }
 
                 let text_for_cancel = text_accumulated.clone();
+                let thinking_for_cancel = thinking_accumulated.clone();
                 let (assistant_content, tool_result_blocks) = execute_tool_calls(
                     tool_calls,
                     text_accumulated,
+                    thinking_accumulated,
                     &tools,
                     &confirmation_mode,
                     &mut confirmation_rx,
@@ -425,6 +446,23 @@ impl Agent {
                         &event_tx,
                     )
                     .await;
+                    // Also persist thinking if any
+                    if !thinking_for_cancel.is_empty() {
+                        let thinking_msg = Message {
+                            role: Role::Assistant,
+                            content: vec![ContentBlock::Thinking {
+                                text: thinking_for_cancel,
+                                signature: String::new(),
+                            }],
+                        };
+                        lock(&history_arc).push(thinking_msg.clone());
+                        let _ = session
+                            .lock()
+                            .await
+                            .conversation()
+                            .insert_message(&thinking_msg)
+                            .await;
+                    }
                     break;
                 }
 
@@ -508,9 +546,11 @@ async fn record_error(
     let _ = event_tx.unbounded_send(AgentEvent::Error(error_msg.to_string()));
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_tool_calls(
     tool_calls: Vec<PendingToolCall>,
     text_prefix: String,
+    thinking_prefix: String,
     tools: &ToolRegistry,
     confirmation_mode: &ConfirmationMode,
     confirmation_rx: &mut Option<mpsc::UnboundedReceiver<ConfirmationResponse>>,
@@ -518,6 +558,12 @@ async fn execute_tool_calls(
     cancel_token: Option<CancellationToken>,
 ) -> (Vec<ContentBlock>, Vec<ContentBlock>) {
     let mut assistant_content: Vec<ContentBlock> = vec![];
+    if !thinking_prefix.is_empty() {
+        assistant_content.push(ContentBlock::Thinking {
+            text: thinking_prefix,
+            signature: String::new(),
+        });
+    }
     if !text_prefix.is_empty() {
         assistant_content.push(ContentBlock::Text(text_prefix));
     }
@@ -805,6 +851,7 @@ pub async fn run_headless(agent: &Agent, prompt: String) -> HeadlessOutcome {
             AgentEvent::SubAgentUsage { .. } => {}
             AgentEvent::Interrupted { .. } => {}
             AgentEvent::Warn(_) => {}
+            AgentEvent::ThinkingReceived(_) => {}
         }
     }
 
@@ -916,7 +963,7 @@ impl AgentSpawner {
 
         let agent =
             match spawn_agent_with_selection(selection, &tool_config, session, registry).await {
-                Ok(a) => a,
+                Ok(a) => a.with_thinking(self.app_config.thinking.clone()),
                 Err(e) => {
                     return HeadlessOutcome {
                         text: String::new(),
@@ -975,6 +1022,7 @@ pub async fn spawn_agent_with_selection(
         model: selection.model,
         max_tokens: DEFAULT_MAX_TOKENS,
         tools: tools.definitions(),
+        thinking: None,
     };
     Ok(Agent::new(selection.backend, request_config, session)
         .await
@@ -1105,6 +1153,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         if let Some(t) = tool {
@@ -1211,6 +1260,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1255,6 +1305,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1300,6 +1351,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1349,6 +1401,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1405,6 +1458,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1706,6 +1760,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1777,6 +1832,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -1824,6 +1880,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
 
         let mut skills = std::collections::HashMap::new();
@@ -1861,6 +1918,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(Box::new(backend), config, test_session_arc().await)
             .await
@@ -1899,6 +1957,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(
             Box::new(SequencedBackend::new(vec![])),
@@ -1947,6 +2006,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
 
         let mut skills = std::collections::HashMap::new();
@@ -2000,6 +2060,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(
             Box::new(SequencedBackend::new(vec![])),
@@ -2026,6 +2087,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(
             Box::new(SequencedBackend::new(vec![])),
@@ -2055,6 +2117,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(
             Box::new(SequencedBackend::new(vec![])),
@@ -2187,6 +2250,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -2348,6 +2412,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -2490,6 +2555,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -2618,6 +2684,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
         let outcome = run_headless(&agent, "hi".to_string()).await;
@@ -2643,6 +2710,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let mut registry = ToolRegistry::new();
         registry
@@ -2686,6 +2754,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 100,
             tools: vec![],
+            thinking: None,
         };
         let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
         let outcome = run_headless(&agent, "fail".to_string()).await;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -168,6 +168,7 @@ mod tests {
             model: "test-model".to_string(),
             max_tokens: 1024,
             tools: vec![],
+            thinking: None,
         };
 
         let mut stream = backend
@@ -218,6 +219,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let factory = super::BackendFactory::new(config);
 
@@ -264,6 +266,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         let factory = super::BackendFactory::new(config);
 

--- a/src/backend/ollama.rs
+++ b/src/backend/ollama.rs
@@ -33,6 +33,12 @@ impl OllamaParser {
             events.push(StreamEvent::TextDelta(content.to_string()));
         }
 
+        if let Some(thinking) = json["message"]["thinking"].as_str()
+            && !thinking.is_empty()
+        {
+            events.push(StreamEvent::ThinkingDelta(thinking.to_string()));
+        }
+
         if let Some(tool_calls) = json["message"]["tool_calls"].as_array() {
             for (idx, tool_call) in tool_calls.iter().enumerate() {
                 let function = &tool_call["function"];
@@ -186,6 +192,8 @@ impl OllamaBackend {
                                         }
                                     }));
                                 }
+                                ContentBlock::Thinking { .. }
+                                | ContentBlock::RedactedThinking { .. } => {}
                                 _ => {}
                             }
                         }
@@ -202,6 +210,8 @@ impl OllamaBackend {
                             .iter()
                             .filter_map(|block| match block {
                                 ContentBlock::Text(text) => Some(text.as_str()),
+                                ContentBlock::Thinking { .. }
+                                | ContentBlock::RedactedThinking { .. } => None,
                                 _ => None,
                             })
                             .collect::<Vec<_>>()
@@ -223,6 +233,12 @@ impl OllamaBackend {
                 "num_predict": config.max_tokens
             }
         });
+
+        if let Some(ref thinking_config) = config.thinking
+            && thinking_config.enabled
+        {
+            body["options"]["thinking"] = serde_json::json!(true);
+        }
 
         if !config.tools.is_empty() {
             let tools_json: Vec<serde_json::Value> = config
@@ -396,6 +412,7 @@ mod tests {
             model: "gpt-oss:120b".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -431,6 +448,7 @@ mod tests {
                     "required": ["command"]
                 }),
             }],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -459,6 +477,7 @@ mod tests {
             model: "gpt-oss:120b".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -490,6 +509,7 @@ mod tests {
                 description: "Run bash".to_string(),
                 input_schema: serde_json::json!({"type": "object", "properties": {}}),
             }],
+            thinking: None,
         };
         let body = backend.build_request_body(&[], &config);
         assert!(
@@ -510,6 +530,7 @@ mod tests {
             model: "gpt-oss:120b".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::Assistant,
@@ -549,6 +570,7 @@ mod tests {
             model: "gpt-oss:120b".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -579,6 +601,7 @@ mod tests {
             model: "gpt-oss:120b".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![
             Message {
@@ -700,5 +723,85 @@ mod tests {
         assert!(matches!(&events[1], StreamEvent::ToolUseStart { .. }));
         assert!(matches!(&events[2], StreamEvent::ToolUseDelta(_)));
         assert!(matches!(&events[3], StreamEvent::ToolUseDone));
+    }
+
+    #[test]
+    fn parser_thinking_field_produces_thinking_delta() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"content":"","thinking":"Let me reason about this..."}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], StreamEvent::ThinkingDelta(t) if t == "Let me reason about this...")
+        );
+    }
+
+    #[test]
+    fn parser_thinking_field_empty_produces_no_thinking_delta() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"content":"","thinking":""}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn request_body_with_thinking_adds_thinking_option() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig::default()),
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+        assert_eq!(body["options"]["thinking"], true);
+    }
+
+    #[test]
+    fn request_body_without_thinking_has_no_thinking_option() {
+        let backend = OllamaBackend::new(&OllamaConfig {
+            api_key: "test-key".to_string(),
+            model: "gpt-oss:120b".to_string(),
+            base_url: "https://ollama.com/api/chat".to_string(),
+        })
+        .unwrap();
+        let config = RequestConfig {
+            model: "gpt-oss:120b".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+            thinking: None,
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+        assert!(
+            body["options"].get("thinking").is_none(),
+            "should not include thinking option when config.thinking is None"
+        );
+    }
+
+    #[test]
+    fn parser_chunk_with_both_thinking_and_content() {
+        let mut parser = OllamaParser::new();
+        let chunk = r#"{"message":{"content":"Here is the answer","thinking":"Let me work through this step by step..."}}"#;
+        let events = parser.parse_chunk(chunk).unwrap();
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], StreamEvent::TextDelta(t) if t == "Here is the answer"));
+        assert!(
+            matches!(&events[1], StreamEvent::ThinkingDelta(t) if t == "Let me work through this step by step...")
+        );
     }
 }

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -13,10 +13,11 @@ use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 /// Required protocol version string for Vertex AI's Anthropic API.
 const ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 
-/// Stateful SSE parser that tracks which block indices are tool_use blocks.
+/// Stateful SSE parser that tracks which block indices are tool_use or thinking blocks.
 #[derive(Default)]
 pub struct VertexSseParser {
     tool_use_indices: HashSet<u64>,
+    thinking_indices: HashSet<u64>,
     input_tokens: u32,
     /// Buffer for events when multiple events appear in a single SSE chunk
     pub(crate) event_buffer: Vec<StreamEvent>,
@@ -60,40 +61,68 @@ impl VertexSseParser {
                 let block_type = json["content_block"]["type"]
                     .as_str()
                     .ok_or_else(|| anyhow::anyhow!("content_block_start missing 'type'"))?;
-                if block_type == "tool_use" {
-                    let index = json["index"]
-                        .as_u64()
-                        .ok_or_else(|| anyhow::anyhow!("content_block_start missing 'index'"))?;
-                    self.tool_use_indices.insert(index);
-                    let id = json["content_block"]["id"]
-                        .as_str()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!("tool_use content_block_start missing 'id'")
-                        })?
-                        .to_string();
-                    let name = json["content_block"]["name"]
-                        .as_str()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!("tool_use content_block_start missing 'name'")
-                        })?
-                        .to_string();
-                    self.event_buffer
-                        .push(StreamEvent::ToolUseStart { id, name });
+                match block_type {
+                    "tool_use" => {
+                        let index = json["index"].as_u64().ok_or_else(|| {
+                            anyhow::anyhow!("content_block_start missing 'index'")
+                        })?;
+                        self.tool_use_indices.insert(index);
+                        let id = json["content_block"]["id"]
+                            .as_str()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("tool_use content_block_start missing 'id'")
+                            })?
+                            .to_string();
+                        let name = json["content_block"]["name"]
+                            .as_str()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("tool_use content_block_start missing 'name'")
+                            })?
+                            .to_string();
+                        self.event_buffer
+                            .push(StreamEvent::ToolUseStart { id, name });
+                    }
+                    "thinking" => {
+                        let index = json["index"].as_u64().ok_or_else(|| {
+                            anyhow::anyhow!("content_block_start missing 'index'")
+                        })?;
+                        self.thinking_indices.insert(index);
+                    }
+                    "redacted_thinking" => {
+                        let index = json["index"].as_u64().ok_or_else(|| {
+                            anyhow::anyhow!("content_block_start missing 'index'")
+                        })?;
+                        self.thinking_indices.insert(index);
+                        if let Some(data) = json["content_block"]["data"].as_str() {
+                            self.event_buffer
+                                .push(StreamEvent::ThinkingDelta(data.to_string()));
+                        }
+                    }
+                    _ => {}
                 }
             }
             "content_block_delta" => {
                 let delta_type = json["delta"]["type"]
                     .as_str()
                     .ok_or_else(|| anyhow::anyhow!("content_block_delta missing 'type'"))?;
-                if delta_type == "input_json_delta" {
-                    let chunk = json["delta"]["partial_json"]
-                        .as_str()
-                        .ok_or_else(|| anyhow::anyhow!("input_json_delta missing 'partial_json'"))?
-                        .to_string();
-                    self.event_buffer.push(StreamEvent::ToolUseDelta(chunk));
-                } else {
-                    let text = json["delta"]["text"].as_str().unwrap_or("").to_string();
-                    self.event_buffer.push(StreamEvent::TextDelta(text));
+                match delta_type {
+                    "input_json_delta" => {
+                        let chunk = json["delta"]["partial_json"]
+                            .as_str()
+                            .ok_or_else(|| {
+                                anyhow::anyhow!("input_json_delta missing 'partial_json'")
+                            })?
+                            .to_string();
+                        self.event_buffer.push(StreamEvent::ToolUseDelta(chunk));
+                    }
+                    "thinking_delta" => {
+                        let text = json["delta"]["thinking"].as_str().unwrap_or("").to_string();
+                        self.event_buffer.push(StreamEvent::ThinkingDelta(text));
+                    }
+                    _ => {
+                        let text = json["delta"]["text"].as_str().unwrap_or("").to_string();
+                        self.event_buffer.push(StreamEvent::TextDelta(text));
+                    }
                 }
             }
             "content_block_stop" => {
@@ -103,6 +132,7 @@ impl VertexSseParser {
                 if self.tool_use_indices.remove(&index) {
                     self.event_buffer.push(StreamEvent::ToolUseDone);
                 }
+                self.thinking_indices.remove(&index);
             }
             "message_delta" => {
                 let stop_reason = json["delta"]["stop_reason"]
@@ -282,12 +312,19 @@ impl LlmBackend for VertexBackend {
 
         let url = self.endpoint(&config.model);
         let body = build_request_body(messages, config)?;
+        let thinking_enabled = config.thinking.as_ref().is_some_and(|tc| tc.enabled);
 
-        let response = self
+        let mut request = self
             .client
             .post(&url)
             .bearer_auth(&token_str)
-            .header("Content-Type", "application/json")
+            .header("Content-Type", "application/json");
+
+        if thinking_enabled {
+            request = request.header("anthropic-beta", "interleaved-thinking-2025-05-14");
+        }
+
+        let response = request
             .json(&body)
             .send()
             .await
@@ -324,12 +361,37 @@ fn build_request_body(messages: &[Message], config: &RequestConfig) -> Result<se
         })
         .collect();
 
+    let mut max_tokens = config.max_tokens as u64;
+
+    let thinking_json = config.thinking.as_ref().and_then(|tc| {
+        if !tc.enabled {
+            return None;
+        }
+        match &tc.mode {
+            crate::types::ThinkingMode::Budget { tokens } => {
+                let budget = *tokens as u64;
+                max_tokens += budget;
+                Some(serde_json::json!({
+                    "type": "enabled",
+                    "budget_tokens": budget
+                }))
+            }
+            crate::types::ThinkingMode::Adaptive => Some(serde_json::json!({
+                "type": "adaptive"
+            })),
+        }
+    });
+
     let mut body = serde_json::json!({
         "anthropic_version": ANTHROPIC_VERSION,
-        "max_tokens": config.max_tokens,
+        "max_tokens": max_tokens,
         "stream": true,
         "messages": messages_json,
     });
+
+    if let Some(thinking) = thinking_json {
+        body["thinking"] = thinking;
+    }
 
     if !config.tools.is_empty() {
         body["tools"] =
@@ -360,6 +422,7 @@ mod tests {
             model: "claude-test".to_string(),
             max_tokens: 32768,
             tools: vec![],
+            thinking: None,
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
         assert_eq!(body["max_tokens"], 32768);
@@ -372,6 +435,7 @@ mod tests {
             model: "claude-test".to_string(),
             max_tokens: 8192,
             tools: vec![],
+            thinking: None,
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
         assert!(
@@ -390,6 +454,7 @@ mod tests {
                 description: "Run a bash command".to_string(),
                 input_schema: serde_json::json!({"type": "object", "properties": {"command": {"type": "string"}}}),
             }],
+            thinking: None,
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
         let tools = body["tools"].as_array().expect("tools should be an array");
@@ -408,6 +473,7 @@ mod tests {
                 description: "Run a bash command".to_string(),
                 input_schema: serde_json::json!({"type": "object", "properties": {}}),
             }],
+            thinking: None,
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
         assert_eq!(body["tool_choice"]["type"], "auto");
@@ -420,6 +486,7 @@ mod tests {
             model: "claude-test".to_string(),
             max_tokens: 8192,
             tools: vec![],
+            thinking: None,
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
         assert!(
@@ -642,5 +709,157 @@ mod tests {
 
         let event4 = parser.parse("").expect("fourth parse");
         assert!(event4.is_none(), "buffer should be empty after 3 events");
+    }
+
+    #[test]
+    fn parser_thinking_delta_returns_thinking_delta() {
+        let mut parser = VertexSseParser::new();
+        let data = r#"{"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"Let me reason about this"}}"#;
+        let result = parser.parse(data).expect("should parse successfully");
+        match result {
+            Some(StreamEvent::ThinkingDelta(text)) => {
+                assert_eq!(text, "Let me reason about this");
+            }
+            other => panic!("expected ThinkingDelta, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parser_thinking_block_start_does_not_emit_event() {
+        let mut parser = VertexSseParser::new();
+        let data = r#"{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}"#;
+        let result = parser.parse(data).expect("should parse successfully");
+        assert!(
+            result.is_none(),
+            "thinking content_block_start should return None, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn parser_redacted_thinking_block_start_captures_data() {
+        let mut parser = VertexSseParser::new();
+        let data = r#"{"type":"content_block_start","index":2,"content_block":{"type":"redacted_thinking","data":"aGVsbG8gd29ybGQ="}}"#;
+        let result = parser.parse(data).expect("should parse successfully");
+        match result {
+            Some(StreamEvent::ThinkingDelta(data)) => {
+                assert_eq!(data, "aGVsbG8gd29ybGQ=");
+            }
+            other => panic!(
+                "expected ThinkingDelta for redacted_thinking, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn parser_redacted_thinking_block_start_without_data_does_not_emit() {
+        let mut parser = VertexSseParser::new();
+        let data = r#"{"type":"content_block_start","index":2,"content_block":{"type":"redacted_thinking"}}"#;
+        let result = parser.parse(data).expect("should parse successfully");
+        assert!(
+            result.is_none(),
+            "redacted_thinking without data should return None, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn parser_content_block_stop_after_thinking_returns_none() {
+        let mut parser = VertexSseParser::new();
+        parser
+            .parse(r#"{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}"#)
+            .expect("should parse thinking block_start");
+        let result = parser
+            .parse(r#"{"type":"content_block_stop","index":1}"#)
+            .expect("should parse block_stop");
+        assert!(
+            result.is_none(),
+            "stopping a thinking block should return None, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn build_request_body_with_budget_thinking_includes_thinking_params() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Budget { tokens: 16384 },
+                enabled: true,
+                budget_tokens: 16384,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 16384);
+    }
+
+    #[test]
+    fn build_request_body_with_adaptive_thinking_includes_thinking_params() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Adaptive,
+                enabled: true,
+                budget_tokens: 8192,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["type"], "adaptive");
+    }
+
+    #[test]
+    fn build_request_body_with_thinking_adjusts_max_tokens() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Budget { tokens: 16384 },
+                enabled: true,
+                budget_tokens: 16384,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["max_tokens"], 24576);
+    }
+
+    #[test]
+    fn build_request_body_without_thinking_has_no_thinking_field() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: None,
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must not be in the request body when None"
+        );
+    }
+
+    #[test]
+    fn build_request_body_with_disabled_thinking_has_no_thinking_field() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Adaptive,
+                enabled: false,
+                budget_tokens: 8192,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must not be in the request body when disabled"
+        );
     }
 }

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -13,11 +13,12 @@ use crate::types::{BoxStream, Message, RequestConfig, StreamEvent};
 /// Required protocol version string for Vertex AI's Anthropic API.
 const ANTHROPIC_VERSION: &str = "vertex-2023-10-16";
 
-/// Stateful SSE parser that tracks which block indices are tool_use or thinking blocks.
+/// Stateful SSE parser that tracks which block indices are tool_use blocks.
 #[derive(Default)]
 pub struct VertexSseParser {
     tool_use_indices: HashSet<u64>,
-    thinking_indices: HashSet<u64>,
+    /// Tracks which indices are thinking blocks so we can emit ThinkingSignature at stop.
+    thinking_signatures: HashMap<u64, String>,
     input_tokens: u32,
     /// Buffer for events when multiple events appear in a single SSE chunk
     pub(crate) event_buffer: Vec<StreamEvent>,
@@ -86,13 +87,19 @@ impl VertexSseParser {
                         let index = json["index"].as_u64().ok_or_else(|| {
                             anyhow::anyhow!("content_block_start missing 'index'")
                         })?;
-                        self.thinking_indices.insert(index);
+                        // Signature may be present in content_block_start for some API versions
+                        let sig = json["content_block"]["signature"]
+                            .as_str()
+                            .unwrap_or("")
+                            .to_string();
+                        self.thinking_signatures.insert(index, sig);
                     }
                     "redacted_thinking" => {
                         let index = json["index"].as_u64().ok_or_else(|| {
                             anyhow::anyhow!("content_block_start missing 'index'")
                         })?;
-                        self.thinking_indices.insert(index);
+                        // Redacted thinking doesn't need a signature — it carries opaque data
+                        self.thinking_signatures.insert(index, String::new());
                         if let Some(data) = json["content_block"]["data"].as_str() {
                             self.event_buffer
                                 .push(StreamEvent::ThinkingDelta(data.to_string()));
@@ -132,7 +139,9 @@ impl VertexSseParser {
                 if self.tool_use_indices.remove(&index) {
                     self.event_buffer.push(StreamEvent::ToolUseDone);
                 }
-                self.thinking_indices.remove(&index);
+                if let Some(sig) = self.thinking_signatures.remove(&index) {
+                    self.event_buffer.push(StreamEvent::ThinkingSignature(sig));
+                }
             }
             "message_delta" => {
                 let stop_reason = json["delta"]["stop_reason"]
@@ -765,19 +774,23 @@ mod tests {
     }
 
     #[test]
-    fn parser_content_block_stop_after_thinking_returns_none() {
+    fn parser_content_block_stop_after_thinking_emits_signature() {
         let mut parser = VertexSseParser::new();
         parser
-            .parse(r#"{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}"#)
+            .parse(r#"{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":"","signature":"sig_test"}}"#)
             .expect("should parse thinking block_start");
         let result = parser
             .parse(r#"{"type":"content_block_stop","index":1}"#)
             .expect("should parse block_stop");
-        assert!(
-            result.is_none(),
-            "stopping a thinking block should return None, got {:?}",
-            result
-        );
+        match result {
+            Some(StreamEvent::ThinkingSignature(sig)) => {
+                assert_eq!(
+                    sig, "sig_test",
+                    "signature should match the one from content_block_start"
+                );
+            }
+            other => panic!("expected ThinkingSignature, got {:?}", other),
+        }
     }
 
     #[test]
@@ -789,7 +802,6 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Budget { tokens: 16384 },
                 enabled: true,
-                budget_tokens: 16384,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
@@ -806,7 +818,6 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Adaptive,
                 enabled: true,
-                budget_tokens: 8192,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
@@ -822,7 +833,6 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Budget { tokens: 16384 },
                 enabled: true,
-                budget_tokens: 16384,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
@@ -853,7 +863,6 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Adaptive,
                 enabled: false,
-                budget_tokens: 8192,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -962,7 +962,6 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
-                budget_tokens: 8192,
             }),
         };
         let messages = vec![Message {

--- a/src/backend/zai.rs
+++ b/src/backend/zai.rs
@@ -81,6 +81,14 @@ impl ZaiSseParser {
             }
         }
 
+        if let Some(reasoning) = json["choices"][0]["delta"]["reasoning_content"].as_str()
+            && !reasoning.is_empty()
+        {
+            self.event_buffer
+                .push(StreamEvent::ThinkingDelta(reasoning.to_string()));
+            return Ok(());
+        }
+
         if let Some(content) = json["choices"][0]["delta"]["content"].as_str()
             && !content.is_empty()
         {
@@ -214,6 +222,10 @@ impl ZaiBackend {
                                         }
                                     }));
                                 }
+                                ContentBlock::Thinking { .. }
+                                | ContentBlock::RedactedThinking { .. } => {
+                                    // Skip — z.ai doesn't support thinking blocks in message history
+                                }
                                 _ => {}
                             }
                         }
@@ -231,6 +243,11 @@ impl ZaiBackend {
                                 .map(|block| match block {
                                     ContentBlock::Text(text) => {
                                         serde_json::json!({"type": "text", "text": text})
+                                    }
+                                    ContentBlock::Thinking { .. }
+                                    | ContentBlock::RedactedThinking { .. } => {
+                                        // Skip — z.ai doesn't support thinking blocks in message history
+                                        serde_json::Value::Null
                                     }
                                     other => serde_json::to_value(other)
                                         .unwrap_or(serde_json::Value::Null),
@@ -268,6 +285,12 @@ impl ZaiBackend {
                 .collect();
             body["tools"] = serde_json::json!(tools_json);
             body["parallel_tool_calls"] = serde_json::json!(true);
+        }
+
+        if let Some(ref thinking_config) = config.thinking
+            && thinking_config.enabled
+        {
+            body["enable_thinking"] = serde_json::json!(true);
         }
 
         body
@@ -340,6 +363,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -360,6 +384,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![
             Message {
@@ -394,6 +419,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -490,6 +516,7 @@ mod tests {
                     }),
                 },
             ],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -534,6 +561,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -564,6 +592,7 @@ mod tests {
                 description: "Run bash".to_string(),
                 input_schema: serde_json::json!({"type": "object", "properties": {}}),
             }],
+            thinking: None,
         };
         let messages = vec![];
 
@@ -781,6 +810,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![
             Message {
@@ -827,6 +857,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![Message {
             role: Role::User,
@@ -852,6 +883,7 @@ mod tests {
             model: "glm-5-turbo".to_string(),
             max_tokens: 4096,
             tools: vec![],
+            thinking: None,
         };
         let messages = vec![
             Message {
@@ -885,5 +917,86 @@ mod tests {
         assert_eq!(msgs[2]["role"], "tool");
         assert_eq!(msgs[2]["tool_call_id"], "tool_0");
         assert_eq!(msgs[2]["content"], "file1.txt");
+    }
+
+    #[test]
+    fn parse_sse_data_extracts_reasoning_content_as_thinking_delta() {
+        let mut parser = ZaiSseParser::new();
+        let data = r#"{"choices":[{"delta":{"reasoning_content":"Let me think about this step by step."}}]}"#;
+        let result = parser.parse(data);
+        assert!(
+            result.is_ok(),
+            "Should successfully parse reasoning_content SSE data"
+        );
+        let event = result.unwrap();
+        assert!(event.is_some(), "Should return Some(event)");
+        assert!(
+            matches!(event, Some(StreamEvent::ThinkingDelta(_))),
+            "Should be ThinkingDelta, got: {:?}",
+            event
+        );
+        if let Some(StreamEvent::ThinkingDelta(text)) = event {
+            assert_eq!(text, "Let me think about this step by step.");
+        }
+    }
+
+    #[test]
+    fn parse_sse_data_reasoning_content_empty_produces_no_event() {
+        let mut parser = ZaiSseParser::new();
+        let data = r#"{"choices":[{"delta":{"reasoning_content":""}}]}"#;
+        let result = parser.parse(data);
+        assert!(result.is_ok());
+        assert!(
+            result.unwrap().is_none(),
+            "Empty reasoning_content should produce no event"
+        );
+    }
+
+    #[test]
+    fn build_request_body_with_thinking_enabled_adds_enable_thinking() {
+        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
+        let config = RequestConfig {
+            model: "glm-5-turbo".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                enabled: true,
+                mode: crate::types::ThinkingMode::Adaptive,
+                budget_tokens: 8192,
+            }),
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        assert_eq!(
+            body["enable_thinking"], true,
+            "enable_thinking should be true when thinking is enabled"
+        );
+    }
+
+    #[test]
+    fn build_request_body_without_thinking_has_no_enable_thinking() {
+        let backend = ZaiBackend::new("test-key".to_string()).unwrap();
+        let config = RequestConfig {
+            model: "glm-5-turbo".to_string(),
+            max_tokens: 4096,
+            tools: vec![],
+            thinking: None,
+        };
+        let messages = vec![Message {
+            role: Role::User,
+            content: vec![ContentBlock::Text("Hello".to_string())],
+        }];
+
+        let body = backend.build_request_body(&messages, &config);
+
+        assert!(
+            body.get("enable_thinking").is_none(),
+            "enable_thinking should not be present when thinking is None"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,16 @@ model = "gpt-oss:120b"
 # Shell commands that are always blocked
 # bash_denylist = ["rm", "wget", "sudo", "chmod", "chown"]
 
+# Extended thinking configuration for models that support it (Vertex AI / Anthropic).
+# [thinking]
+# Whether thinking is enabled (default: true)
+# enabled = true
+# Thinking mode: "budget" (fixed token count) or "adaptive" (model decides)
+# For budget mode, set the token budget in the mode field:
+#   mode = { type = "budget", tokens = 8192 }
+# For adaptive mode:
+#   mode = { type = "adaptive" }
+
 # Named model roles for multi-agent workflows.
 # When absent, a "default" role is synthesized from the top-level backend
 # and the matching [vertex]/[zai]/[ollama] model field above.

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,12 +153,6 @@ model = "gpt-oss:120b"
 # [models.implement]
 # backend = "vertex"
 # model = "claude-sonnet-4-20250514"
-
-# [thinking]
-# Whether extended thinking is enabled
-# enabled = true
-# Thinking mode: "budget" (fixed token count) or "adaptive" (model decides)
-# mode = { type = "adaptive" }
 "#;
 
 /// A named model role binding a backend to a specific model string.

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,8 +149,6 @@ model = "gpt-oss:120b"
 # enabled = true
 # Thinking mode: "budget" (fixed token count) or "adaptive" (model decides)
 # mode = { type = "adaptive" }
-# Default token budget when mode is "budget"
-# budget_tokens = 8192
 "#;
 
 /// A named model role binding a backend to a specific model string.
@@ -1448,13 +1446,11 @@ mod tests {
             project = "my-project"
             [thinking]
             enabled = true
-            budget_tokens = 16384
             mode = { type = "adaptive" }
         "#;
         let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
         let thinking = config.thinking.expect("thinking should be present");
         assert!(thinking.enabled);
-        assert_eq!(thinking.budget_tokens, 16384);
         assert_eq!(thinking.mode, crate::types::ThinkingMode::Adaptive);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,6 +143,14 @@ model = "gpt-oss:120b"
 # [models.implement]
 # backend = "vertex"
 # model = "claude-sonnet-4-20250514"
+
+# [thinking]
+# Whether extended thinking is enabled
+# enabled = true
+# Thinking mode: "budget" (fixed token count) or "adaptive" (model decides)
+# mode = { type = "adaptive" }
+# Default token budget when mode is "budget"
+# budget_tokens = 8192
 "#;
 
 /// A named model role binding a backend to a specific model string.
@@ -176,6 +184,8 @@ pub struct AppConfig {
     /// the top-level `backend` + `[vertex]`/`[zai]` blocks for back-compat.
     #[serde(default, rename = "models")]
     pub models: BTreeMap<String, ModelRole>,
+    #[serde(default)]
+    pub thinking: Option<crate::types::ThinkingConfig>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
@@ -603,6 +613,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -623,6 +634,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_ok());
@@ -642,6 +654,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -665,6 +678,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -688,6 +702,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_ok());
@@ -707,6 +722,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -727,6 +743,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let msg = generate_intro_message(&config);
         assert!(msg.contains("vertex"), "should mention backend name");
@@ -755,6 +772,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let msg = generate_intro_message(&config);
         assert!(msg.contains("zai"), "should mention backend name");
@@ -781,6 +799,7 @@ mod tests {
             },
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let msg = generate_intro_message(&config);
         assert!(msg.contains("Always"), "should mention confirmation mode");
@@ -803,6 +822,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: sessions_dir.clone(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let msg = generate_intro_message(&config);
         assert!(
@@ -825,6 +845,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let msg = generate_intro_message(&config);
         assert!(msg.starts_with("# "), "should start with markdown heading");
@@ -878,6 +899,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         config.normalize_back_compat();
         assert!(
@@ -924,6 +946,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         config.normalize_back_compat();
         assert_eq!(
@@ -975,6 +998,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         let resolved = config.resolve_role("fast").expect("should resolve");
         assert_eq!(resolved.backend_name, "vertex");
@@ -995,6 +1019,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = config.resolve_role("nonexistent");
         assert!(result.is_err());
@@ -1023,6 +1048,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -1058,6 +1084,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -1082,6 +1109,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -1106,6 +1134,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -1130,6 +1159,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_ok());
@@ -1153,6 +1183,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_ok());
@@ -1176,6 +1207,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         apply_overrides(&mut config, None, None, Some("custom-model"));
         assert_eq!(
@@ -1207,6 +1239,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         config.normalize_back_compat();
 
@@ -1238,6 +1271,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         config.normalize_back_compat();
 
@@ -1267,6 +1301,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         config.normalize_back_compat();
 
@@ -1300,6 +1335,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_err());
@@ -1336,6 +1372,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models,
+            thinking: None,
         };
         let result = validate(&config, None);
         assert!(result.is_ok(), "ollama role with valid config should pass");
@@ -1392,11 +1429,77 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         };
         let msg = generate_intro_message(&config);
         assert!(msg.contains("ollama"), "should mention backend name");
         assert!(msg.contains("gpt-oss:120b"), "should mention ollama model");
         assert!(msg.contains("ollama.com"), "should mention base_url");
         assert!(!msg.contains("secret-key"), "should not leak API key");
+    }
+
+    // ── Thinking config tests ─────────────────────────────────────────────
+
+    #[test]
+    fn thinking_section_parses_from_toml() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            enabled = true
+            budget_tokens = 16384
+            mode = { type = "adaptive" }
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        let thinking = config.thinking.expect("thinking should be present");
+        assert!(thinking.enabled);
+        assert_eq!(thinking.budget_tokens, 16384);
+        assert_eq!(thinking.mode, crate::types::ThinkingMode::Adaptive);
+    }
+
+    #[test]
+    fn thinking_section_defaults_to_none() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        assert!(
+            config.thinking.is_none(),
+            "thinking should be None when not specified"
+        );
+    }
+
+    #[test]
+    fn thinking_budget_mode_parses_correctly() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            mode = { type = "budget", tokens = 16384 }
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        let thinking = config.thinking.expect("thinking should be present");
+        assert_eq!(
+            thinking.mode,
+            crate::types::ThinkingMode::Budget { tokens: 16384 }
+        );
+    }
+
+    #[test]
+    fn thinking_adaptive_mode_parses_correctly() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            mode = { type = "adaptive" }
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        let thinking = config.thinking.expect("thinking should be present");
+        assert_eq!(thinking.mode, crate::types::ThinkingMode::Adaptive);
     }
 }

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -137,6 +137,12 @@ async fn run_text<W: Write, R: BufRead>(
             AgentEvent::Usage { .. } => {}
             AgentEvent::SubAgentUsage { .. } => {}
             AgentEvent::Warn(_) => {}
+            AgentEvent::ThinkingReceived(text) => {
+                if logger.is_some() {
+                    write!(writer, "// {}", text)?;
+                    writer.flush()?;
+                }
+            }
             AgentEvent::Interrupted { .. } => {
                 writeln!(writer, "\n*(interrupted)*")?;
                 break;
@@ -197,6 +203,7 @@ async fn collect_response<R: BufRead>(
             AgentEvent::Usage { .. } => {}
             AgentEvent::SubAgentUsage { .. } => {}
             AgentEvent::Warn(_) => {}
+            AgentEvent::ThinkingReceived(_) => {}
             AgentEvent::Interrupted { partial_text } => {
                 is_error = true;
                 result_text = partial_text;
@@ -789,6 +796,7 @@ mod tests {
             model: "test".to_string(),
             max_tokens: 1024,
             tools: vec![],
+            thinking: None,
         };
         Arc::new(Agent::new(Box::new(backend), config, session).await)
     }

--- a/src/frontend/tui/commands.rs
+++ b/src/frontend/tui/commands.rs
@@ -219,6 +219,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::env::temp_dir(),
             models: BTreeMap::new(),
+            thinking: None,
         }
     }
 
@@ -270,6 +271,7 @@ mod tests {
                         model: "test".to_string(),
                         max_tokens: 1024,
                         tools: vec![],
+                        thinking: None,
                     },
                     session,
                 )
@@ -309,6 +311,7 @@ mod tests {
                         model: "test".to_string(),
                         max_tokens: 1024,
                         tools: vec![],
+                        thinking: None,
                     },
                     session,
                 )
@@ -347,6 +350,7 @@ mod tests {
                         model: "test".to_string(),
                         max_tokens: 1024,
                         tools: vec![],
+                        thinking: None,
                     },
                     session,
                 )
@@ -385,6 +389,7 @@ mod tests {
                         model: "claude-original".to_string(),
                         max_tokens: 1024,
                         tools: vec![],
+                        thinking: None,
                     },
                     session,
                 )
@@ -423,6 +428,7 @@ mod tests {
                         model: "claude-original".to_string(),
                         max_tokens: 1024,
                         tools: vec![],
+                        thinking: None,
                     },
                     session,
                 )
@@ -484,6 +490,7 @@ mod tests {
                         model: "test".to_string(),
                         max_tokens: 1024,
                         tools: vec![],
+                        thinking: None,
                     },
                     session,
                 )
@@ -531,6 +538,7 @@ mod tests {
                     model: "test".to_string(),
                     max_tokens: 1024,
                     tools: vec![],
+                    thinking: None,
                 },
                 session_arc,
             )

--- a/src/frontend/tui/conversation_area.rs
+++ b/src/frontend/tui/conversation_area.rs
@@ -19,6 +19,7 @@ pub enum ConversationRole {
     ToolUse,
     ToolResult,
     Info,
+    Thinking,
 }
 
 impl ConversationRole {
@@ -30,6 +31,7 @@ impl ConversationRole {
             ConversationRole::ToolUse => "[Tool]",
             ConversationRole::ToolResult => "[Result]",
             ConversationRole::Info => "Info",
+            ConversationRole::Thinking => "[Thinking]",
         }
     }
 
@@ -41,6 +43,7 @@ impl ConversationRole {
             ConversationRole::ToolUse => Color::Cyan,
             ConversationRole::ToolResult => Color::Yellow,
             ConversationRole::Info => Color::Magenta,
+            ConversationRole::Thinking => Color::DarkGray,
         }
     }
 }
@@ -793,6 +796,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::path::PathBuf::from("/sessions"),
             models: std::collections::BTreeMap::new(),
+            thinking: None,
         };
         let mut entries = vec![ConversationEntry::new(
             ConversationRole::Info,

--- a/src/frontend/tui/conversation_area.rs
+++ b/src/frontend/tui/conversation_area.rs
@@ -207,6 +207,16 @@ fn render_current_response_lines(current_response: &str, text_width: u16) -> Vec
     )
 }
 
+fn render_current_thinking_lines(current_thinking: &str, text_width: u16) -> Vec<Line<'static>> {
+    render_role_lines(
+        &ConversationRole::Thinking,
+        None,
+        current_thinking,
+        false,
+        text_width,
+    )
+}
+
 fn estimate_wrapped_count(lines: &[Line<'_>], text_width: u16) -> u16 {
     if text_width == 0 {
         return lines.len() as u16;
@@ -222,6 +232,7 @@ fn estimate_wrapped_count(lines: &[Line<'_>], text_width: u16) -> u16 {
 
 pub struct ConversationArea<'a> {
     entries: &'a mut [ConversationEntry],
+    current_thinking: &'a str,
     current_response: &'a str,
     scroll_offset: u16,
     viewport_height: u16,
@@ -230,12 +241,14 @@ pub struct ConversationArea<'a> {
 impl<'a> ConversationArea<'a> {
     pub fn new(
         entries: &'a mut [ConversationEntry],
+        current_thinking: &'a str,
         current_response: &'a str,
         scroll_offset: u16,
         viewport_height: u16,
     ) -> Self {
         Self {
             entries,
+            current_thinking,
             current_response,
             scroll_offset,
             viewport_height,
@@ -253,6 +266,13 @@ impl<'a> ConversationArea<'a> {
         let entry_counts = self.compute_entry_counts(text_width);
         let total_entries: u16 = entry_counts.iter().sum();
 
+        let thinking_count = if self.current_thinking.is_empty() {
+            0u16
+        } else {
+            let thinking_lines = render_current_thinking_lines(self.current_thinking, text_width);
+            estimate_wrapped_count(&thinking_lines, text_width)
+        };
+
         let response_count = if self.current_response.is_empty() {
             0u16
         } else {
@@ -260,7 +280,9 @@ impl<'a> ConversationArea<'a> {
             estimate_wrapped_count(&response_lines, text_width)
         };
 
-        let total_visual = total_entries.saturating_add(response_count);
+        let total_visual = total_entries
+            .saturating_add(thinking_count)
+            .saturating_add(response_count);
         total_visual.saturating_sub(self.viewport_height)
     }
 
@@ -269,6 +291,17 @@ impl<'a> ConversationArea<'a> {
 
         let entry_counts = self.compute_entry_counts(text_width);
         let total_entries: u16 = entry_counts.iter().sum();
+
+        let thinking_lines = if self.current_thinking.is_empty() {
+            Vec::new()
+        } else {
+            render_current_thinking_lines(self.current_thinking, text_width)
+        };
+        let thinking_count = if thinking_lines.is_empty() {
+            0u16
+        } else {
+            estimate_wrapped_count(&thinking_lines, text_width)
+        };
 
         let response_lines = if self.current_response.is_empty() {
             Vec::new()
@@ -281,7 +314,9 @@ impl<'a> ConversationArea<'a> {
             estimate_wrapped_count(&response_lines, text_width)
         };
 
-        let total_visual = total_entries.saturating_add(response_count);
+        let total_visual = total_entries
+            .saturating_add(thinking_count)
+            .saturating_add(response_count);
         let auto_scroll = total_visual.saturating_sub(visible_height);
         let scroll_row = auto_scroll.saturating_sub(self.scroll_offset.min(auto_scroll));
 
@@ -289,6 +324,7 @@ impl<'a> ConversationArea<'a> {
         // plus compute how many wrapped lines to skip at the top of the window.
         let (window_lines, lines_to_skip) = self.collect_window_lines(
             &entry_counts,
+            &thinking_lines,
             &response_lines,
             scroll_row,
             visible_height,
@@ -309,6 +345,7 @@ impl<'a> ConversationArea<'a> {
     fn collect_window_lines(
         &self,
         entry_counts: &[u16],
+        thinking_lines: &[Line<'static>],
         response_lines: &[Line<'static>],
         scroll_row: u16,
         visible_height: u16,
@@ -343,6 +380,22 @@ impl<'a> ConversationArea<'a> {
             result.extend(self.entries[i].lines().iter().cloned());
 
             cumulative = entry_end;
+        }
+
+        // Add current thinking lines if they fall within the window
+        if !thinking_lines.is_empty() {
+            let thinking_count = estimate_wrapped_count(thinking_lines, text_width);
+            let thinking_start = cumulative;
+            let thinking_end = cumulative.saturating_add(thinking_count);
+
+            if thinking_end > scroll_row && thinking_start < window_end {
+                if first_included_start.is_none() {
+                    first_included_start = Some(thinking_start);
+                }
+                result.extend(thinking_lines.iter().cloned());
+            }
+
+            cumulative = thinking_end;
         }
 
         // Add current response lines if they fall within the window
@@ -430,7 +483,7 @@ mod tests {
     #[test]
     fn entry_lines_empty_conversation() {
         let entries: &mut [ConversationEntry] = &mut [];
-        let area = ConversationArea::new(entries, "", 0, 10);
+        let area = ConversationArea::new(entries, "", "", 0, 10);
         assert!(area.entries.is_empty());
     }
 
@@ -442,14 +495,55 @@ mod tests {
         ];
         let total_lines: usize = entries.iter().map(|e| e.lines().len()).sum();
         assert_eq!(total_lines, 6);
-        let _ = ConversationArea::new(&mut entries, "", 0, 10);
+        let _ = ConversationArea::new(&mut entries, "", "", 0, 10);
     }
 
     #[test]
     fn entry_lines_with_current_response() {
         let mut entries: Vec<ConversationEntry> = Vec::new();
-        let area = ConversationArea::new(&mut entries, "streaming text", 0, 10);
+        let area = ConversationArea::new(&mut entries, "", "streaming text", 0, 10);
         assert!(!area.current_response.is_empty());
+    }
+
+    #[test]
+    fn entry_lines_with_current_thinking_and_response() {
+        let mut entries: Vec<ConversationEntry> = Vec::new();
+        let area = ConversationArea::new(&mut entries, "my reasoning", "streaming text", 0, 10);
+        assert!(!area.current_thinking.is_empty());
+        assert!(!area.current_response.is_empty());
+    }
+
+    #[test]
+    fn render_current_thinking_appears_above_current_response() {
+        let mut entries: Vec<ConversationEntry> = Vec::new();
+        let backend = ratatui::backend::TestBackend::new(60, 20);
+        let mut terminal = ratatui::Terminal::new(backend).expect("terminal creation");
+        terminal
+            .draw(|frame| {
+                let rect = ratatui::layout::Rect::new(0, 0, 58, 18);
+                let mut area = ConversationArea::new(
+                    &mut entries,
+                    "reasoning about the answer",
+                    "the answer",
+                    0,
+                    18,
+                );
+                area.render(frame, rect, 56);
+            })
+            .expect("draw");
+
+        let rendered = format!("{:?}", terminal.backend());
+        // Thinking label and content must appear before Assistant label and content
+        let thinking_pos = rendered
+            .find("[Thinking]")
+            .expect("should contain [Thinking] label");
+        let assistant_pos = rendered
+            .find("Assistant:")
+            .expect("should contain Assistant label");
+        assert!(
+            thinking_pos < assistant_pos,
+            "thinking should appear above assistant response in rendered output"
+        );
     }
 
     #[test]
@@ -505,7 +599,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -524,7 +618,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -541,7 +635,7 @@ mod tests {
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
                 let mut area_widget =
-                    ConversationArea::new(&mut entries, "Streaming response...", 0, 20);
+                    ConversationArea::new(&mut entries, "", "Streaming response...", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -554,7 +648,7 @@ mod tests {
         let mut entries: Vec<ConversationEntry> = (0..40)
             .map(|i| ConversationEntry::new(ConversationRole::User, format!("line {i}")))
             .collect();
-        let mut area = ConversationArea::new(&mut entries, "", 0, 10);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, 10);
         let max = area.max_scroll(58);
         assert!(max > 0, "should have scrollable content");
     }
@@ -565,7 +659,7 @@ mod tests {
             ConversationRole::User,
             "short".to_string(),
         )];
-        let mut area = ConversationArea::new(&mut entries, "", 0, 100);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, 100);
         let max = area.max_scroll(58);
         assert_eq!(max, 0);
     }
@@ -588,7 +682,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -607,7 +701,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -626,7 +720,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -645,7 +739,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -665,7 +759,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -685,7 +779,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -705,7 +799,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -726,7 +820,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, table, 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", table, 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -750,7 +844,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -772,7 +866,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -807,7 +901,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -826,7 +920,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -866,7 +960,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -925,7 +1019,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 10);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 8);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 8);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -943,7 +1037,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, 12);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 20, 10);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 20, 10);
                 area_widget.render(frame, rect, 58);
             })
             .expect("draw");
@@ -960,7 +1054,7 @@ mod tests {
         )];
         let viewport = 10u16;
         let text_width = 30u16;
-        let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
         let max = area.max_scroll(text_width);
 
         let paragraph = Paragraph::new(entries[0].lines().to_vec()).wrap(Wrap { trim: false });
@@ -988,7 +1082,7 @@ mod tests {
             ));
         }
 
-        let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
         let max = area.max_scroll(text_width);
 
         let all_lines: Vec<Line<'static>> =
@@ -1014,7 +1108,7 @@ mod tests {
             ));
         }
 
-        let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
         let max = area.max_scroll(text_width);
 
         let backend = ratatui::backend::TestBackend::new(60, viewport + 2);
@@ -1022,7 +1116,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, viewport + 2);
-                let mut scrolled_area = ConversationArea::new(&mut entries, "", max, viewport);
+                let mut scrolled_area = ConversationArea::new(&mut entries, "", "", max, viewport);
                 scrolled_area.render(frame, rect, text_width);
             })
             .expect("draw");
@@ -1051,7 +1145,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 60, viewport + 2);
-                let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+                let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
                 area.render(frame, rect, text_width);
             })
             .expect("draw");
@@ -1076,7 +1170,7 @@ mod tests {
             long_text,
         )];
 
-        let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
         let max = area.max_scroll(text_width);
         assert!(max > 0, "should have scrollable content");
 
@@ -1089,7 +1183,7 @@ mod tests {
             terminal
                 .draw(|frame| {
                     let rect = ratatui::layout::Rect::new(0, 0, text_width + 2, viewport + 2);
-                    let mut area = ConversationArea::new(&mut entries, "", scroll, viewport);
+                    let mut area = ConversationArea::new(&mut entries, "", "", scroll, viewport);
                     area.render(frame, rect, text_width);
                 })
                 .expect("draw");
@@ -1127,7 +1221,7 @@ mod tests {
             .collect();
 
         // Verify entries exist so the boundary scenario is meaningful.
-        let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
         let entry_only_max = area.max_scroll(text_width);
         assert!(
             entry_only_max == 0,
@@ -1148,7 +1242,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, text_width + 2, viewport + 2);
-                let mut area = ConversationArea::new(&mut entries, &streaming, 0, viewport);
+                let mut area = ConversationArea::new(&mut entries, "", &streaming, 0, viewport);
                 area.render(frame, rect, text_width);
             })
             .expect("draw");
@@ -1169,7 +1263,7 @@ mod tests {
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, text_width + 2, viewport + 2);
                 let mut area =
-                    ConversationArea::new(&mut entries, &streaming, scroll_up_amount, viewport);
+                    ConversationArea::new(&mut entries, "", &streaming, scroll_up_amount, viewport);
                 area.render(frame, rect, text_width);
             })
             .expect("draw");
@@ -1198,7 +1292,7 @@ mod tests {
             ConversationEntry::new(ConversationRole::User, "final message".to_string()),
         ];
 
-        let mut area = ConversationArea::new(&mut entries, "", 0, viewport);
+        let mut area = ConversationArea::new(&mut entries, "", "", 0, viewport);
         let max = area.max_scroll(text_width);
         assert!(
             max > viewport,
@@ -1215,7 +1309,7 @@ mod tests {
             terminal
                 .draw(|frame| {
                     let rect = ratatui::layout::Rect::new(0, 0, 60, viewport + 2);
-                    let mut area = ConversationArea::new(entries, "", scroll, viewport);
+                    let mut area = ConversationArea::new(entries, "", "", scroll, viewport);
                     area.render(frame, rect, text_width);
                 })
                 .expect("draw");
@@ -1244,7 +1338,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let rect = ratatui::layout::Rect::new(0, 0, 40, 20);
-                let mut area_widget = ConversationArea::new(&mut entries, "", 0, 20);
+                let mut area_widget = ConversationArea::new(&mut entries, "", "", 0, 20);
                 area_widget.render(frame, rect, 38);
             })
             .expect("draw");

--- a/src/frontend/tui/status_line.rs
+++ b/src/frontend/tui/status_line.rs
@@ -49,6 +49,8 @@ pub fn estimate_usage_from_messages(messages: &[crate::types::Message]) -> (u32,
                     name.len() + input.to_string().len()
                 }
                 crate::types::ContentBlock::ToolResult { content, .. } => content.len(),
+                crate::types::ContentBlock::Thinking { text, .. } => text.len(),
+                crate::types::ContentBlock::RedactedThinking { .. } => 0,
             })
             .sum();
 

--- a/src/frontend/tui/status_line.rs
+++ b/src/frontend/tui/status_line.rs
@@ -49,7 +49,8 @@ pub fn estimate_usage_from_messages(messages: &[crate::types::Message]) -> (u32,
                     name.len() + input.to_string().len()
                 }
                 crate::types::ContentBlock::ToolResult { content, .. } => content.len(),
-                crate::types::ContentBlock::Thinking { text, .. } => text.len(),
+                // Thinking is excluded from the context budget estimate
+                crate::types::ContentBlock::Thinking { .. } => 0,
                 crate::types::ContentBlock::RedactedThinking { .. } => 0,
             })
             .sum();
@@ -618,5 +619,39 @@ mod tests {
             .expect("draw");
 
         insta::assert_snapshot!("render_status_line_with_subagent_usage", terminal.backend());
+    }
+
+    #[test]
+    fn estimate_usage_excludes_thinking_blocks() {
+        use crate::types::{ContentBlock, Message, Role};
+
+        let messages = vec![
+            Message {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Thinking {
+                        text: "a very long thinking block that should not count toward tokens"
+                            .to_string(),
+                        signature: "sig".to_string(),
+                    },
+                    ContentBlock::Text("short".to_string()),
+                ],
+            },
+            Message {
+                role: Role::Assistant,
+                content: vec![ContentBlock::RedactedThinking {
+                    data: "opaque data blob".to_string(),
+                }],
+            },
+        ];
+
+        let (input, output) = estimate_usage_from_messages(&messages);
+
+        // Only "short" (5 chars / 4 ≈ 2 tokens) should count
+        assert_eq!(input, 0, "no user messages");
+        assert!(
+            output > 0 && output <= 2,
+            "only the Text block should count, not thinking; got output={output}"
+        );
     }
 }

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -48,6 +48,7 @@ pub struct App {
     pub input: InputArea<'static>,
     pub conversation: Vec<ConversationEntry>,
     pub current_response: String,
+    pub current_thinking: String,
     pub state: AppState,
     pub confirmation_tx: Option<fmpsc::UnboundedSender<ConfirmationResponse>>,
     pub cancel_token: Option<CancellationToken>,
@@ -101,6 +102,7 @@ impl App {
             input: InputArea::new(),
             conversation: Vec::new(),
             current_response: String::new(),
+            current_thinking: String::new(),
             state: AppState::Input,
             confirmation_tx: None,
             cancel_token: None,
@@ -184,6 +186,15 @@ impl App {
                             ConversationEntry::new(entry_role, content.clone())
                         };
                         Some(entry)
+                    }
+                    crate::types::ContentBlock::Thinking { text, .. } => Some(
+                        ConversationEntry::new(ConversationRole::Thinking, text.clone()),
+                    ),
+                    crate::types::ContentBlock::RedactedThinking { .. } => {
+                        Some(ConversationEntry::new(
+                            ConversationRole::Thinking,
+                            "[redacted thinking]".to_string(),
+                        ))
                     }
                 };
                 if let Some(e) = entry {
@@ -441,9 +452,16 @@ pub fn handle_agent_event(
             app.scroll_offset = 0;
         }
         AgentEvent::ResponseComplete(full) => {
+            if !app.current_thinking.is_empty() {
+                app.conversation.push(ConversationEntry::new(
+                    ConversationRole::Thinking,
+                    std::mem::take(&mut app.current_thinking),
+                ));
+            }
             app.conversation
                 .push(ConversationEntry::new(ConversationRole::Assistant, full));
             app.current_response.clear();
+            app.current_thinking.clear();
             app.confirmation_tx = None;
             app.cancel_token = None;
             app.set_state(AppState::Input);
@@ -454,6 +472,7 @@ pub fn handle_agent_event(
             app.conversation
                 .push(ConversationEntry::new(ConversationRole::Error, msg));
             app.current_response.clear();
+            app.current_thinking.clear();
             app.confirmation_tx = None;
             app.cancel_token = None;
             app.set_state(AppState::Input);
@@ -544,6 +563,7 @@ pub fn handle_agent_event(
                 ));
             }
             app.current_response.clear();
+            app.current_thinking.clear();
             app.confirmation_tx = None;
             app.cancel_token = None;
             app.set_state(AppState::Input);
@@ -551,6 +571,9 @@ pub fn handle_agent_event(
         }
         AgentEvent::Warn(_) => {
             // Diagnostic only — written to the debug log via log_event; not shown in UI.
+        }
+        AgentEvent::ThinkingReceived(text) => {
+            app.current_thinking.push_str(&text);
         }
     }
     Ok(())
@@ -974,6 +997,7 @@ mod tests {
                     model: "test".to_string(),
                     max_tokens: 1024,
                     tools: vec![],
+                    thinking: None,
                 },
                 session,
             )
@@ -1890,6 +1914,7 @@ mod tests {
                     model: "test".to_string(),
                     max_tokens: 1024,
                     tools: vec![],
+                    thinking: None,
                 },
                 initial_session,
             )
@@ -1987,6 +2012,7 @@ mod tests {
             tools: ToolsConfig::default(),
             sessions_dir: std::path::PathBuf::from("/sessions"),
             models: std::collections::BTreeMap::new(),
+            thinking: None,
         };
         let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
         app.set_intro_message(generate_intro_message(&config));
@@ -2163,6 +2189,7 @@ mod tests {
                     model: "claude-original".to_string(),
                     max_tokens: 1024,
                     tools: vec![],
+                    thinking: None,
                 },
                 session,
             )
@@ -2207,6 +2234,7 @@ mod tests {
                     model: "claude-original".to_string(),
                     max_tokens: 1024,
                     tools: vec![],
+                    thinking: None,
                 },
                 session,
             )

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -356,6 +356,7 @@ impl App {
         }
         let mut conv_area = ConversationArea::new(
             &mut self.conversation,
+            &self.current_thinking,
             &self.current_response,
             0,
             self.viewport_height,
@@ -389,6 +390,7 @@ pub fn render_app(app: &mut App, frame: &mut ratatui::Frame) {
     app.text_width = text_width;
     let mut conv_area = ConversationArea::new(
         &mut app.conversation,
+        &app.current_thinking,
         &app.current_response,
         app.scroll_offset,
         chunks[0].height.saturating_sub(2),

--- a/src/frontend/tui/tui_app.rs
+++ b/src/frontend/tui/tui_app.rs
@@ -2589,4 +2589,121 @@ mod tests {
             "ToolConfirmation state should clear pending_g"
         );
     }
+
+    // ── Thinking handler tests (Finding 7) ────────────────────────────────
+
+    #[test]
+    fn thinking_received_accumulates_into_current_thinking() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+        assert!(app.current_thinking.is_empty());
+
+        handle_agent_event(
+            &mut app,
+            AgentEvent::ThinkingReceived("reasoning step 1".to_string()),
+            None,
+        )
+        .expect("handle event");
+        assert_eq!(app.current_thinking, "reasoning step 1");
+
+        handle_agent_event(
+            &mut app,
+            AgentEvent::ThinkingReceived(" reasoning step 2".to_string()),
+            None,
+        )
+        .expect("handle event");
+        assert_eq!(
+            app.current_thinking, "reasoning step 1 reasoning step 2",
+            "thinking should accumulate"
+        );
+    }
+
+    #[test]
+    fn thinking_received_then_response_complete_creates_thinking_entry() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        handle_agent_event(
+            &mut app,
+            AgentEvent::ThinkingReceived("my thoughts".to_string()),
+            None,
+        )
+        .expect("handle thinking");
+        handle_agent_event(
+            &mut app,
+            AgentEvent::ResponseComplete("my answer".to_string()),
+            None,
+        )
+        .expect("handle complete");
+
+        let thinking_entries: Vec<_> = app
+            .conversation
+            .iter()
+            .filter(|e| e.role == ConversationRole::Thinking)
+            .collect();
+        assert_eq!(thinking_entries.len(), 1, "should have one thinking entry");
+        assert_eq!(thinking_entries[0].content, "my thoughts");
+
+        let assistant_entries: Vec<_> = app
+            .conversation
+            .iter()
+            .filter(|e| e.role == ConversationRole::Assistant)
+            .collect();
+        assert_eq!(
+            assistant_entries.len(),
+            1,
+            "should have one assistant entry"
+        );
+        assert_eq!(assistant_entries[0].content, "my answer");
+
+        assert!(
+            app.current_thinking.is_empty(),
+            "current_thinking should be cleared after ResponseComplete"
+        );
+    }
+
+    #[test]
+    fn thinking_cleared_on_error_event() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        handle_agent_event(
+            &mut app,
+            AgentEvent::ThinkingReceived("partial thinking".to_string()),
+            None,
+        )
+        .expect("handle thinking");
+        assert!(!app.current_thinking.is_empty());
+
+        handle_agent_event(&mut app, AgentEvent::Error("error".to_string()), None)
+            .expect("handle error");
+
+        assert!(
+            app.current_thinking.is_empty(),
+            "current_thinking should be cleared on Error"
+        );
+    }
+
+    #[test]
+    fn thinking_cleared_on_interrupted_event() {
+        let mut app = App::new(std::sync::Arc::new(crate::tools::ToolRegistry::new()));
+
+        handle_agent_event(
+            &mut app,
+            AgentEvent::ThinkingReceived("thinking before interrupt".to_string()),
+            None,
+        )
+        .expect("handle thinking");
+
+        handle_agent_event(
+            &mut app,
+            AgentEvent::Interrupted {
+                partial_text: "partial".to_string(),
+            },
+            None,
+        )
+        .expect("handle interrupted");
+
+        assert!(
+            app.current_thinking.is_empty(),
+            "current_thinking should be cleared on Interrupted"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ async fn main() -> Result<()> {
             registry,
         )
         .await?
+        .with_thinking(app_config.thinking.clone())
         // This ordering is because both `with_skills` and `with_context_files` PREPEND to history.
         // because initial history is set from the input session
         .with_skills(&skills)

--- a/src/tools/agent.rs
+++ b/src/tools/agent.rs
@@ -412,6 +412,7 @@ mod tests {
             },
             sessions_dir: dir_path.clone(),
             models: BTreeMap::new(),
+            thinking: None,
         });
 
         // Spawner that wires ImmediateTextBackend bypassing real auth.

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,6 +20,42 @@ pub enum Role {
     Assistant,
 }
 
+/// Thinking mode for extended thinking requests.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThinkingMode {
+    Budget { tokens: u32 },
+    Adaptive,
+}
+
+/// Thinking configuration for requests that support extended thinking.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ThinkingConfig {
+    pub mode: ThinkingMode,
+    #[serde(default = "default_thinking_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_budget_tokens")]
+    pub budget_tokens: u32,
+}
+
+fn default_thinking_enabled() -> bool {
+    true
+}
+
+fn default_budget_tokens() -> u32 {
+    8192
+}
+
+impl Default for ThinkingConfig {
+    fn default() -> Self {
+        Self {
+            mode: ThinkingMode::Adaptive,
+            enabled: true,
+            budget_tokens: 8192,
+        }
+    }
+}
+
 /// A content block within a message
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentBlock {
@@ -33,6 +69,13 @@ pub enum ContentBlock {
         tool_use_id: String,
         content: String,
         is_error: bool,
+    },
+    Thinking {
+        text: String,
+        signature: String,
+    },
+    RedactedThinking {
+        data: String,
     },
 }
 
@@ -69,6 +112,21 @@ impl Serialize for ContentBlock {
                 map.serialize_entry("tool_use_id", tool_use_id)?;
                 map.serialize_entry("content", content)?;
                 map.serialize_entry("is_error", is_error)?;
+                map.end()
+            }
+            ContentBlock::Thinking { text, signature } => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(3))?;
+                map.serialize_entry("type", "thinking")?;
+                map.serialize_entry("thinking", text)?;
+                map.serialize_entry("signature", signature)?;
+                map.end()
+            }
+            ContentBlock::RedactedThinking { data } => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("type", "redacted_thinking")?;
+                map.serialize_entry("data", data)?;
                 map.end()
             }
         }
@@ -118,6 +176,8 @@ impl<'de> Deserialize<'de> for ContentBlock {
                 let mut content = None;
                 let mut is_error = None;
                 let mut text = None;
+                let mut signature = None;
+                let mut data = None;
 
                 while let Some(key) = map.next_key::<String>()? {
                     match key.as_str() {
@@ -125,6 +185,9 @@ impl<'de> Deserialize<'de> for ContentBlock {
                             type_field = Some(map.next_value()?);
                         }
                         "text" => {
+                            text = Some(map.next_value()?);
+                        }
+                        "thinking" => {
                             text = Some(map.next_value()?);
                         }
                         "id" => {
@@ -144,6 +207,12 @@ impl<'de> Deserialize<'de> for ContentBlock {
                         }
                         "is_error" => {
                             is_error = Some(map.next_value()?);
+                        }
+                        "signature" => {
+                            signature = Some(map.next_value()?);
+                        }
+                        "data" => {
+                            data = Some(map.next_value()?);
                         }
                         _ => {
                             map.next_value::<serde::de::IgnoredAny>()?;
@@ -166,9 +235,23 @@ impl<'de> Deserialize<'de> for ContentBlock {
                         content: content.ok_or_else(|| de::Error::missing_field("content"))?,
                         is_error: is_error.ok_or_else(|| de::Error::missing_field("is_error"))?,
                     }),
+                    Some("thinking") => Ok(ContentBlock::Thinking {
+                        text: text.ok_or_else(|| de::Error::missing_field("thinking"))?,
+                        signature: signature
+                            .ok_or_else(|| de::Error::missing_field("signature"))?,
+                    }),
+                    Some("redacted_thinking") => Ok(ContentBlock::RedactedThinking {
+                        data: data.ok_or_else(|| de::Error::missing_field("data"))?,
+                    }),
                     Some(other) => Err(de::Error::unknown_variant(
                         other,
-                        &["text", "tool_use", "tool_result"],
+                        &[
+                            "text",
+                            "tool_use",
+                            "tool_result",
+                            "thinking",
+                            "redacted_thinking",
+                        ],
                     )),
                     None => Err(de::Error::missing_field("type")),
                 }
@@ -201,12 +284,14 @@ pub struct RequestConfig {
     pub model: String,
     pub max_tokens: u32,
     pub tools: Vec<ToolDefinition>,
+    pub thinking: Option<ThinkingConfig>,
 }
 
 /// Events emitted by the LLM backend during streaming
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
     TextDelta(String),
+    ThinkingDelta(String),
     ToolUseStart {
         id: String,
         name: String,
@@ -226,6 +311,7 @@ pub enum StreamEvent {
 #[derive(Debug, Clone)]
 pub enum AgentEvent {
     TokenReceived(String),
+    ThinkingReceived(String),
     ToolUseReceived {
         id: String,
         name: String,
@@ -400,9 +486,6 @@ mod tests {
 
     #[test]
     fn content_block_text_produces_object_not_string_for_api_compatibility() {
-        // Regression test: Vertex AI / Anthropic API requires content blocks to be
-        // dictionaries, not plain strings. ContentBlock::Text must serialize as
-        // {"type":"text","text":"..."} rather than a bare string.
         let block = ContentBlock::Text("hello".to_string());
         let value = serde_json::to_value(&block).expect("should serialize");
         assert!(
@@ -469,7 +552,10 @@ mod tests {
         let json = serde_json::to_string(&msg).expect("Message should serialize");
         let parsed: serde_json::Value = serde_json::from_str(&json).expect("Should parse JSON");
         assert_eq!(parsed["role"], "assistant");
-        assert_eq!(parsed["content"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            parsed["content"].as_array().expect("content array").len(),
+            2
+        );
         assert_eq!(parsed["content"][0]["type"], "text");
         assert_eq!(parsed["content"][0]["text"], "Thinking...");
         assert_eq!(parsed["content"][1]["type"], "tool_use");
@@ -571,6 +657,168 @@ mod tests {
             assert_eq!(name, "bash");
             assert_eq!(event_input, input);
             assert_eq!(index, 1);
+        }
+    }
+
+    // ── Thinking types ────────────────────────────────────────────────────
+
+    #[test]
+    fn thinking_content_block_roundtrips_through_serde() {
+        let original = ContentBlock::Thinking {
+            text: "I need to reason about this carefully.".to_string(),
+            signature: "sig_abc123".to_string(),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: ContentBlock = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn redacted_thinking_content_block_roundtrips_through_serde() {
+        let original = ContentBlock::RedactedThinking {
+            data: "encrypted_blob_data".to_string(),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: ContentBlock = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn thinking_serializes_to_anthropic_format() {
+        let block = ContentBlock::Thinking {
+            text: "reasoning text".to_string(),
+            signature: "sig123".to_string(),
+        };
+        let json = serde_json::to_string(&block).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["type"], "thinking");
+        assert_eq!(parsed["thinking"], "reasoning text");
+        assert_eq!(parsed["signature"], "sig123");
+    }
+
+    #[test]
+    fn redacted_thinking_serializes_to_anthropic_format() {
+        let block = ContentBlock::RedactedThinking {
+            data: "encrypted".to_string(),
+        };
+        let json = serde_json::to_string(&block).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["type"], "redacted_thinking");
+        assert_eq!(parsed["data"], "encrypted");
+    }
+
+    #[test]
+    fn thinking_deserializes_from_anthropic_json() {
+        let json = r#"{"type":"thinking","thinking":"reasoning text","signature":"sig123"}"#;
+        let block: ContentBlock = serde_json::from_str(json).expect("deserialize");
+        match block {
+            ContentBlock::Thinking { text, signature } => {
+                assert_eq!(text, "reasoning text");
+                assert_eq!(signature, "sig123");
+            }
+            other => panic!("expected Thinking block, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn redacted_thinking_deserializes_from_anthropic_json() {
+        let json = r#"{"type":"redacted_thinking","data":"encrypted"}"#;
+        let block: ContentBlock = serde_json::from_str(json).expect("deserialize");
+        match block {
+            ContentBlock::RedactedThinking { data } => {
+                assert_eq!(data, "encrypted");
+            }
+            other => panic!("expected RedactedThinking block, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thinking_mode_budget_serializes_correctly() {
+        let mode = ThinkingMode::Budget { tokens: 4096 };
+        let json = serde_json::to_string(&mode).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["type"], "budget");
+        assert_eq!(parsed["tokens"], 4096);
+    }
+
+    #[test]
+    fn thinking_mode_adaptive_serializes_correctly() {
+        let mode = ThinkingMode::Adaptive;
+        let json = serde_json::to_string(&mode).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed["type"], "adaptive");
+    }
+
+    #[test]
+    fn thinking_config_defaults_are_correct() {
+        let config = ThinkingConfig::default();
+        assert_eq!(config.enabled, true);
+        assert_eq!(config.budget_tokens, 8192);
+        assert_eq!(config.mode, ThinkingMode::Adaptive);
+    }
+
+    #[test]
+    fn message_with_thinking_blocks_roundtrips() {
+        let msg = Message {
+            role: Role::Assistant,
+            content: vec![
+                ContentBlock::Thinking {
+                    text: "deep reasoning here".to_string(),
+                    signature: "sig_xyz".to_string(),
+                },
+                ContentBlock::Text("Here is my answer.".to_string()),
+            ],
+        };
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let deserialized: Message = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(msg, deserialized);
+    }
+
+    #[test]
+    fn backward_compat_old_session_without_thinking() {
+        let json = r#"{
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Hello world"},
+                {"type": "tool_use", "id": "t1", "name": "bash", "input": {"cmd": "ls"}},
+                {"type": "tool_result", "tool_use_id": "t1", "content": "output", "is_error": false}
+            ]
+        }"#;
+        let msg: Message = serde_json::from_str(json).expect("should deserialize old format");
+        assert_eq!(msg.role, Role::Assistant);
+        assert_eq!(msg.content.len(), 3);
+        assert!(matches!(&msg.content[0], ContentBlock::Text(_)));
+        assert!(matches!(&msg.content[1], ContentBlock::ToolUse { .. }));
+        assert!(matches!(&msg.content[2], ContentBlock::ToolResult { .. }));
+    }
+
+    #[test]
+    fn thinking_config_toml_roundtrip() {
+        let config = ThinkingConfig {
+            mode: ThinkingMode::Budget { tokens: 16384 },
+            enabled: true,
+            budget_tokens: 16384,
+        };
+        let toml_str = toml::to_string(&config).expect("serialize to TOML");
+        let deserialized: ThinkingConfig = toml::from_str(&toml_str).expect("parse from TOML");
+        assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn stream_event_thinking_delta_contains_text() {
+        let event = StreamEvent::ThinkingDelta("I am thinking...".to_string());
+        assert!(matches!(event, StreamEvent::ThinkingDelta(_)));
+        if let StreamEvent::ThinkingDelta(text) = event {
+            assert_eq!(text, "I am thinking...");
+        }
+    }
+
+    #[test]
+    fn agent_event_thinking_received_contains_text() {
+        let event = AgentEvent::ThinkingReceived("Let me reason about this.".to_string());
+        assert!(matches!(event, AgentEvent::ThinkingReceived(_)));
+        if let AgentEvent::ThinkingReceived(text) = event {
+            assert_eq!(text, "Let me reason about this.");
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,16 +34,10 @@ pub struct ThinkingConfig {
     pub mode: ThinkingMode,
     #[serde(default = "default_thinking_enabled")]
     pub enabled: bool,
-    #[serde(default = "default_budget_tokens")]
-    pub budget_tokens: u32,
 }
 
 fn default_thinking_enabled() -> bool {
     true
-}
-
-fn default_budget_tokens() -> u32 {
-    8192
 }
 
 impl Default for ThinkingConfig {
@@ -51,7 +45,6 @@ impl Default for ThinkingConfig {
         Self {
             mode: ThinkingMode::Adaptive,
             enabled: true,
-            budget_tokens: 8192,
         }
     }
 }
@@ -292,6 +285,9 @@ pub struct RequestConfig {
 pub enum StreamEvent {
     TextDelta(String),
     ThinkingDelta(String),
+    /// Signature for the most recent thinking block, emitted at content_block_stop.
+    /// Used by Anthropic to validate thinking blocks on subsequent turns.
+    ThinkingSignature(String),
     ToolUseStart {
         id: String,
         name: String,
@@ -753,7 +749,6 @@ mod tests {
     fn thinking_config_defaults_are_correct() {
         let config = ThinkingConfig::default();
         assert_eq!(config.enabled, true);
-        assert_eq!(config.budget_tokens, 8192);
         assert_eq!(config.mode, ThinkingMode::Adaptive);
     }
 
@@ -797,7 +792,6 @@ mod tests {
         let config = ThinkingConfig {
             mode: ThinkingMode::Budget { tokens: 16384 },
             enabled: true,
-            budget_tokens: 16384,
         };
         let toml_str = toml::to_string(&config).expect("serialize to TOML");
         let deserialized: ThinkingConfig = toml::from_str(&toml_str).expect("parse from TOML");

--- a/tests/agent_context_test.rs
+++ b/tests/agent_context_test.rs
@@ -45,6 +45,7 @@ async fn load_context_files_adds_messages_to_history() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(backend, config, test_session_arc().await).await;
 
@@ -97,6 +98,7 @@ async fn load_context_files_with_empty_vec_does_not_modify_history() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(backend, config, test_session_arc().await).await;
 

--- a/tests/agent_test.rs
+++ b/tests/agent_test.rs
@@ -59,6 +59,7 @@ async fn test_agent_single_message() {
         model: "test-model".to_string(),
         max_tokens: 1024,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
 
@@ -102,6 +103,7 @@ async fn test_agent_history_accumulates() {
         model: "test-model".to_string(),
         max_tokens: 1024,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(Box::new(backend), config, test_session_arc().await).await;
 
@@ -141,6 +143,7 @@ async fn test_agent_backend_error_emits_error_event() {
         model: "test-model".to_string(),
         max_tokens: 1024,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(Box::new(ErrorBackend), config, test_session_arc().await).await;
 
@@ -175,6 +178,7 @@ async fn cleanup_empty_session_integration_deletes_db_on_exit_with_no_messages()
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(
         Box::new(MockBackend::new(vec![])),
@@ -205,6 +209,7 @@ async fn cleanup_empty_session_integration_retains_db_when_messages_exist() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(
         Box::new(MockBackend::new(vec![])),
@@ -237,6 +242,7 @@ async fn agent_checkpoint_session_persists_messages_to_main_db() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(
         Box::new(MockBackend::new(vec![])),

--- a/tests/context_integration_test.rs
+++ b/tests/context_integration_test.rs
@@ -64,6 +64,7 @@ async fn context_files_from_pwd_are_loaded_into_agent() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(backend, config, test_session_arc().await).await;
     agent.load_context_files(files);
@@ -97,6 +98,7 @@ async fn context_files_from_home_are_loaded_into_agent() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(backend, config, test_session_arc().await).await;
     agent.load_context_files(files);
@@ -139,6 +141,7 @@ async fn multiple_context_files_from_both_locations_are_all_loaded() {
         model: "test".to_string(),
         max_tokens: 100,
         tools: vec![],
+        thinking: None,
     };
     let agent = Agent::new(backend, config, test_session_arc().await).await;
     agent.load_context_files(files);

--- a/tests/tui_test.rs
+++ b/tests/tui_test.rs
@@ -185,6 +185,7 @@ async fn user_message_appears_immediately() {
         model: "test-model".to_string(),
         max_tokens: 1024,
         tools: vec![],
+        thinking: None,
     };
 
     let call_count = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Closes #118

Display LLM extended thinking / reasoning output to the user and persist it through sessions, while keeping it excluded from the context window budget.

Implementation plan posted as a comment below.
