### PR TITLE
Add active column for soft-delete readiness

### DIFF
--- a/src/session/conversation.rs
+++ b/src/session/conversation.rs
@@ -23,7 +23,7 @@ impl<'a> ConversationRepo<'a> {
         self.session
             .conn
             .execute(
-                "INSERT INTO conversation (role, content) VALUES (?1, ?2)",
+                "INSERT INTO conversation (role, content, active) VALUES (?1, ?2, 1)",
                 [
                     turso::Value::Text(role_str.to_string()),
                     turso::Value::Text(content_json),
@@ -57,7 +57,10 @@ impl<'a> ConversationRepo<'a> {
         let mut rows = self
             .session
             .conn
-            .query("SELECT role, content FROM conversation ORDER BY id ASC", ())
+            .query(
+                "SELECT role, content FROM conversation WHERE active = 1 ORDER BY id ASC",
+                (),
+            )
             .await
             .context("Failed to query conversation history")?;
 
@@ -113,5 +116,165 @@ impl<'a> ConversationRepo<'a> {
         }
 
         Ok(String::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{Message, Role};
+    use tempfile::TempDir;
+
+    async fn create_test_session() -> (TempDir, super::super::Session) {
+        let dir = TempDir::new().expect("temp dir");
+        let session = super::super::Session::new(None, dir.path().to_path_buf())
+            .await
+            .expect("create session");
+        (dir, session)
+    }
+
+    #[tokio::test]
+    async fn load_history_filters_out_inactive_entries() {
+        let (_dir, session) = create_test_session().await;
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "active one".to_string()))
+            .await
+            .expect("insert 1");
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::Assistant, "inactive".to_string()))
+            .await
+            .expect("insert 2");
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "active two".to_string()))
+            .await
+            .expect("insert 3");
+
+        session
+            .conn
+            .execute("UPDATE conversation SET active = 0 WHERE id = 2", ())
+            .await
+            .expect("deactivate row 2");
+
+        let history = session
+            .conversation()
+            .load_history()
+            .await
+            .expect("load history");
+        assert_eq!(history.len(), 2, "should only return active entries");
+    }
+
+    #[tokio::test]
+    async fn load_history_returns_all_when_all_active() {
+        let (_dir, session) = create_test_session().await;
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "a".to_string()))
+            .await
+            .expect("insert 1");
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::Assistant, "b".to_string()))
+            .await
+            .expect("insert 2");
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "c".to_string()))
+            .await
+            .expect("insert 3");
+
+        let history = session
+            .conversation()
+            .load_history()
+            .await
+            .expect("load history");
+        assert_eq!(history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn insert_message_sets_active_to_1() {
+        let (_dir, session) = create_test_session().await;
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "check active".to_string()))
+            .await
+            .expect("insert");
+
+        let mut rows = session
+            .conn
+            .query(
+                "SELECT active FROM conversation ORDER BY id DESC LIMIT 1",
+                (),
+            )
+            .await
+            .expect("query active column");
+        let row = rows
+            .next()
+            .await
+            .expect("get row")
+            .expect("should have a row");
+        match row.get_value(0).expect("get active value") {
+            turso::Value::Integer(n) => assert_eq!(n, 1, "active column should be 1"),
+            other => panic!("expected integer, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn is_empty_counts_inactive_entries() {
+        let (_dir, session) = create_test_session().await;
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "will deactivate".to_string()))
+            .await
+            .expect("insert");
+
+        session
+            .conn
+            .execute("UPDATE conversation SET active = 0 WHERE id = 1", ())
+            .await
+            .expect("deactivate");
+
+        let empty = session.conversation().is_empty().await.expect("is_empty");
+        assert!(
+            !empty,
+            "is_empty should return false because the row still exists regardless of active"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_first_user_message_ignores_active_filter() {
+        let (_dir, session) = create_test_session().await;
+
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "first".to_string()))
+            .await
+            .expect("insert 1");
+        session
+            .conversation()
+            .insert_message(&Message::text(Role::User, "second".to_string()))
+            .await
+            .expect("insert 2");
+
+        session
+            .conn
+            .execute("UPDATE conversation SET active = 0 WHERE id = 1", ())
+            .await
+            .expect("deactivate first");
+
+        let msg = session
+            .conversation()
+            .read_first_user_message()
+            .await
+            .expect("read first user message");
+        assert_eq!(
+            msg, "first",
+            "should return the absolute first user message, not filtered by active"
+        );
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -128,28 +128,7 @@ impl Session {
             .await
             .context("Failed to run schema DDL")?;
 
-        {
-            let mut rows = conn
-                .query("PRAGMA table_info(conversation)", ())
-                .await
-                .context("Failed to query conversation table info")?;
-            let mut has_active = false;
-            while let Some(row) = rows.next().await? {
-                if let turso::Value::Text(name) = row.get_value(1)?
-                    && name == "active"
-                {
-                    has_active = true;
-                    break;
-                }
-            }
-            if !has_active {
-                conn.execute_batch(
-                    "ALTER TABLE conversation ADD COLUMN active INTEGER NOT NULL DEFAULT 1",
-                )
-                .await
-                .context("Failed to add active column to conversation table")?;
-            }
-        }
+        migrate_active_column(&conn).await?;
 
         Ok(Self {
             id: sess_id,
@@ -194,6 +173,28 @@ impl Session {
         }
         Ok(())
     }
+}
+
+async fn migrate_active_column(conn: &Connection) -> Result<()> {
+    let mut rows = conn
+        .query("PRAGMA table_info(conversation)", ())
+        .await
+        .context("Failed to query conversation table info")?;
+    let mut has_active = false;
+    while let Some(row) = rows.next().await? {
+        if let turso::Value::Text(name) = row.get_value(1)?
+            && name == "active"
+        {
+            has_active = true;
+            break;
+        }
+    }
+    if !has_active {
+        conn.execute_batch("ALTER TABLE conversation ADD COLUMN active INTEGER NOT NULL DEFAULT 1")
+            .await
+            .context("Failed to add active column to conversation table")?;
+    }
+    Ok(())
 }
 
 fn generate_uuidv7() -> String {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -90,7 +90,8 @@ const SCHEMA: &str = "\
 CREATE TABLE IF NOT EXISTS conversation (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     role TEXT NOT NULL,
-    content TEXT NOT NULL
+    content TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 1
 );
 CREATE TABLE IF NOT EXISTS task (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -126,6 +127,29 @@ impl Session {
         conn.execute_batch(SCHEMA)
             .await
             .context("Failed to run schema DDL")?;
+
+        {
+            let mut rows = conn
+                .query("PRAGMA table_info(conversation)", ())
+                .await
+                .context("Failed to query conversation table info")?;
+            let mut has_active = false;
+            while let Some(row) = rows.next().await? {
+                if let turso::Value::Text(name) = row.get_value(1)?
+                    && name == "active"
+                {
+                    has_active = true;
+                    break;
+                }
+            }
+            if !has_active {
+                conn.execute_batch(
+                    "ALTER TABLE conversation ADD COLUMN active INTEGER NOT NULL DEFAULT 1",
+                )
+                .await
+                .context("Failed to add active column to conversation table")?;
+            }
+        }
 
         Ok(Self {
             id: sess_id,
@@ -719,5 +743,44 @@ mod tests {
             .expect("reopen");
         let task_id = session.tasks().create("t", None).await.expect("create");
         assert_eq!(task_id, 1);
+    }
+
+    #[tokio::test]
+    async fn active_column_is_added_on_reopen_of_existing_db() {
+        let dir = TempDir::new().expect("temp dir");
+        let id = uuid::Uuid::now_v7().to_string();
+        let db_path = dir.path().join(format!("{id}.db"));
+
+        {
+            let db = Builder::new_local(db_path.to_string_lossy().as_ref())
+                .build()
+                .await
+                .expect("build");
+            let conn = db.connect().expect("connect");
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS conversation (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    role TEXT NOT NULL,
+                    content TEXT NOT NULL
+                )",
+            )
+            .await
+            .expect("create old schema");
+            conn.execute(
+                "INSERT INTO conversation (role, content) VALUES (?1, ?2)",
+                [
+                    turso::Value::Text("user".to_string()),
+                    turso::Value::Text("[{\"type\":\"text\",\"text\":\"hello\"}]".to_string()),
+                ],
+            )
+            .await
+            .expect("insert");
+        }
+
+        let session = Session::new(Some(id), dir.path().to_path_buf())
+            .await
+            .expect("reopen with migration");
+        let history = session.conversation().load_history().await.expect("load");
+        assert_eq!(history.len(), 1);
     }
 }


### PR DESCRIPTION
Closes #181

Add an `active` boolean column to the `conversation` table, defaulting to `1`. Filter `load_history()` to only return active entries. No soft-delete UI — this is strictly a schema + filtering preparatory change.

Implementation plan posted as a comment below.
