### PR TITLE
Default thinking.display to summarized for Opus 4.7 visibility

### DIFF
--- a/src/backend/openai_compat.rs
+++ b/src/backend/openai_compat.rs
@@ -595,6 +595,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
+                display: None,
             }),
         };
         let body = b.build_request_body(&[], &config);
@@ -618,6 +619,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
+                display: None,
             }),
         };
         let body = b.build_request_body(&[], &config);
@@ -867,6 +869,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
+                display: None,
             }),
         };
         let body = b.build_request_body(&[user_text("hi")], &config);
@@ -890,6 +893,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
+                display: None,
             }),
         };
         let body = b.build_request_body(&[user_text("hi")], &config);
@@ -913,6 +917,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
+                display: None,
             }),
         };
         let body = b.build_request_body(&[user_text("hi")], &config);
@@ -936,6 +941,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 enabled: true,
                 mode: crate::types::ThinkingMode::Adaptive,
+                display: None,
             }),
         };
         let body = b.build_request_body(&[user_text("hi")], &config);

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -407,17 +407,23 @@ fn build_request_body(messages: &[Message], config: &RequestConfig) -> Result<se
         if !tc.enabled {
             return None;
         }
+        let display = match tc.display {
+            Some(crate::types::ThinkingDisplay::Omitted) => "omitted",
+            _ => "summarized",
+        };
         match &tc.mode {
             crate::types::ThinkingMode::Budget { tokens } => {
                 let budget = *tokens as u64;
                 max_tokens += budget;
                 Some(serde_json::json!({
                     "type": "enabled",
-                    "budget_tokens": budget
+                    "budget_tokens": budget,
+                    "display": display
                 }))
             }
             crate::types::ThinkingMode::Adaptive => Some(serde_json::json!({
-                "type": "adaptive"
+                "type": "adaptive",
+                "display": display
             })),
         }
     });
@@ -962,6 +968,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Budget { tokens: 16384 },
                 enabled: true,
+                display: None,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
@@ -978,6 +985,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Adaptive,
                 enabled: true,
+                display: None,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
@@ -993,6 +1001,7 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Budget { tokens: 16384 },
                 enabled: true,
+                display: None,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
@@ -1023,6 +1032,105 @@ mod tests {
             thinking: Some(crate::types::ThinkingConfig {
                 mode: crate::types::ThinkingMode::Adaptive,
                 enabled: false,
+                display: None,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must not be in the request body when disabled"
+        );
+    }
+
+    #[test]
+    fn build_request_body_adaptive_thinking_defaults_display_to_summarized() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Adaptive,
+                enabled: true,
+                display: None,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["display"], "summarized");
+    }
+
+    #[test]
+    fn build_request_body_budget_thinking_defaults_display_to_summarized() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Budget { tokens: 8192 },
+                enabled: true,
+                display: None,
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["display"], "summarized");
+    }
+
+    #[test]
+    fn build_request_body_thinking_explicit_omitted_serializes_omitted() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Adaptive,
+                enabled: true,
+                display: Some(crate::types::ThinkingDisplay::Omitted),
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["display"], "omitted");
+    }
+
+    #[test]
+    fn build_request_body_thinking_explicit_summarized_serializes_summarized() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Adaptive,
+                enabled: true,
+                display: Some(crate::types::ThinkingDisplay::Summarized),
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["display"], "summarized");
+    }
+
+    #[test]
+    fn build_request_body_no_thinking_has_no_display_field() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: None,
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert!(
+            body.get("thinking").is_none(),
+            "thinking must not be in the request body when None"
+        );
+    }
+
+    #[test]
+    fn build_request_body_disabled_thinking_has_no_display_field() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Adaptive,
+                enabled: false,
+                display: None,
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -974,6 +974,7 @@ mod tests {
         let body = build_request_body(&[], &config).expect("should build successfully");
         assert_eq!(body["thinking"]["type"], "enabled");
         assert_eq!(body["thinking"]["budget_tokens"], 16384);
+        assert_eq!(body["thinking"]["display"], "summarized");
     }
 
     #[test]
@@ -990,6 +991,7 @@ mod tests {
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
         assert_eq!(body["thinking"]["type"], "adaptive");
+        assert_eq!(body["thinking"]["display"], "summarized");
     }
 
     #[test]
@@ -1107,37 +1109,39 @@ mod tests {
     }
 
     #[test]
-    fn build_request_body_no_thinking_has_no_display_field() {
-        let config = RequestConfig {
-            model: "claude-test".to_string(),
-            max_tokens: 8192,
-            tools: vec![],
-            thinking: None,
-        };
-        let body = build_request_body(&[], &config).expect("should build successfully");
-        assert!(
-            body.get("thinking").is_none(),
-            "thinking must not be in the request body when None"
-        );
-    }
-
-    #[test]
-    fn build_request_body_disabled_thinking_has_no_display_field() {
+    fn build_request_body_budget_thinking_explicit_omitted_serializes_omitted() {
         let config = RequestConfig {
             model: "claude-test".to_string(),
             max_tokens: 8192,
             tools: vec![],
             thinking: Some(crate::types::ThinkingConfig {
-                mode: crate::types::ThinkingMode::Adaptive,
-                enabled: false,
-                display: None,
+                mode: crate::types::ThinkingMode::Budget { tokens: 8192 },
+                enabled: true,
+                display: Some(crate::types::ThinkingDisplay::Omitted),
             }),
         };
         let body = build_request_body(&[], &config).expect("should build successfully");
-        assert!(
-            body.get("thinking").is_none(),
-            "thinking must not be in the request body when disabled"
-        );
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 8192);
+        assert_eq!(body["thinking"]["display"], "omitted");
+    }
+
+    #[test]
+    fn build_request_body_budget_thinking_explicit_summarized_serializes_summarized() {
+        let config = RequestConfig {
+            model: "claude-test".to_string(),
+            max_tokens: 8192,
+            tools: vec![],
+            thinking: Some(crate::types::ThinkingConfig {
+                mode: crate::types::ThinkingMode::Budget { tokens: 8192 },
+                enabled: true,
+                display: Some(crate::types::ThinkingDisplay::Summarized),
+            }),
+        };
+        let body = build_request_body(&[], &config).expect("should build successfully");
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["thinking"]["budget_tokens"], 8192);
+        assert_eq!(body["thinking"]["display"], "summarized");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,10 @@ model = "glm-5.1"
 #   mode = { type = "budget", tokens = 8192 }
 # For adaptive mode:
 #   mode = { type = "adaptive" }
+# Whether the API emits thinking content: "summarized" (default) or "omitted".
+# Vertex defaults to "summarized" for visibility on models that would otherwise
+# suppress thinking_delta events (e.g. Opus 4.7).
+# display = "summarized"
 
 # Named model roles for multi-agent workflows.
 # When absent, a "default" role is synthesized from the top-level backend
@@ -1778,6 +1782,24 @@ mod tests {
         "#;
         let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
         assert!(config.thinking.expect("thinking present").display.is_none());
+    }
+
+    #[test]
+    fn thinking_section_with_unknown_display_value_fails_to_parse() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            mode = { type = "adaptive" }
+            display = "hidden"
+        "#;
+        let result: Result<AppConfig, _> = toml::from_str(toml_str);
+        assert!(
+            result.is_err(),
+            "unknown display value must fail deserialization, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1733,6 +1733,54 @@ mod tests {
     }
 
     #[test]
+    fn thinking_section_with_display_summarized_parses() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            mode = { type = "adaptive" }
+            display = "summarized"
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        assert_eq!(
+            config.thinking.expect("thinking present").display,
+            Some(crate::types::ThinkingDisplay::Summarized)
+        );
+    }
+
+    #[test]
+    fn thinking_section_with_display_omitted_parses() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            mode = { type = "adaptive" }
+            display = "omitted"
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        assert_eq!(
+            config.thinking.expect("thinking present").display,
+            Some(crate::types::ThinkingDisplay::Omitted)
+        );
+    }
+
+    #[test]
+    fn thinking_section_without_display_defaults_to_none() {
+        let toml_str = r#"
+            backend = "vertex"
+            [vertex]
+            project = "my-project"
+            [thinking]
+            mode = { type = "adaptive" }
+            enabled = true
+        "#;
+        let config: AppConfig = toml::from_str(toml_str).expect("valid toml");
+        assert!(config.thinking.expect("thinking present").display.is_none());
+    }
+
+    #[test]
     fn compaction_role_defaults_to_compaction() {
         let toml_str = r#"
             backend = "vertex"

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,12 +28,22 @@ pub enum ThinkingMode {
     Adaptive,
 }
 
+/// Controls whether the API emits thinking content in the response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingDisplay {
+    Summarized,
+    Omitted,
+}
+
 /// Thinking configuration for requests that support extended thinking.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThinkingConfig {
     pub mode: ThinkingMode,
     #[serde(default = "default_thinking_enabled")]
     pub enabled: bool,
+    #[serde(default)]
+    pub display: Option<ThinkingDisplay>,
 }
 
 fn default_thinking_enabled() -> bool {
@@ -45,6 +55,7 @@ impl Default for ThinkingConfig {
         Self {
             mode: ThinkingMode::Adaptive,
             enabled: true,
+            display: None,
         }
     }
 }
@@ -762,6 +773,7 @@ mod tests {
         let config = ThinkingConfig::default();
         assert_eq!(config.enabled, true);
         assert_eq!(config.mode, ThinkingMode::Adaptive);
+        assert!(config.display.is_none());
     }
 
     #[test]
@@ -804,6 +816,7 @@ mod tests {
         let config = ThinkingConfig {
             mode: ThinkingMode::Budget { tokens: 16384 },
             enabled: true,
+            display: None,
         };
         let toml_str = toml::to_string(&config).expect("serialize to TOML");
         let deserialized: ThinkingConfig = toml::from_str(&toml_str).expect("parse from TOML");
@@ -826,5 +839,22 @@ mod tests {
         if let AgentEvent::ThinkingReceived(text) = event {
             assert_eq!(text, "Let me reason about this.");
         }
+    }
+
+    #[test]
+    fn thinking_display_summarized_serializes_as_snake_case() {
+        let json = serde_json::to_string(&ThinkingDisplay::Summarized).expect("serialize");
+        assert_eq!(json, r#""summarized""#);
+    }
+
+    #[test]
+    fn thinking_display_omitted_serializes_as_snake_case() {
+        let json = serde_json::to_string(&ThinkingDisplay::Omitted).expect("serialize");
+        assert_eq!(json, r#""omitted""#);
+    }
+
+    #[test]
+    fn thinking_config_default_display_is_none() {
+        assert!(ThinkingConfig::default().display.is_none());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -824,6 +824,19 @@ mod tests {
     }
 
     #[test]
+    fn thinking_config_with_display_toml_roundtrip() {
+        let config = ThinkingConfig {
+            mode: ThinkingMode::Adaptive,
+            enabled: true,
+            display: Some(ThinkingDisplay::Summarized),
+        };
+        let toml_str = toml::to_string(&config).expect("serialize to TOML");
+        let deserialized: ThinkingConfig = toml::from_str(&toml_str).expect("parse from TOML");
+        assert_eq!(config, deserialized);
+        assert!(toml_str.contains("display = \"summarized\""));
+    }
+
+    #[test]
     fn stream_event_thinking_delta_contains_text() {
         let event = StreamEvent::ThinkingDelta("I am thinking...".to_string());
         assert!(matches!(event, StreamEvent::ThinkingDelta(_)));
@@ -851,10 +864,5 @@ mod tests {
     fn thinking_display_omitted_serializes_as_snake_case() {
         let json = serde_json::to_string(&ThinkingDisplay::Omitted).expect("serialize");
         assert_eq!(json, r#""omitted""#);
-    }
-
-    #[test]
-    fn thinking_config_default_display_is_none() {
-        assert!(ThinkingConfig::default().display.is_none());
     }
 }


### PR DESCRIPTION
Closes #199

Default `thinking.display` to `"summarized"` on Vertex requests so Opus 4.7 (which defaults server-side to `"omitted"`) emits `thinking_delta` events the TUI can render.

Implementation plan posted as a comment below.
