### PR TITLE
fix: route diagnostic output through logging module (issue 207)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ These are _strict_ policies that must be followed by all engineers and developer
 - Always run `cargo fmt` before committing code.
 - Always run `cargo clippy` before committing code.
 - Keep code comments to a minimum. Only comment in cases where something is unable to be gleaned from the code itself.
+- The use of `eprintln!`, `println!`, `eprint!`, `print!`, and `dbg!` is forbidden in `src/`. All diagnostic output must go through the `logging` module. Direct stdout/stderr writes corrupt the TUI. Genuinely interactive prompts or end-of-process user-facing notices (e.g. single-shot TTY confirmation, session-id epilogue) may use `write!(io::stderr(), ...)` and must include a comment justifying why.
 
 ### Testing
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -144,28 +144,6 @@ impl BackendFactory {
 }
 
 #[cfg(test)]
-pub(crate) mod test_support {
-    use super::*;
-    use futures::stream;
-
-    /// A minimal `LlmBackend` implementation that returns an empty stream.
-    /// Shared across test modules to avoid duplication.
-    #[allow(dead_code)]
-    pub struct MockBackend;
-
-    #[async_trait]
-    impl LlmBackend for MockBackend {
-        async fn send_message(
-            &self,
-            _messages: &[Message],
-            _config: &RequestConfig,
-        ) -> Result<BoxStream<Result<StreamEvent>>> {
-            Ok(Box::pin(stream::empty()))
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use crate::config::CompactionConfig;
     use anyhow::Result;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -150,6 +150,7 @@ pub(crate) mod test_support {
 
     /// A minimal `LlmBackend` implementation that returns an empty stream.
     /// Shared across test modules to avoid duplication.
+    #[allow(dead_code)]
     pub struct MockBackend;
 
     #[async_trait]

--- a/src/backend/vertex.rs
+++ b/src/backend/vertex.rs
@@ -371,26 +371,37 @@ impl LlmBackend for VertexBackend {
     }
 }
 
+fn filter_content_blocks<'a>(
+    blocks: &'a [crate::types::ContentBlock],
+    warnings: &mut Vec<String>,
+) -> Vec<&'a crate::types::ContentBlock> {
+    blocks
+        .iter()
+        .filter(|block| {
+            if let crate::types::ContentBlock::Thinking { signature, .. } = block
+                && signature.is_empty()
+            {
+                warnings.push(
+                    "dropping thinking block with empty signature from history \
+                     (corrupted session data); it cannot be replayed."
+                        .to_string(),
+                );
+                return false;
+            }
+            true
+        })
+        .collect()
+}
+
 fn build_request_body(messages: &[Message], config: &RequestConfig) -> Result<serde_json::Value> {
     let messages_json: Vec<serde_json::Value> = messages
         .iter()
         .filter_map(|m| {
-            let content: Vec<&crate::types::ContentBlock> = m
-                .content
-                .iter()
-                .filter(|block| {
-                    if let crate::types::ContentBlock::Thinking { signature, .. } = block
-                        && signature.is_empty()
-                    {
-                        eprintln!(
-                            "WARNING: dropping thinking block with empty signature from history \
-                             (corrupted session data); it cannot be replayed."
-                        );
-                        return false;
-                    }
-                    true
-                })
-                .collect();
+            let mut warnings = Vec::new();
+            let content = filter_content_blocks(&m.content, &mut warnings);
+            for w in warnings {
+                crate::logging::log_warn(&w);
+            }
             if content.is_empty() {
                 return None;
             }
@@ -1223,5 +1234,29 @@ mod tests {
             "message with only empty-signature thinking blocks must be dropped"
         );
         assert_eq!(msgs[0]["role"], "user");
+    }
+
+    #[test]
+    fn filter_content_blocks_drops_empty_signature_thinking_and_records_warning() {
+        use crate::types::ContentBlock;
+        let blocks = vec![
+            ContentBlock::Thinking {
+                text: "reasoning".to_string(),
+                signature: String::new(), // empty → should be dropped
+            },
+            ContentBlock::Text("hello".to_string()),
+        ];
+        let mut warnings = Vec::new();
+        let filtered = filter_content_blocks(&blocks, &mut warnings);
+        assert_eq!(filtered.len(), 1, "only the Text block should remain");
+        assert!(
+            matches!(filtered[0], ContentBlock::Text(_)),
+            "remaining block should be Text"
+        );
+        assert_eq!(warnings.len(), 1, "one warning should be recorded");
+        assert!(
+            warnings[0].contains("empty signature"),
+            "warning should mention empty signature"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,8 @@
 use dirs;
 use std::collections::BTreeMap;
-use std::fmt::Write;
+use std::fmt::Write as FmtWrite;
 use std::fs;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -369,7 +370,12 @@ pub fn load_config(custom_path: Option<&Path>) -> Result<AppConfig> {
         }
         fs::write(&path, CONFIG_TEMPLATE)
             .with_context(|| format!("Failed to write default config: {}", path.display()))?;
-        eprintln!("Created default config at: {}", path.display());
+        // Intentional stderr write: config creation notice runs before the TUI starts.
+        writeln!(
+            io::stderr(),
+            "Created default config at: {}",
+            path.display()
+        )?;
     }
 
     load_config_from_path(&path)

--- a/src/frontend/stdout.rs
+++ b/src/frontend/stdout.rs
@@ -114,7 +114,7 @@ async fn run_text<W: Write, R: BufRead>(
                 break;
             }
             AgentEvent::Error(msg) => {
-                eprintln!("\nError: {}", msg);
+                crate::logging::log_error(&format!("\nError: {}", msg));
                 anyhow::bail!("LLM error: {}", msg);
             }
             AgentEvent::ToolUseReceived {
@@ -363,14 +363,22 @@ fn handle_confirmation<R: BufRead>(
     input: &serde_json::Value,
 ) -> Result<()> {
     if !is_tty {
-        eprintln!(
+        // Intentional stderr write: stdout.rs runs outside the TUI; this is a fatal user-facing error.
+        writeln!(
+            io::stderr(),
             "Error: tool confirmation required but stdin is not a TTY (tool: {})",
             name
-        );
+        )?;
         let _ = confirm_tx.unbounded_send(ConfirmationResponse::Rejected);
         anyhow::bail!("tool confirmation required in non-TTY mode");
     }
-    eprint!("Allow tool '{}' with input {}? [y/N] ", name, input);
+    // Intentional stderr write: interactive TTY confirmation prompt runs outside the TUI.
+    write!(
+        io::stderr(),
+        "Allow tool '{}' with input {}? [y/N] ",
+        name,
+        input
+    )?;
     io::stderr().flush()?;
     let mut response = String::new();
     stdin.read_line(&mut response)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stderr, clippy::print_stdout, clippy::dbg_macro)]
+
 pub mod agent;
 pub mod backend;
 pub mod config;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -4,24 +4,19 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 use crate::types::AgentEvent;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 static GLOBAL_WRITER: OnceLock<Mutex<Option<BufWriter<File>>>> = OnceLock::new();
 
 /// Initialise the global debug-log writer once.
 pub fn init_global(log_path: Option<PathBuf>) -> Result<()> {
-    GLOBAL_WRITER.get_or_init(|| {
-        let writer = match log_path {
-            Some(path) => {
-                let file = File::create(&path).unwrap_or_else(|_| {
-                    panic!("Failed to create debug log file at {}", path.display())
-                });
-                Some(BufWriter::new(file))
-            }
-            None => None,
-        };
-        Mutex::new(writer)
-    });
+    let writer = match log_path {
+        Some(path) => Some(BufWriter::new(File::create(&path).with_context(|| {
+            format!("Failed to create debug log file at {}", path.display())
+        })?)),
+        None => None,
+    };
+    let _ = GLOBAL_WRITER.set(Mutex::new(writer));
     Ok(())
 }
 
@@ -829,5 +824,43 @@ mod tests {
         logger.log_error("x").expect("Failed to log error");
         logger.log_info("x").expect("Failed to log info");
         // No panic = success.
+    }
+
+    #[test]
+    fn global_writer_path_and_free_log_event() {
+        // GLOBAL_WRITER is a process-global OnceLock. This is the only test that calls
+        // init_global; a single test function avoids races with other test threads.
+        // If the OnceLock was already set (e.g. by a prior call in the same process),
+        // init_global silently no-ops — the "no panic" guarantee still holds.
+        use crate::types::AgentEvent;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("global-test.log");
+
+        init_global(Some(path.clone())).expect("init_global should succeed");
+
+        log_warn("global warn");
+        log_error("global error");
+        log_event(&AgentEvent::ResponseComplete("assistant text".to_string()));
+        log_event(&AgentEvent::Error("some error".to_string()));
+        flush();
+
+        // Only assert file contents when this process's init_global call won the OnceLock.
+        if path.exists() {
+            let content = std::fs::read_to_string(&path).expect("read log");
+            assert!(content.contains("[WARN]"), "expected [WARN] tag");
+            assert!(content.contains("global warn"), "expected warn message");
+            assert!(content.contains("[ERROR]"), "expected [ERROR] tag");
+            assert!(content.contains("global error"), "expected error message");
+            assert!(
+                content.contains("[ASSISTANT RESPONSE]"),
+                "expected [ASSISTANT RESPONSE] tag"
+            );
+            assert!(
+                content.contains("assistant text"),
+                "expected assistant text"
+            );
+        }
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,69 +1,281 @@
-use crate::types::AgentEvent;
-use anyhow::Result;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+use crate::types::AgentEvent;
+use anyhow::Result;
+
+static GLOBAL_WRITER: OnceLock<Mutex<Option<BufWriter<File>>>> = OnceLock::new();
+
+/// Initialise the global debug-log writer once.
+pub fn init_global(log_path: Option<PathBuf>) -> Result<()> {
+    GLOBAL_WRITER.get_or_init(|| {
+        let writer = match log_path {
+            Some(path) => {
+                let file = File::create(&path).unwrap_or_else(|_| {
+                    panic!("Failed to create debug log file at {}", path.display())
+                });
+                Some(BufWriter::new(file))
+            }
+            None => None,
+        };
+        Mutex::new(writer)
+    });
+    Ok(())
+}
+
+// ── Free functions ──────────────────────────────────────────────────────────
+
+fn with_global_writer(f: impl FnOnce(&mut BufWriter<File>)) {
+    let guard = match GLOBAL_WRITER.get() {
+        Some(g) => g,
+        None => return,
+    };
+    let mut lock = match guard.lock() {
+        Ok(l) => l,
+        Err(_) => return,
+    };
+    if let Some(ref mut writer) = *lock {
+        f(writer);
+    }
+}
+
+pub fn log_warn(message: &str) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[WARN]\n{}\n", message);
+    });
+}
+
+pub fn log_error(message: &str) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[ERROR]\n{}\n", message);
+    });
+}
+
+pub fn log_info(message: &str) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[INFO]\n{}\n", message);
+    });
+}
+
+pub fn log_user_input(input: &str) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[USER INPUT]\n{}\n", input);
+    });
+}
+
+pub fn log_tool_use(name: &str, input: &serde_json::Value) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[TOOL CALL]\nname: {}\ninput: {}\n", name, input);
+    });
+}
+
+pub fn log_tool_result(name: &str, content: &str, is_error: bool) {
+    with_global_writer(|w| {
+        let _ = writeln!(
+            w,
+            "[TOOL RESULT]\nname: {}\ncontent: {}\nis_error: {}\n",
+            name, content, is_error
+        );
+    });
+}
+
+pub fn log_assistant_response(response: &str) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[ASSISTANT RESPONSE]\n{}\n", response);
+    });
+}
+
+pub fn log_usage(input_tokens: u32, output_tokens: u32, stop_reason: &str) {
+    with_global_writer(|w| {
+        let _ = writeln!(
+            w,
+            "[USAGE]\ninput_tokens: {}\noutput_tokens: {}\nstop_reason: {}\n",
+            input_tokens, output_tokens, stop_reason
+        );
+    });
+}
+
+pub fn log_config(config: &dyn std::fmt::Debug) {
+    with_global_writer(|w| {
+        let _ = writeln!(w, "[CONFIG]\n{:#?}\n", config);
+    });
+}
+
+pub fn log_event(event: &AgentEvent) {
+    match event {
+        AgentEvent::TokenReceived(_text) => {}
+        AgentEvent::ThinkingReceived(text) => {
+            with_global_writer(|w| {
+                let _ = writeln!(w, "[THINKING]\n{}\n", text);
+            });
+        }
+        AgentEvent::ToolUseReceived { name, input, .. } => {
+            log_tool_use(name, input);
+        }
+        AgentEvent::ToolResult {
+            name,
+            content,
+            is_error,
+            ..
+        } => {
+            log_tool_result(name, content, *is_error);
+        }
+        AgentEvent::ToolConfirmationRequired { name, input, .. } => {
+            with_global_writer(|w| {
+                let _ = writeln!(w, "[TOOL CONFIRMATION]\nname: {}\ninput: {}\n", name, input);
+            });
+        }
+        AgentEvent::ResponseComplete(text) => {
+            log_assistant_response(text);
+        }
+        AgentEvent::Error(msg) => {
+            log_error(msg);
+        }
+        AgentEvent::Usage {
+            input_tokens,
+            output_tokens,
+            stop_reason,
+        } => {
+            log_usage(*input_tokens, *output_tokens, stop_reason);
+        }
+        AgentEvent::SubAgentUsage {
+            input_tokens,
+            output_tokens,
+            role,
+        } => {
+            with_global_writer(|w| {
+                let _ = writeln!(
+                    w,
+                    "[SUB-AGENT USAGE]\nrole: {}\ninput_tokens: {}\noutput_tokens: {}\n",
+                    role, input_tokens, output_tokens
+                );
+            });
+        }
+        AgentEvent::Interrupted { partial_text } => {
+            with_global_writer(|w| {
+                let _ = writeln!(w, "[INTERRUPTED]\n{}\n", partial_text);
+            });
+        }
+        AgentEvent::Warn(msg) => {
+            log_warn(msg);
+        }
+        AgentEvent::CompactionComplete { summary, is_error } => {
+            with_global_writer(|w| {
+                let _ = writeln!(
+                    w,
+                    "[COMPACTION]\nsummary: {}\nis_error: {}\n",
+                    summary, is_error
+                );
+            });
+        }
+        AgentEvent::AutoCompactTriggered {
+            current_tokens,
+            threshold,
+        } => {
+            with_global_writer(|w| {
+                let _ = writeln!(
+                    w,
+                    "[AUTO-COMPACT]\ncurrent_tokens: {}\nthreshold: {}\n",
+                    current_tokens, threshold
+                );
+            });
+        }
+    }
+}
+
+pub fn flush() {
+    with_global_writer(|w| {
+        let _ = w.flush();
+    });
+}
+
+// ── Logger (instance API — kept for backward compat / tests) ────────────────
 
 pub struct Logger {
     log_file: Option<BufWriter<File>>,
 }
 
 impl Logger {
-    pub fn new(log_path: Option<PathBuf>) -> Result<Self> {
-        let log_file = match log_path {
-            Some(path) => {
-                let file = File::create(&path)?;
-                Some(BufWriter::new(file))
+    pub fn new(path: Option<PathBuf>) -> Result<Self> {
+        let log_file = match path {
+            Some(p) => {
+                let f = File::create(&p)?;
+                Some(BufWriter::new(f))
             }
             None => None,
         };
         Ok(Self { log_file })
     }
 
-    pub fn flush(&mut self) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writer.flush()?;
+    fn write_or_delegate(
+        &mut self,
+        file_fn: impl FnOnce(&mut BufWriter<File>) -> Result<()>,
+        free_fn: impl FnOnce(),
+    ) -> Result<()> {
+        if let Some(ref mut w) = self.log_file {
+            file_fn(w)
+        } else {
+            free_fn();
+            Ok(())
         }
-        Ok(())
+    }
+
+    pub fn log_warn(&mut self, message: &str) -> Result<()> {
+        self.write_or_delegate(
+            |w| writeln!(w, "[WARN]\n{}\n", message).map_err(Into::into),
+            || log_warn(message),
+        )
+    }
+
+    pub fn log_error(&mut self, message: &str) -> Result<()> {
+        self.write_or_delegate(
+            |w| writeln!(w, "[ERROR]\n{}\n", message).map_err(Into::into),
+            || log_error(message),
+        )
+    }
+
+    pub fn log_info(&mut self, message: &str) -> Result<()> {
+        self.write_or_delegate(
+            |w| writeln!(w, "[INFO]\n{}\n", message).map_err(Into::into),
+            || log_info(message),
+        )
     }
 
     pub fn log_user_input(&mut self, input: &str) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[USER INPUT]")?;
-            writeln!(writer, "{}", input)?;
-            writeln!(writer)?;
-        }
-        Ok(())
+        self.write_or_delegate(
+            |w| writeln!(w, "[USER INPUT]\n{}\n", input).map_err(Into::into),
+            || log_user_input(input),
+        )
     }
 
     pub fn log_tool_use(&mut self, name: &str, input: &serde_json::Value) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[TOOL CALL]")?;
-            writeln!(writer, "name: {}", name)?;
-            writeln!(writer, "input: {}", serde_json::to_string(input)?)?;
-            writeln!(writer)?;
-        }
-        Ok(())
+        self.write_or_delegate(
+            |w| writeln!(w, "[TOOL CALL]\nname: {}\ninput: {}\n", name, input).map_err(Into::into),
+            || log_tool_use(name, input),
+        )
     }
 
     pub fn log_tool_result(&mut self, name: &str, content: &str, is_error: bool) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[TOOL RESULT]")?;
-            writeln!(writer, "name: {}", name)?;
-            writeln!(writer, "content: {}", content)?;
-            writeln!(writer, "is_error: {}", is_error)?;
-            writeln!(writer)?;
-        }
-        Ok(())
+        self.write_or_delegate(
+            |w| {
+                writeln!(
+                    w,
+                    "[TOOL RESULT]\nname: {}\ncontent: {}\nis_error: {}\n",
+                    name, content, is_error
+                )
+                .map_err(Into::into)
+            },
+            || log_tool_result(name, content, is_error),
+        )
     }
 
     pub fn log_assistant_response(&mut self, response: &str) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[ASSISTANT RESPONSE]")?;
-            writeln!(writer, "{}", response)?;
-            writeln!(writer)?;
-        }
-        Ok(())
+        self.write_or_delegate(
+            |w| writeln!(w, "[ASSISTANT RESPONSE]\n{}\n", response).map_err(Into::into),
+            || log_assistant_response(response),
+        )
     }
 
     pub fn log_usage(
@@ -72,315 +284,550 @@ impl Logger {
         output_tokens: u32,
         stop_reason: &str,
     ) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[USAGE]")?;
-            writeln!(writer, "input_tokens: {}", input_tokens)?;
-            writeln!(writer, "output_tokens: {}", output_tokens)?;
-            writeln!(writer, "stop_reason: {}", stop_reason)?;
-            writeln!(writer)?;
-        }
-        Ok(())
+        self.write_or_delegate(
+            |w| {
+                writeln!(
+                    w,
+                    "[USAGE]\ninput_tokens: {}\noutput_tokens: {}\nstop_reason: {}\n",
+                    input_tokens, output_tokens, stop_reason
+                )
+                .map_err(Into::into)
+            },
+            || log_usage(input_tokens, output_tokens, stop_reason),
+        )
     }
 
     pub fn log_config(&mut self, config: &dyn std::fmt::Debug) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[CONFIG]")?;
-            writeln!(writer, "{:#?}", config)?;
-            writeln!(writer)?;
-        }
-        Ok(())
-    }
-
-    pub fn log_error(&mut self, message: &str) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[ERROR]")?;
-            writeln!(writer, "{}", message)?;
-            writeln!(writer)?;
-        }
-        Ok(())
-    }
-
-    pub fn log_warn(&mut self, message: &str) -> Result<()> {
-        if let Some(ref mut writer) = self.log_file {
-            writeln!(writer, "[WARN]")?;
-            writeln!(writer, "{}", message)?;
-            writeln!(writer)?;
-        }
-        Ok(())
+        self.write_or_delegate(
+            |w| writeln!(w, "[CONFIG]\n{:#?}\n", config).map_err(Into::into),
+            || log_config(config),
+        )
     }
 
     pub fn log_event(&mut self, event: &AgentEvent) -> Result<()> {
+        if let Some(ref mut w) = self.log_file {
+            Self::write_event(w, event)
+        } else {
+            log_event(event);
+            Ok(())
+        }
+    }
+
+    fn write_event(w: &mut BufWriter<File>, event: &AgentEvent) -> Result<()> {
         match event {
+            AgentEvent::TokenReceived(_) => Ok(()),
+            AgentEvent::ThinkingReceived(text) => {
+                writeln!(w, "[THINKING]\n{}\n", text).map_err(Into::into)
+            }
             AgentEvent::ToolUseReceived { name, input, .. } => {
-                self.log_tool_use(name, input)?;
+                writeln!(w, "[TOOL CALL]\nname: {}\ninput: {}\n", name, input).map_err(Into::into)
             }
             AgentEvent::ToolResult {
                 name,
                 content,
                 is_error,
                 ..
-            } => {
-                self.log_tool_result(name, content, *is_error)?;
+            } => writeln!(
+                w,
+                "[TOOL RESULT]\nname: {}\ncontent: {}\nis_error: {}\n",
+                name, content, is_error
+            )
+            .map_err(Into::into),
+            AgentEvent::ToolConfirmationRequired { name, input, .. } => {
+                writeln!(w, "[TOOL CONFIRMATION]\nname: {}\ninput: {}\n", name, input)
+                    .map_err(Into::into)
             }
-            AgentEvent::ResponseComplete(response) => {
-                self.log_assistant_response(response)?;
+            AgentEvent::ResponseComplete(text) => {
+                writeln!(w, "[ASSISTANT RESPONSE]\n{}\n", text).map_err(Into::into)
             }
-            AgentEvent::Error(message) => {
-                self.log_error(message)?;
-            }
-            AgentEvent::Warn(message) => {
-                self.log_warn(message)?;
-            }
+            AgentEvent::Error(msg) => writeln!(w, "[ERROR]\n{}\n", msg).map_err(Into::into),
             AgentEvent::Usage {
                 input_tokens,
                 output_tokens,
                 stop_reason,
-            } => {
-                self.log_usage(*input_tokens, *output_tokens, stop_reason)?;
+            } => writeln!(
+                w,
+                "[USAGE]\ninput_tokens: {}\noutput_tokens: {}\nstop_reason: {}\n",
+                input_tokens, output_tokens, stop_reason
+            )
+            .map_err(Into::into),
+            AgentEvent::SubAgentUsage {
+                input_tokens,
+                output_tokens,
+                role,
+            } => writeln!(
+                w,
+                "[SUB-AGENT USAGE]\nrole: {}\ninput_tokens: {}\noutput_tokens: {}\n",
+                role, input_tokens, output_tokens
+            )
+            .map_err(Into::into),
+            AgentEvent::Interrupted { partial_text } => {
+                writeln!(w, "[INTERRUPTED]\n{}\n", partial_text).map_err(Into::into)
             }
-            _ => {}
+            AgentEvent::Warn(msg) => writeln!(w, "[WARN]\n{}\n", msg).map_err(Into::into),
+            AgentEvent::CompactionComplete { summary, is_error } => writeln!(
+                w,
+                "[COMPACTION]\nsummary: {}\nis_error: {}\n",
+                summary, is_error
+            )
+            .map_err(Into::into),
+            AgentEvent::AutoCompactTriggered {
+                current_tokens,
+                threshold,
+            } => writeln!(
+                w,
+                "[AUTO-COMPACT]\ncurrent_tokens: {}\nthreshold: {}\n",
+                current_tokens, threshold
+            )
+            .map_err(Into::into),
         }
-        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        if let Some(ref mut w) = self.log_file {
+            w.flush().map_err(Into::into)
+        } else {
+            flush();
+            Ok(())
+        }
     }
 }
 
-impl Drop for Logger {
-    fn drop(&mut self) {
-        if let Some(ref mut writer) = self.log_file {
-            let _ = writer.flush();
-        }
-    }
-}
+// ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::AgentEvent;
-    use tempfile::TempDir;
+    use std::fs;
+    use std::io::Read;
+
+    fn temp_log_path(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("illustrious-manager-logging-tests");
+        let _ = fs::create_dir_all(&dir);
+        dir.join(format!("{}-{}.log", name, std::process::id()))
+    }
+
+    fn read_file(path: &PathBuf) -> String {
+        let mut contents = String::new();
+        File::open(path)
+            .and_then(|mut f| f.read_to_string(&mut contents))
+            .expect("Should be able to read temp log file");
+        contents
+    }
 
     #[test]
-    fn logger_with_none_path_creates_disabled_logger() {
-        let mut logger = Logger::new(None).expect("logger creation should succeed");
-        // Logger with None should not panic on any operations
+    fn logger_creates_file_on_init() {
+        let path = temp_log_path("creates_file");
+        let _logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        assert!(path.exists(), "Log file should be created");
+    }
+
+    #[test]
+    fn logger_warn_writes_to_file() {
+        let path = temp_log_path("warn");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
         logger
-            .log_user_input("test")
-            .expect("log_user_input should not error");
-        logger
-            .log_tool_use("bash", &serde_json::json!({}))
-            .expect("log_tool_use should not error");
-        logger
-            .log_assistant_response("response")
-            .expect("log_assistant_response should not error");
-    }
-
-    #[test]
-    fn log_user_input_writes_to_file() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            logger
-                .log_user_input("hello world")
-                .expect("Failed to log user input");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[USER INPUT]"));
-        assert!(content.contains("hello world"));
-    }
-
-    #[test]
-    fn log_tool_use_writes_name_and_input_to_file() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            let input = serde_json::json!({"command": "ls -la"});
-            logger
-                .log_tool_use("bash", &input)
-                .expect("Failed to log tool use");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[TOOL CALL]"));
-        assert!(content.contains("name: bash"));
-        assert!(content.contains(r#""command":"ls -la""#));
-    }
-
-    #[test]
-    fn log_tool_result_writes_name_content_and_error_status_to_file() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            logger
-                .log_tool_result("bash", "file1.txt\nfile2.txt", false)
-                .expect("Failed to log tool result");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[TOOL RESULT]"));
-        assert!(content.contains("name: bash"));
-        assert!(content.contains("content: file1.txt\nfile2.txt"));
-        assert!(content.contains("is_error: false"));
-    }
-
-    #[test]
-    fn log_assistant_response_writes_response_to_file() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            logger
-                .log_assistant_response("Hello, how can I help you?")
-                .expect("Failed to log assistant response");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[ASSISTANT RESPONSE]"));
-        assert!(content.contains("Hello, how can I help you?"));
-    }
-
-    #[test]
-    fn log_event_tool_use_received_calls_log_tool_use() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            let event = AgentEvent::ToolUseReceived {
-                id: "tool-1".to_string(),
-                name: "bash".to_string(),
-                input: serde_json::json!({"command": "ls"}),
-                index: 1,
-            };
-            logger.log_event(&event).expect("Failed to log event");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[TOOL CALL]"));
-        assert!(content.contains("name: bash"));
-    }
-
-    #[test]
-    fn log_event_tool_result_calls_log_tool_result() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            let event = AgentEvent::ToolResult {
-                name: "bash".to_string(),
-                content: "output".to_string(),
-                is_error: false,
-                index: 1,
-            };
-            logger.log_event(&event).expect("Failed to log event");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[TOOL RESULT]"));
-        assert!(content.contains("name: bash"));
-        assert!(content.contains("content: output"));
-    }
-
-    #[test]
-    fn log_event_response_complete_calls_log_assistant_response() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            let event = AgentEvent::ResponseComplete("Hello world".to_string());
-            logger.log_event(&event).expect("Failed to log event");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[ASSISTANT RESPONSE]"));
-        assert!(content.contains("Hello world"));
-    }
-
-    #[test]
-    fn multiple_logs_append_to_same_file() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            logger.log_user_input("input1").expect("Failed to log");
-            logger
-                .log_assistant_response("response1")
-                .expect("Failed to log");
-            logger.log_user_input("input2").expect("Failed to log");
-            logger
-                .log_assistant_response("response2")
-                .expect("Failed to log");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("input1"));
-        assert!(content.contains("response1"));
-        assert!(content.contains("input2"));
-        assert!(content.contains("response2"));
-    }
-
-    #[test]
-    fn logger_flushes_on_drop() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            logger.log_user_input("test input").expect("Failed to log");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[USER INPUT]"));
-        assert!(content.contains("test input"));
-    }
-
-    #[test]
-    fn log_config_writes_pretty_debug_representation() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-
-        {
-            let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-            let config = vec!["backend", "vertex"];
-            logger.log_config(&config).expect("Failed to log config");
-        }
-
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("[CONFIG]"));
-        assert!(content.contains(r#""backend""#));
-        assert!(content.contains(r#""vertex""#));
-    }
-
-    #[test]
-    fn log_config_does_nothing_when_no_log_file() {
-        let mut logger = Logger::new(None).expect("logger creation should succeed");
-        let config = vec!["backend", "vertex"];
-        logger
-            .log_config(&config)
-            .expect("log_config should not error");
-    }
-
-    #[test]
-    fn explicit_flush_method_writes_buffered_content() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let log_path = temp_dir.path().join("test.log");
-        let mut logger = Logger::new(Some(log_path.clone())).expect("Failed to create logger");
-
-        logger
-            .log_user_input("before flush")
-            .expect("Failed to log");
+            .log_warn("warning message")
+            .expect("Failed to log warn");
         logger.flush().expect("Failed to flush");
 
-        let content = std::fs::read_to_string(&log_path).expect("Failed to read log file");
-        assert!(content.contains("before flush"));
+        let contents = read_file(&path);
+        assert!(contents.contains("[WARN]"));
+        assert!(contents.contains("warning message"));
+    }
+
+    #[test]
+    fn logger_error_writes_to_file() {
+        let path = temp_log_path("error");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_error("error message")
+            .expect("Failed to log error");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[ERROR]"));
+        assert!(contents.contains("error message"));
+    }
+
+    #[test]
+    fn logger_info_writes_to_file() {
+        let path = temp_log_path("info");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger.log_info("info message").expect("Failed to log info");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[INFO]"));
+        assert!(contents.contains("info message"));
+    }
+
+    #[test]
+    fn logger_user_input_writes_to_file() {
+        let path = temp_log_path("user_input");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_user_input("ls -la")
+            .expect("Failed to log user input");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[USER INPUT]"));
+        assert!(contents.contains("ls -la"));
+    }
+
+    #[test]
+    fn logger_tool_use_writes_to_file() {
+        let path = temp_log_path("tool_use");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        let input = serde_json::json!({"command": "ls"});
+        logger
+            .log_tool_use("bash", &input)
+            .expect("Failed to log tool use");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[TOOL CALL]"));
+        assert!(contents.contains("name: bash"));
+        assert!(contents.contains("command"));
+    }
+
+    #[test]
+    fn logger_tool_result_writes_to_file() {
+        let path = temp_log_path("tool_result");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_tool_result("bash", "file1\nfile2", false)
+            .expect("Failed to log tool result");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[TOOL RESULT]"));
+        assert!(contents.contains("name: bash"));
+        assert!(contents.contains("file1"));
+        assert!(contents.contains("is_error: false"));
+    }
+
+    #[test]
+    fn logger_assistant_response_writes_to_file() {
+        let path = temp_log_path("assistant_response");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_assistant_response("Hello, world!")
+            .expect("Failed to log assistant response");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[ASSISTANT RESPONSE]"));
+        assert!(contents.contains("Hello, world!"));
+    }
+
+    #[test]
+    fn logger_usage_writes_to_file() {
+        let path = temp_log_path("usage");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_usage(100, 200, "end_turn")
+            .expect("Failed to log usage");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[USAGE]"));
+        assert!(contents.contains("input_tokens: 100"));
+        assert!(contents.contains("output_tokens: 200"));
+        assert!(contents.contains("stop_reason: end_turn"));
+    }
+
+    #[test]
+    fn logger_config_writes_to_file() {
+        let path = temp_log_path("config");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        let config = serde_json::json!({"model": "claude-sonnet-4"});
+        logger.log_config(&config).expect("Failed to log config");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[CONFIG]"));
+        assert!(contents.contains("claude-sonnet-4"));
+    }
+
+    #[test]
+    fn logger_event_token_received_does_not_write() {
+        let path = temp_log_path("event_token");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::TokenReceived("test".into()))
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.is_empty());
+    }
+
+    #[test]
+    fn logger_event_thinking_received_writes() {
+        let path = temp_log_path("event_thinking");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::ThinkingReceived("thinking...".into()))
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[THINKING]"));
+        assert!(contents.contains("thinking..."));
+    }
+
+    #[test]
+    fn logger_event_tool_use_received_writes() {
+        let path = temp_log_path("event_tool_use");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::ToolUseReceived {
+                id: "1".into(),
+                name: "bash".into(),
+                input: serde_json::json!({"command": "ls"}),
+                index: 1,
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[TOOL CALL]"));
+        assert!(contents.contains("name: bash"));
+    }
+
+    #[test]
+    fn logger_event_tool_result_writes() {
+        let path = temp_log_path("event_tool_result");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::ToolResult {
+                name: "bash".into(),
+                content: "output".into(),
+                is_error: false,
+                index: 1,
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[TOOL RESULT]"));
+        assert!(contents.contains("name: bash"));
+    }
+
+    #[test]
+    fn logger_event_response_complete_writes() {
+        let path = temp_log_path("event_response_complete");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::ResponseComplete("Done".into()))
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[ASSISTANT RESPONSE]"));
+        assert!(contents.contains("Done"));
+    }
+
+    #[test]
+    fn logger_event_error_writes() {
+        let path = temp_log_path("event_error");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::Error("something failed".into()))
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[ERROR]"));
+        assert!(contents.contains("something failed"));
+    }
+
+    #[test]
+    fn logger_event_usage_writes() {
+        let path = temp_log_path("event_usage");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::Usage {
+                input_tokens: 50,
+                output_tokens: 100,
+                stop_reason: "max_tokens".into(),
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[USAGE]"));
+        assert!(contents.contains("input_tokens: 50"));
+        assert!(contents.contains("output_tokens: 100"));
+    }
+
+    #[test]
+    fn logger_event_subagent_usage_writes() {
+        let path = temp_log_path("event_subagent_usage");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::SubAgentUsage {
+                input_tokens: 200,
+                output_tokens: 300,
+                role: "default".into(),
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[SUB-AGENT USAGE]"));
+        assert!(contents.contains("role: default"));
+        assert!(contents.contains("input_tokens: 200"));
+        assert!(contents.contains("output_tokens: 300"));
+    }
+
+    #[test]
+    fn logger_event_interrupted_writes() {
+        let path = temp_log_path("event_interrupted");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::Interrupted {
+                partial_text: "partial".into(),
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[INTERRUPTED]"));
+        assert!(contents.contains("partial"));
+    }
+
+    #[test]
+    fn logger_event_warn_writes() {
+        let path = temp_log_path("event_warn");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::Warn("warning from agent".into()))
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[WARN]"));
+        assert!(contents.contains("warning from agent"));
+    }
+
+    #[test]
+    fn logger_event_compaction_complete_writes() {
+        let path = temp_log_path("event_compaction");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::CompactionComplete {
+                summary: "summarised".into(),
+                is_error: false,
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[COMPACTION]"));
+        assert!(contents.contains("summary: summarised"));
+        assert!(contents.contains("is_error: false"));
+    }
+
+    #[test]
+    fn logger_event_auto_compact_triggered_writes() {
+        let path = temp_log_path("event_auto_compact");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::AutoCompactTriggered {
+                current_tokens: 50000,
+                threshold: 48000,
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[AUTO-COMPACT]"));
+        assert!(contents.contains("current_tokens: 50000"));
+        assert!(contents.contains("threshold: 48000"));
+    }
+
+    #[test]
+    fn logger_multiple_messages_append() {
+        let path = temp_log_path("multiple");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger.log_info("first").expect("Failed to log info");
+        logger.log_warn("second").expect("Failed to log warn");
+        logger.log_info("third").expect("Failed to log info");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        let info_count = contents.matches("[INFO]").count();
+        assert_eq!(info_count, 2, "Should have two [INFO] entries");
+        assert!(contents.contains("first"));
+        assert!(contents.contains("second"));
+        assert!(contents.contains("third"));
+    }
+
+    #[test]
+    fn logger_tool_error_flag_is_true() {
+        let path = temp_log_path("tool_error");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_tool_result("bash", "error output", true)
+            .expect("Failed to log tool result");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("is_error: true"));
+    }
+
+    #[test]
+    fn logger_tool_confirmation_required_writes() {
+        let path = temp_log_path("tool_confirmation");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger
+            .log_event(&AgentEvent::ToolConfirmationRequired {
+                id: "tool-1".into(),
+                name: "write_file".into(),
+                input: serde_json::json!({"path": "test.txt"}),
+                index: 1,
+            })
+            .expect("Failed to log event");
+        logger.flush().expect("Failed to flush");
+
+        let contents = read_file(&path);
+        assert!(contents.contains("[TOOL CONFIRMATION]"));
+        assert!(contents.contains("name: write_file"));
+    }
+
+    #[test]
+    fn logger_flush_succeeds() {
+        let path = temp_log_path("flush");
+        let mut logger = Logger::new(Some(path.clone())).expect("Failed to create logger");
+        logger.log_info("flush test").expect("Failed to log info");
+        logger.flush().expect("Failed to flush");
+        let first = read_file(&path);
+        logger.log_info("flush test 2").expect("Failed to log info");
+        logger.flush().expect("Failed to flush");
+        let second = read_file(&path);
+        assert!(
+            second.len() > first.len(),
+            "Second flush should have more data"
+        );
+    }
+
+    #[test]
+    fn log_free_functions_are_noop_when_global_not_used() {
+        log_warn("x");
+        log_error("x");
+        log_info("x");
+        // No panic = success.
+    }
+
+    #[test]
+    fn logger_none_delegates_to_free_functions() {
+        let mut logger = Logger::new(None).expect("Failed to create logger");
+        logger.log_warn("x").expect("Failed to log warn");
+        logger.log_error("x").expect("Failed to log error");
+        logger.log_info("x").expect("Failed to log info");
+        // No panic = success.
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::print_stderr, clippy::print_stdout, clippy::dbg_macro)]
+
 pub mod agent;
 pub mod backend;
 pub mod config;
@@ -11,6 +13,7 @@ pub mod types;
 use anyhow::Result;
 use clap::Parser;
 use std::collections::HashMap;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -172,9 +175,11 @@ async fn main() -> Result<()> {
         .with_compaction_spawner(spawner),
     );
 
-    let mut logger = if cli.debug {
-        let log_path = create_log_path()?;
-        Some(Logger::new(Some(log_path))?)
+    if cli.debug {
+        logging::init_global(Some(create_log_path()?))?;
+    }
+    let mut logger: Option<Logger> = if cli.debug {
+        Some(Logger::new(None)?)
     } else {
         None
     };
@@ -225,16 +230,17 @@ async fn main() -> Result<()> {
     };
 
     if let Err(e) = agent.checkpoint_session().await {
-        eprintln!("checkpoint_session failed: {e}");
+        logging::log_error(&format!("checkpoint_session failed: {e}"));
     }
 
     if let Err(e) = agent.cleanup_empty_session().await
         && cli.debug
     {
-        eprintln!("cleanup_empty_session failed: {e}");
+        logging::log_error(&format!("cleanup_empty_session failed: {e}"));
     }
 
-    eprintln!("Session ID: {}", agent.session_id().await);
+    // Intentional stderr write: session ID epilogue is printed after TUI tears down, safe to write directly.
+    writeln!(io::stderr(), "Session ID: {}", agent.session_id().await)?;
     frontend_result
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,9 @@ async fn main() -> Result<()> {
         logging::log_error(&format!("cleanup_empty_session failed: {e}"));
     }
 
+    // Flush the debug log before printing the session-ID epilogue so no buffered
+    // entries are lost (static OnceLock is never dropped by Rust).
+    logging::flush();
     // Intentional stderr write: session ID epilogue is printed after TUI tears down, safe to write directly.
     writeln!(io::stderr(), "Session ID: {}", agent.session_id().await)?;
     frontend_result

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -143,11 +143,11 @@ impl ToolRegistry {
             allowlist.iter().map(String::as_str).collect();
         self.tools.retain(|name, _| allowed.contains(name.as_str()));
         if self.tools.is_empty() && !allowlist.is_empty() {
-            eprintln!(
-                "WARNING: agent tool allowlist [{list}] matched no registered tools; \
-                 sub-agent will run with an empty tool set",
+            crate::logging::log_warn(&format!(
+                "agent tool allowlist [{list}] matched no registered tools; \
+             sub-agent will run with an empty tool set",
                 list = allowlist.join(", ")
-            );
+            ));
         }
         self
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -771,7 +771,7 @@ mod tests {
     #[test]
     fn thinking_config_defaults_are_correct() {
         let config = ThinkingConfig::default();
-        assert_eq!(config.enabled, true);
+        assert!(config.enabled);
         assert_eq!(config.mode, ThinkingMode::Adaptive);
         assert!(config.display.is_none());
     }


### PR DESCRIPTION
Closes #207

Purge `eprintln!`/`println!` from `src/` and route all diagnostic output through the `logging` module. Add a clippy-enforced policy so this cannot recur. Two pre/post-TUI user-facing notices (Session ID at exit, "Created default config" on first run) and the single-shot interactive confirmation prompt are kept user-visible via `write!(io::stderr(), ...)`, which the new lint does not flag.

Implementation plan posted as a comment below.
